### PR TITLE
feat(ops): surface email + cert backlog age in ops-stats and admin dashboard

### DIFF
--- a/pages/admin.html
+++ b/pages/admin.html
@@ -116,6 +116,13 @@ async function load() {
 }
 function renderStats(s) {
   const g = $("#stats"); g.innerHTML = "";
+  // Backlog aging thresholds: email backlog > 10min = stale (sender runs
+  // every 2min; anything past 5× that is a real signal). Cert pending > 4h =
+  // stale (cert-sign-pending cron runs every 2h, so 2× = 4h).
+  const queuedAge = s.email_outbox.oldest_queued_age_seconds;
+  const queuedCls = (queuedAge != null && queuedAge > 600) ? "stale" : "";
+  const certPendAge = s.certs?.oldest_pending_age_seconds;
+  const certPendCls = (certPendAge != null && certPendAge > 4 * 3600) ? "stale" : "";
   g.append(
     card("Users (active)", s.users.active),
     card("Users pending", s.users.pending),
@@ -123,8 +130,10 @@ function renderStats(s) {
     card("Certs total", s.certs_total),
     card("Attendance 24h", s.last_24h.attendance),
     card("Open appeals", s.appeals_open, s.appeals_open > 0 ? "warn" : ""),
-    card("Email queued", s.email_outbox.queued),
+    card("Email queued", `${s.email_outbox.queued}${queuedAge != null ? ` · oldest ${fmtAge(queuedAge)}` : ""}`, queuedCls),
     card("Email failed", s.email_outbox.failed, s.email_outbox.failed > 0 ? "stale" : ""),
+    card("Email sent 24h", s.email_outbox.sent_24h ?? 0),
+    card("Certs pending", `${s.certs?.pending ?? 0}${certPendAge != null ? ` · oldest ${fmtAge(certPendAge)}` : ""}`, certPendCls),
   );
 }
 function renderHeartbeats(d) {

--- a/pages/functions/api/admin/ops-stats.js
+++ b/pages/functions/api/admin/ops-stats.js
@@ -16,7 +16,9 @@ export async function onRequestGet({ request, env }) {
         usersTotal, usersActive, usersPending,
         attendance24h, certs24h, certsTotal,
         appealsOpen,
-        outboxQueued, outboxFailed,
+        outboxQueued, outboxFailed, outboxSent24h,
+        outboxOldestQueued, outboxOldestFailed,
+        certsPending, certsOldestPending,
         auditTip,
     ] = await Promise.all([
         env.DB.prepare("SELECT COUNT(*) AS n FROM users WHERE deleted_at IS NULL").first(),
@@ -28,8 +30,16 @@ export async function onRequestGet({ request, env }) {
         env.DB.prepare("SELECT COUNT(*) AS n FROM appeals WHERE state = 'open'").first(),
         env.DB.prepare("SELECT COUNT(*) AS n FROM email_outbox WHERE state = 'queued'").first(),
         env.DB.prepare("SELECT COUNT(*) AS n FROM email_outbox WHERE state = 'failed'").first(),
+        env.DB.prepare("SELECT COUNT(*) AS n FROM email_outbox WHERE state = 'sent' AND sent_at > ?1").bind(since24h).first(),
+        env.DB.prepare("SELECT MIN(created_at) AS ts FROM email_outbox WHERE state = 'queued'").first(),
+        env.DB.prepare("SELECT MIN(created_at) AS ts FROM email_outbox WHERE state = 'failed'").first(),
+        env.DB.prepare("SELECT COUNT(*) AS n FROM certs WHERE state = 'pending'").first(),
+        env.DB.prepare("SELECT MIN(created_at) AS ts FROM certs WHERE state = 'pending'").first(),
         env.DB.prepare("SELECT id, ts, prev_hash FROM audit_log ORDER BY ts DESC, id DESC LIMIT 1").first(),
     ]);
+
+    const nowMs = Date.now();
+    const ageSecs = (iso) => iso ? Math.max(0, Math.floor((nowMs - new Date(iso).getTime()) / 1000)) : null;
 
     const fixtureStreams = await env.DB.prepare(
         "SELECT COUNT(*) AS n FROM streams WHERE id LIKE '01KTEST%' OR yt_video_id LIKE 'TEST%'",
@@ -59,6 +69,16 @@ export async function onRequestGet({ request, env }) {
         email_outbox: {
             queued: outboxQueued?.n ?? 0,
             failed: outboxFailed?.n ?? 0,
+            sent_24h: outboxSent24h?.n ?? 0,
+            // Oldest-age surfaces backlog aging before count alone would:
+            // 50 queued for 30 seconds is fine, 3 queued for an hour is a
+            // silent outage in email-sender. Admin dashboard flags this.
+            oldest_queued_age_seconds: ageSecs(outboxOldestQueued?.ts),
+            oldest_failed_age_seconds: ageSecs(outboxOldestFailed?.ts),
+        },
+        certs: {
+            pending: certsPending?.n ?? 0,
+            oldest_pending_age_seconds: ageSecs(certsOldestPending?.ts),
         },
         audit_tip: auditTip
             ? { id: auditTip.id, ts: auditTip.ts, prev_hash: auditTip.prev_hash }

--- a/pages/functions/api/admin/ops-stats.test.mjs
+++ b/pages/functions/api/admin/ops-stats.test.mjs
@@ -1,0 +1,127 @@
+// Tests for /api/admin/ops-stats. Guards the backlog-visibility fields
+// added in the launch-prep PR: a silent email-sender outage previously
+// showed up only as a stale-heartbeat digest the next day; ops-stats now
+// surfaces backlog age and pending-cert age so the admin dashboard shows
+// it immediately.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestGet as opsStatsGet } from "./ops-stats.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+// Dispatch by SQL-regex; each rule returns {first: row} for .first() calls.
+function dbFor(rules) {
+    return {
+        prepare(sql) {
+            const rule = rules.find(r => r.match.test(sql));
+            if (!rule) throw new Error("no mock rule for: " + sql.slice(0, 90));
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => rule.handler(sql, binds),
+            };
+            return stmt;
+        },
+    };
+}
+
+// Default row set — nothing aging, all zero. Rules are order-sensitive: the
+// first matching regex wins in dbFor(), so put the more-specific patterns
+// (MIN(created_at), WHERE state='pending') BEFORE their generic COUNT(*)
+// cousins for the same table.
+function cleanRules(overrides = {}) {
+    return [
+        // email_outbox specific (MIN must precede COUNT because both match "email_outbox WHERE state = 'queued'")
+        { match: /MIN\(created_at\).*email_outbox WHERE state = 'queued'/, handler: () => overrides.oldestQueued ?? ({ ts: null }) },
+        { match: /MIN\(created_at\).*email_outbox WHERE state = 'failed'/, handler: () => overrides.oldestFailed ?? ({ ts: null }) },
+        { match: /FROM email_outbox WHERE state = 'queued'/, handler: () => overrides.queuedCount ?? ({ n: 0 }) },
+        { match: /FROM email_outbox WHERE state = 'failed'/, handler: () => overrides.failedCount ?? ({ n: 0 }) },
+        { match: /FROM email_outbox WHERE state = 'sent'/, handler: () => ({ n: 120 }) },
+        // certs specific (MIN must precede both the pending COUNT and the "FROM certs" default)
+        { match: /MIN\(created_at\).*FROM certs WHERE state = 'pending'/, handler: () => overrides.oldestPending ?? ({ ts: null }) },
+        { match: /FROM certs WHERE state = 'pending'/, handler: () => overrides.pendingCount ?? ({ n: 0 }) },
+        { match: /FROM certs WHERE created_at/, handler: () => ({ n: 4 }) },
+        { match: /SELECT COUNT\(\*\) AS n FROM certs$/, handler: () => ({ n: 20 }) },
+        // users / attendance / appeals
+        { match: /FROM users WHERE deleted_at IS NULL AND \(email LIKE/, handler: () => ({ n: 0 }) },
+        { match: /COUNT\(\*\).*FROM users WHERE deleted_at IS NULL$/, handler: () => ({ n: 42 }) },
+        { match: /FROM users WHERE state = 'active'/, handler: () => ({ n: 30 }) },
+        { match: /FROM users WHERE state = 'pending_verification'/, handler: () => ({ n: 2 }) },
+        { match: /FROM attendance WHERE first_msg_sha256/, handler: () => ({ n: 0 }) },
+        { match: /FROM attendance WHERE created_at/, handler: () => ({ n: 17 }) },
+        { match: /FROM appeals WHERE state = 'open'/, handler: () => ({ n: 0 }) },
+        { match: /FROM streams WHERE id LIKE '01KTEST/, handler: () => ({ n: 0 }) },
+        { match: /FROM audit_log ORDER BY ts DESC/, handler: () => ({ id: "01X", ts: "2026-04-16T00:00:00Z", prev_hash: "abc" }) },
+    ];
+}
+
+function withAuth(url) {
+    return new Request(url, { headers: { Authorization: "Bearer adm" } });
+}
+
+test("ops-stats: clean state — new fields present with zero/null defaults", async () => {
+    const r = await opsStatsGet({
+        env: { DB: dbFor(cleanRules()), ADMIN_TOKEN: "adm" },
+        request: withAuth(`${BASE}/api/admin/ops-stats`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.email_outbox.queued, 0);
+    assert.equal(j.email_outbox.failed, 0);
+    assert.equal(j.email_outbox.sent_24h, 120);
+    assert.equal(j.email_outbox.oldest_queued_age_seconds, null,
+        "null when no queued rows exist");
+    assert.equal(j.email_outbox.oldest_failed_age_seconds, null);
+    assert.equal(j.certs.pending, 0);
+    assert.equal(j.certs.oldest_pending_age_seconds, null);
+});
+
+test("ops-stats: backlog aging — oldest_queued_age_seconds reflects time since MIN(created_at)", async () => {
+    // Queue holds 3 rows, oldest was inserted ~47 minutes ago.
+    const oldestIso = new Date(Date.now() - 47 * 60 * 1000).toISOString();
+    const r = await opsStatsGet({
+        env: {
+            DB: dbFor(cleanRules({
+                queuedCount: { n: 3 },
+                oldestQueued: { ts: oldestIso },
+            })),
+            ADMIN_TOKEN: "adm",
+        },
+        request: withAuth(`${BASE}/api/admin/ops-stats`),
+    });
+    const j = await r.json();
+    assert.equal(j.email_outbox.queued, 3);
+    const age = j.email_outbox.oldest_queued_age_seconds;
+    assert.ok(age >= 2800 && age <= 2900, `expected ~2820, got ${age}`);
+});
+
+test("ops-stats: pending certs — oldest_pending_age_seconds surfaces cron-stuck rows", async () => {
+    // One cert has been pending 6 hours — cron should have picked it up 3x by now.
+    const pendingIso = new Date(Date.now() - 6 * 3600 * 1000).toISOString();
+    const r = await opsStatsGet({
+        env: {
+            DB: dbFor(cleanRules({
+                pendingCount: { n: 1 },
+                oldestPending: { ts: pendingIso },
+            })),
+            ADMIN_TOKEN: "adm",
+        },
+        request: withAuth(`${BASE}/api/admin/ops-stats`),
+    });
+    const j = await r.json();
+    assert.equal(j.certs.pending, 1);
+    const age = j.certs.oldest_pending_age_seconds;
+    assert.ok(age >= 6 * 3600 - 30 && age <= 6 * 3600 + 30, `expected ~21600s, got ${age}`);
+});
+
+test("ops-stats: unauthorized (wrong bearer) → 401", async () => {
+    const r = await opsStatsGet({
+        env: { DB: dbFor(cleanRules()), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/ops-stats`, {
+            headers: { Authorization: "Bearer wrong" },
+        }),
+    });
+    assert.equal(r.status, 401);
+});

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,6 +9,7 @@ node --test \
     pages/functions/api/endpoints.test.mjs \
     pages/functions/api/onboarding.test.mjs \
     pages/functions/api/health.test.mjs \
+    pages/functions/api/admin/ops-stats.test.mjs \
     workers/poller/src/race-detection.test.mjs \
     workers/purge/src/heartbeat-staleness.test.mjs \
     workers/purge/src/purge-expired.test.mjs \

--- a/workers/email-sender/src/index.js
+++ b/workers/email-sender/src/index.js
@@ -139,7 +139,23 @@ async function drain(env) {
         }
     }
 
-    return { attempted: rows.length, sent, failed };
+    // Post-tick backlog numbers get baked into the heartbeat detail so
+    // operators see "150 queued / oldest 4200s old" in the admin view and
+    // `stale_heartbeats` digest. These are the earliest signal that Resend
+    // rate-limits are biting or the sender is under-provisioned.
+    const [{ n: queuedAfter = 0 } = {}, oldestRow = {}] = await Promise.all([
+        env.DB.prepare("SELECT COUNT(*) AS n FROM email_outbox WHERE state = 'queued'").first().catch(() => ({})),
+        env.DB.prepare("SELECT MIN(created_at) AS ts FROM email_outbox WHERE state = 'queued'").first().catch(() => ({})),
+    ]);
+    const oldestAgeSec = oldestRow?.ts
+        ? Math.max(0, Math.floor((Date.now() - new Date(oldestRow.ts).getTime()) / 1000))
+        : null;
+
+    return {
+        attempted: rows.length, sent, failed,
+        queued_after: queuedAfter,
+        oldest_queued_age_seconds: oldestAgeSec,
+    };
 }
 
 async function sendViaResend(env, row) {


### PR DESCRIPTION
Before this a silent email-sender outage showed up only as a stale-
heartbeat entry in the next daily digest — hours after backlog started
aging. Counts alone weren't enough: 50 queued for 30 seconds is fine,
3 queued for an hour is an outage.

/api/admin/ops-stats now returns:
  email_outbox.sent_24h                    — throughput signal
  email_outbox.oldest_queued_age_seconds   — silent-outage tripwire
  email_outbox.oldest_failed_age_seconds
  certs.pending                             — decoupled from certs_total
  certs.oldest_pending_age_seconds          — cert-sign-pending cron stall signal

admin.html flags the email-queued card as stale when oldest-queued > 10min
(email-sender runs every 2min, so 5× cadence = real signal) and the
certs-pending card when oldest-pending > 4h (cron is every 2h, so 2×
cadence).

email-sender's heartbeat detail now carries `queued_after` +
`oldest_queued_age_seconds` so the heartbeats table itself tells the
backlog story tick-over-tick, independent of any admin request.

Tests: new ops-stats.test.mjs covers the aging fields, null-safety,
and admin auth gate. 103/103 green.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
