### PR TITLE
fix(launch): rate-limit register, extend health to all cron sources, trim stale recover comment

### DIFF
--- a/pages/functions/api/health.js
+++ b/pages/functions/api/health.js
@@ -1,89 +1,43 @@
 import { json } from "../_lib.js";
+import { classifyAll, inPollerWindow } from "../_heartbeat.js";
 
 // Public liveness endpoint the external watchdog polls every 15 min.
 // Reveals heartbeat ages + per-source `stale` bool; no PII, no credentials,
-// so no auth required. The `stale` flag is evaluated against each source's
-// expected cadence:
-//   - poller: expected to beat at least once every ~5 min while inside the
-//     ET weekday poll window; outside the window silence is normal.
-//   - purge : expected to beat once per ~24h; alert if >26h silent.
+// so no auth required.
+//
+// Delegates to the shared _heartbeat classifier so every known cron source
+// (poller, purge, email_sender, security_alerts, canary) is reported and
+// alerted on consistently. Previously this endpoint only checked poller
+// and purge, which let a dead email_sender or security_alerts digest
+// hide behind a green `/api/health` — see codex launch review 2026-04-16.
 //
 // Watchdog logic for alert suppression lives in /api/watchdog-state.
 
-const POLLER_STALE_SECONDS = 300;   // 5 min of silence inside the poll window
-const PURGE_STALE_SECONDS = 26 * 3600;
-
 export async function onRequest({ request, env }) {
     const now = new Date();
-    const windowActive = inPollWindow(now, env);
-
-    const rows = await env.DB.prepare(
-        "SELECT source, last_beat_at, last_status, detail_json FROM heartbeats"
+    const { results = [] } = await env.DB.prepare(
+        "SELECT source, last_beat_at, last_status FROM heartbeats"
     ).all();
-    const bySource = new Map();
-    for (const r of rows.results || []) bySource.set(r.source, r);
 
-    const sources = [
-        buildSourceStatus("poller", bySource.get("poller"), now, {
-            expected: windowActive,
-            stale_seconds: POLLER_STALE_SECONDS,
-        }),
-        buildSourceStatus("purge", bySource.get("purge"), now, {
-            expected: true,
-            stale_seconds: PURGE_STALE_SECONDS,
-        }),
-    ];
+    const classified = classifyAll(results, now, env);
 
-    const anyStale = sources.some(s => s.stale);
+    const sources = classified.map(s => ({
+        source: s.source,
+        last_beat_at: s.last_beat_at,
+        last_status: s.last_status,
+        age_seconds: s.age_seconds,
+        expected: s.on_duty,
+        stale: s.stale,
+        // Exposing threshold lets the watchdog + operators see exactly what
+        // triggered a stale flag. classifyAll considers a source stale when
+        // age > 2×expected, so the effective threshold is 2×expected_s.
+        threshold_seconds: s.expected_s != null ? s.expected_s * 2 : null,
+    }));
 
     return json({
         now: now.toISOString(),
-        poll_window_active: windowActive,
-        any_stale: anyStale,
+        poll_window_active: inPollerWindow(now, env),
+        any_stale: sources.some(s => s.stale),
         sources,
     }, 200);
-}
-
-function buildSourceStatus(source, row, now, { expected, stale_seconds }) {
-    if (!row) {
-        return {
-            source,
-            last_beat_at: null,
-            last_status: null,
-            age_seconds: null,
-            expected,
-            stale: expected,  // no heartbeat at all + expected = definitely stale
-            threshold_seconds: stale_seconds,
-        };
-    }
-    const last = new Date(row.last_beat_at);
-    const age = Math.floor((now - last) / 1000);
-    const stale = expected && (age > stale_seconds || row.last_status === "error");
-    return {
-        source,
-        last_beat_at: row.last_beat_at,
-        last_status: row.last_status,
-        age_seconds: age,
-        expected,
-        stale,
-        threshold_seconds: stale_seconds,
-    };
-}
-
-function inPollWindow(now, env) {
-    const tz = env.POLL_WINDOW_TZ || "America/New_York";
-    const fmt = new Intl.DateTimeFormat("en-US", {
-        timeZone: tz,
-        hour12: false,
-        weekday: "short",
-        hour: "2-digit",
-    });
-    const p = fmt.formatToParts(now).reduce((o, x) => (o[x.type] = x.value, o), {});
-    const dowMap = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
-    const dow = dowMap[p.weekday];
-    const hour = parseInt(p.hour, 10);
-    const days = (env.POLL_WINDOW_DAYS || "1,2,3,4,5").split(",").map(Number);
-    const start = parseInt(env.POLL_WINDOW_START_HOUR || "8", 10);
-    const end = parseInt(env.POLL_WINDOW_END_HOUR || "11", 10);
-    return days.includes(dow) && hour >= start && hour < end;
 }

--- a/pages/functions/api/health.test.mjs
+++ b/pages/functions/api/health.test.mjs
@@ -1,0 +1,95 @@
+// Tests for /api/health. Guards against the silent-dead-source regression
+// that the codex launch review surfaced: before 2026-04-16 the endpoint
+// reported only poller + purge, so a dead email_sender, security_alerts,
+// or canary cron could hide behind a green health page.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequest as healthGet } from "./health.js";
+
+const WINDOW_ENV = {
+    POLL_WINDOW_TZ: "America/New_York",
+    POLL_WINDOW_START_HOUR: "8",
+    POLL_WINDOW_END_HOUR: "11",
+    POLL_WINDOW_DAYS: "1,2,3,4,5",
+};
+
+function dbWith(rows) {
+    return {
+        prepare(sql) {
+            return {
+                all: async () => ({ results: rows }),
+            };
+        },
+    };
+}
+
+function request() {
+    return new Request("https://sc-cpe-web.pages.dev/api/health");
+}
+
+test("health: reports every known cron source — poller, purge, email_sender, security_alerts, canary", async () => {
+    const r = await healthGet({ env: { DB: dbWith([]), ...WINDOW_ENV }, request: request() });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    const names = new Set(j.sources.map(s => s.source));
+    for (const expected of ["poller", "purge", "email_sender", "security_alerts", "canary"]) {
+        assert.ok(names.has(expected), `health.sources must include ${expected}`);
+    }
+});
+
+test("health: missing heartbeat on an on-duty source → stale:true", async () => {
+    // email_sender has no row at all. It's continuously on-duty, so missing = stale.
+    const r = await healthGet({ env: { DB: dbWith([]), ...WINDOW_ENV }, request: request() });
+    const j = await r.json();
+    const es = j.sources.find(s => s.source === "email_sender");
+    assert.ok(es, "email_sender must appear");
+    assert.equal(es.stale, true, "missing + on-duty must flag stale");
+    assert.equal(es.last_beat_at, null);
+});
+
+test("health: fresh beat on email_sender → stale:false", async () => {
+    const now = new Date();
+    const fresh = new Date(now.getTime() - 60_000).toISOString();
+    const r = await healthGet({
+        env: {
+            DB: dbWith([{ source: "email_sender", last_beat_at: fresh, last_status: "ok" }]),
+            ...WINDOW_ENV,
+        },
+        request: request(),
+    });
+    const j = await r.json();
+    const es = j.sources.find(s => s.source === "email_sender");
+    assert.equal(es.stale, false);
+    assert.equal(es.last_status, "ok");
+});
+
+test("health: any_stale rolls up correctly", async () => {
+    // Fresh email_sender, everything else missing. Non-poller missing sources
+    // (purge, security_alerts, canary) are on-duty continuously → stale.
+    const now = new Date();
+    const fresh = new Date(now.getTime() - 60_000).toISOString();
+    const r = await healthGet({
+        env: {
+            DB: dbWith([{ source: "email_sender", last_beat_at: fresh, last_status: "ok" }]),
+            ...WINDOW_ENV,
+        },
+        request: request(),
+    });
+    const j = await r.json();
+    assert.equal(j.any_stale, true, "purge/security_alerts/canary missing → any_stale must be true");
+});
+
+test("health: watchdog contract — every source has source/stale/last_beat_at/age_seconds fields", async () => {
+    // watchdog.yml's jq extracts these four fields per source. Breaking any
+    // of them would break alert dedup without the workflow turning red.
+    const r = await healthGet({ env: { DB: dbWith([]), ...WINDOW_ENV }, request: request() });
+    const j = await r.json();
+    for (const s of j.sources) {
+        assert.ok("source" in s);
+        assert.ok("stale" in s);
+        assert.ok("last_beat_at" in s);
+        assert.ok("age_seconds" in s);
+    }
+});

--- a/pages/functions/api/onboarding.test.mjs
+++ b/pages/functions/api/onboarding.test.mjs
@@ -172,6 +172,23 @@ test("register: new user → 200 must NOT leak dashboard_token or verification_c
     assert.equal(j.dashboard_token, undefined, "must NOT return dashboard_token in any form");
 });
 
+test("register: rate limit trips when KV reports 10 prior hits this hour", async () => {
+    // Defence-in-depth past Turnstile: a solver farm at 10+ Turnstiles/IP/hour
+    // gets rate-limited here and stops piling rows into email_outbox + D1.
+    const kvAtLimit = { get: async () => "10", put: async () => {} };
+    const r = await registerPost({
+        env: { DB: mockDB([]), RATE_KV: kvAtLimit },
+        request: new Request(`${BASE}/api/register`, {
+            method: "POST",
+            body: JSON.stringify({ email: "alice@example.com", legal_name: "Alice Smith",
+                legal_name_attested: true, age_attested_13plus: true }),
+        }),
+    });
+    assert.equal(r.status, 429);
+    const j = await r.json();
+    assert.equal(j.error, "rate_limited");
+});
+
 test("register: existing pending user re-registers → 200 must NOT leak dashboard_token or code", async () => {
     let updateCalled = false;
     const db = mockDB([

--- a/pages/functions/api/recover.js
+++ b/pages/functions/api/recover.js
@@ -51,10 +51,8 @@ this email — no further action is taken.</p>`;
 // Success path: if we find an active user, we queue a recovery email via
 // email_outbox with idempotency_key=recover:{user_id}:{hour_bucket}, so two
 // requests in the same hour for the same user collapse to one queued email.
-//
-// The email_outbox consumer for non-monthly templates is not yet built — rows
-// are queued but will only send once a consumer Worker is deployed. This is
-// an accepted MVP gap; the row is durable and the consumer can drain later.
+// workers/email-sender drains the outbox every 2 min (templates: monthly_cert,
+// recover, register), so delivery is typically within one drain cycle.
 
 const MAX_PER_HOUR = 5;
 const CONSTANT_RESPONSE = {

--- a/pages/functions/api/register.js
+++ b/pages/functions/api/register.js
@@ -1,8 +1,14 @@
 import {
     ulid, randomCode, randomToken, json, now, audit, clientIp, ipHash,
     isValidEmail, isValidName, verifyTurnstile, queueEmail,
-    escapeHtml, emailShell, sha256Hex,
+    escapeHtml, emailShell, sha256Hex, rateLimit,
 } from "../_lib.js";
+
+// Defence-in-depth against a Turnstile-solver farm. Turnstile is the first
+// gate (~$0.002/solve on grey-market solvers), this is the second — 10
+// successful Turnstiles per IP per hour is plenty for any legit user (code
+// expires after 72h; you rarely re-register more than once a day).
+const MAX_REGISTRATIONS_PER_HOUR = 10;
 
 const SITE_BASE = "https://sc-cpe-web.pages.dev";
 
@@ -64,6 +70,11 @@ export async function onRequestPost({ request, env }) {
 
     const captcha = await verifyTurnstile(env, turnstileToken, clientIp(request));
     if (!captcha.ok) return json({ error: "captcha_failed", detail: captcha.reason }, 403);
+
+    const ipH = await ipHash(clientIp(request));
+    const hourBucket = new Date().toISOString().slice(0, 13); // "YYYY-MM-DDTHH"
+    const rl = await rateLimit(env, `register:${ipH}:${hourBucket}`, MAX_REGISTRATIONS_PER_HOUR);
+    if (!rl.ok) return json(rl.body, rl.status);
 
     const existing = await env.DB.prepare(
         "SELECT id, state, dashboard_token FROM users WHERE lower(email) = ?1 AND deleted_at IS NULL"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,6 +8,7 @@ node --test \
     pages/functions/_heartbeat.test.mjs \
     pages/functions/api/endpoints.test.mjs \
     pages/functions/api/onboarding.test.mjs \
+    pages/functions/api/health.test.mjs \
     workers/poller/src/race-detection.test.mjs \
     workers/purge/src/heartbeat-staleness.test.mjs \
     workers/purge/src/purge-expired.test.mjs \


### PR DESCRIPTION
Three pre-launch P0 items bundled. All small, all testable.

1. `/api/register` gets a defence-in-depth IP rate limit on top of Turnstile
   (10/ip/hour). A Turnstile-solver farm at commodity pricing would otherwise
   hammer D1 + email_outbox unchecked; this caps the damage without affecting
   a legit user (codes are 72h, you rarely re-register within the hour).

2. `/api/health` now reports every source classifyAll() knows about
   (poller, purge, email_sender, security_alerts, canary) instead of just
   poller + purge. Before this a dead email_sender could hide behind a
   green public health page — surfaced by codex pre-launch review.
   Implementation delegates to the shared _heartbeat classifier so
   staleness rules stay single-source.

3. recover.js: remove the stale "email_outbox consumer for non-monthly
   templates is not yet built — MVP gap" comment. The consumer is built
   and drains recover/register/monthly_cert every 2 min; the comment was
   lying to future readers.

Tests: new register rate-limit test + 5 health-endpoint tests (source
inventory, missing-source staleness, fresh-beat staleness, any_stale
rollup, watchdog contract). 99/99 green.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
