### PR TITLE
feat(me): POST /api/me/{token}/rotate — dashboard link revocation

### DIFF
--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -194,6 +194,18 @@
             </p>
         </div>
 
+        <div class="card" id="rotate-card" hidden>
+            <h2>Dashboard link security</h2>
+            <p class="muted" style="font-size:12px;">
+                This dashboard URL is your account credential. If it leaked
+                (accidentally shared, screenshot posted, lost device), rotate
+                it here. We'll email a fresh URL to the address on file — this
+                page will stop working a few seconds later.
+            </p>
+            <button type="button" id="rotate-btn" style="margin-top:8px;">Rotate dashboard link</button>
+            <span id="rotate-msg" class="muted" hidden style="margin-left:8px;"></span>
+        </div>
+
         <div class="card" id="prefs-card" hidden>
             <h2>Certificate delivery</h2>
             <p class="muted" style="font-size:12px;">
@@ -246,6 +258,10 @@ async function load() {
     document.getElementById("body").hidden = false;
     document.getElementById("name").textContent = d.user.legal_name;
     document.getElementById("state").textContent = d.user.state;
+
+    // Rotate card is available to both pending and active users — either
+    // can have a leaked dashboard URL and need to invalidate it.
+    document.getElementById("rotate-card").hidden = false;
 
     if (d.user.state === "active") {
         const prefsCard = document.getElementById("prefs-card");
@@ -614,6 +630,43 @@ document.getElementById("prefs-radios").addEventListener("change", async (e) => 
         msg.textContent = "saved — next monthly run will respect this.";
     } catch (err) {
         msg.textContent = "failed: " + err.message;
+    }
+});
+
+document.getElementById("rotate-btn").addEventListener("click", async () => {
+    if (!confirm("Rotate your dashboard link now?\n\nWe'll email the new URL to the address on file. This page will stop working a few seconds later.")) return;
+    const btn = document.getElementById("rotate-btn");
+    const msg = document.getElementById("rotate-msg");
+    btn.disabled = true;
+    msg.hidden = true;
+    try {
+        const r = await fetch(`/api/me/${encodeURIComponent(token)}/rotate`,
+            { method: "POST" });
+        const d = await r.json().catch(() => ({}));
+        if (r.ok) {
+            msg.textContent = "Rotated. Check your email for the new link — this one stops working shortly.";
+            msg.style.color = "#15803d";
+            btn.textContent = "Rotated ✓";
+            // Leave button disabled — the old token is already invalid.
+        } else if (r.status === 429) {
+            msg.textContent = "Too many rotations — try again in an hour.";
+            msg.style.color = "#b91c1c";
+            btn.disabled = false;
+        } else if (r.status === 403) {
+            msg.textContent = "Blocked (origin check failed). Open the dashboard URL directly in your browser.";
+            msg.style.color = "#b91c1c";
+            btn.disabled = false;
+        } else {
+            msg.textContent = `Couldn't rotate (${r.status}).`;
+            msg.style.color = "#b91c1c";
+            btn.disabled = false;
+        }
+        msg.hidden = false;
+    } catch {
+        msg.textContent = "Network error — try again.";
+        msg.style.color = "#b91c1c";
+        msg.hidden = false;
+        btn.disabled = false;
     }
 });
 

--- a/pages/functions/api/me/[token]/rotate.js
+++ b/pages/functions/api/me/[token]/rotate.js
@@ -1,0 +1,119 @@
+import {
+    randomToken, json, now, audit, clientIp, ipHash,
+    queueEmail, escapeHtml, emailShell, isSameOrigin, rateLimit, sha256Hex,
+} from "../../../_lib.js";
+
+// POST /api/me/{dashboard_token}/rotate
+//
+// Invalidates the current dashboard token and emails a fresh URL to the
+// address on file. The user (or attacker) holding the current URL can
+// trigger this — same origin, with CSRF gate — but the NEW token is
+// delivered only by email. Email-inbox possession is therefore the gate
+// against a rotation-hijack by whoever leaked/stole the old URL.
+//
+// This is the first-line response to "my dashboard link leaked" and to
+// "I think my laptop screen got screenshotted" without requiring us to
+// build an account-recovery flow that needs another credential.
+
+const MAX_PER_HOUR = 3;
+const SITE_BASE = "https://sc-cpe-web.pages.dev";
+
+function bodies({ legalName, dashboardUrl }) {
+    const subject = "Simply Cyber CPE — your dashboard link has been rotated";
+    const text =
+        `Hi ${legalName},\n\n` +
+        `Your SC-CPE dashboard link was just rotated. Bookmark the new\n` +
+        `URL — your previous link no longer works:\n\n` +
+        `  ${dashboardUrl}\n\n` +
+        `If you did not request this rotation, your account is now safe:\n` +
+        `the old link can no longer access the dashboard. Contact us if\n` +
+        `anything else looks wrong.\n\n` +
+        `— Simply Cyber\n`;
+    const bodyHtml = `
+<p>Hi ${escapeHtml(legalName)},</p>
+<p>Your SC-CPE dashboard link was just rotated. <strong>Bookmark the new URL</strong> —
+your previous link no longer works:</p>
+<p>
+  <a href="${dashboardUrl}"
+     style="display:inline-block;background:#0b3d5c;color:#fff;
+            padding:10px 16px;border-radius:4px;text-decoration:none;">
+     Open my dashboard
+  </a>
+</p>
+<p style="word-break:break-all;font-family:Menlo,monospace;font-size:12px;color:#555;">
+  ${dashboardUrl}
+</p>
+<p style="color:#666;font-size:12px;">If you did not request this rotation,
+your account is now safe: the old link can no longer access the dashboard.</p>`;
+    return {
+        subject, text,
+        html: emailShell({
+            title: "Dashboard link rotated",
+            preheader: "Your new SC-CPE dashboard URL",
+            bodyHtml,
+        }),
+    };
+}
+
+export async function onRequestPost({ params, request, env }) {
+    const token = params.token;
+    if (!token || token.length < 32) return json({ error: "invalid_token" }, 400);
+
+    // CSRF gate — the dashboard token sits in the URL, so a browser will
+    // happily POST here from any page that knows it. Same-origin only.
+    if (!isSameOrigin(request, env)) {
+        return json({ error: "forbidden_origin" }, 403);
+    }
+
+    const ip = clientIp(request);
+    const ipH = await ipHash(ip);
+
+    const user = await env.DB.prepare(
+        "SELECT id, email, legal_name FROM users " +
+        "WHERE dashboard_token = ?1 AND deleted_at IS NULL"
+    ).bind(token).first();
+    if (!user) return json({ error: "not_found" }, 404);
+
+    // Per-user rate limit. Rotating >3/hour is almost certainly abuse.
+    // Fail-closed via rateLimit() so a missing RATE_KV returns 503.
+    const hourBucket = new Date().toISOString().slice(0, 13);
+    const rl = await rateLimit(env, `rotate:${user.id}:${hourBucket}`, MAX_PER_HOUR);
+    if (!rl.ok) return json(rl.body, rl.status);
+
+    const newToken = randomToken();
+    await env.DB.prepare(
+        "UPDATE users SET dashboard_token = ?1 WHERE id = ?2"
+    ).bind(newToken, user.id).run();
+
+    const dashboardUrl = `${SITE_BASE}/dashboard.html?t=${newToken}`;
+    const b = bodies({
+        legalName: user.legal_name || "there",
+        dashboardUrl,
+    });
+
+    await queueEmail(env, {
+        userId: user.id,
+        template: "register",
+        to: user.email,
+        subject: b.subject,
+        html: b.html,
+        text: b.text,
+        // Idempotency on (user, new_token) — same token never queues twice.
+        idempotencyKey: `rotate:${user.id}:${await sha256Hex(newToken)}`,
+    });
+
+    await audit(env, "user", user.id, "dashboard_token_rotated", "user", user.id,
+        null,
+        {
+            // Hash of the old token lets auditors link rotate events to
+            // specific URL leaks without the token itself landing in the
+            // append-only log.
+            old_token_sha256: await sha256Hex(token),
+            email_sha256: await sha256Hex(user.email),
+        },
+        { ip_hash: ipH });
+
+    // Do NOT return the new token. Possession of the email inbox is the
+    // gate — same philosophy as register.js.
+    return json({ ok: true, email_sent: true });
+}

--- a/pages/functions/api/onboarding.test.mjs
+++ b/pages/functions/api/onboarding.test.mjs
@@ -13,6 +13,7 @@ import { onRequestPost as recoverPost } from "./recover.js";
 import { onRequestGet as meGet } from "./me/[token].js";
 import { onRequestPost as deletePost } from "./me/[token]/delete.js";
 import { onRequestPost as resendPost } from "./me/[token]/resend-code.js";
+import { onRequestPost as rotatePost } from "./me/[token]/rotate.js";
 
 // ── helpers ───────────────────────────────────────────────────────────────
 
@@ -569,4 +570,89 @@ test("resend-code: unknown token → 404", async () => {
         request: req(`${BASE}/api/me/${SHORT_TOKEN}/resend-code`),
     });
     assert.equal(r.status, 404);
+});
+
+// ── me/[token]/rotate.js ──────────────────────────────────────────────────
+
+test("rotate: updates dashboard_token, queues email, returns no new token", async () => {
+    let updatedToken = null;
+    let queuedTo = null;
+    const db = mockDB([
+        {
+            match: /FROM users WHERE dashboard_token.*deleted_at IS NULL/s,
+            handler: () => ({ first: { id: FAKE_ULID, email: "alice@example.com", legal_name: "Alice Smith" } }),
+        },
+        {
+            match: /UPDATE users SET dashboard_token = \?1 WHERE id = \?2/,
+            handler: (_sql, binds) => { updatedToken = binds[0]; return { run: { meta: {} } }; },
+        },
+        {
+            match: /INSERT INTO email_outbox/,
+            handler: (_sql, binds) => { queuedTo = binds.find(b => String(b).includes("@")); return { run: { meta: {} } }; },
+        },
+        ...auditRules,
+    ]);
+    const r = await rotatePost({
+        params: { token: FAKE_TOKEN },
+        env: { DB: db, RATE_KV: kvPermissive },
+        request: req(`${BASE}/api/me/${FAKE_TOKEN}/rotate`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.ok(j.ok);
+    assert.ok(j.email_sent);
+    // Response body must NOT leak the new token (same philosophy as /register)
+    assert.equal(j.dashboard_url, undefined);
+    assert.equal(j.dashboard_token, undefined);
+    // UPDATE must have fired with a fresh 64-hex token
+    assert.ok(updatedToken, "UPDATE users SET dashboard_token must run");
+    assert.notEqual(updatedToken, FAKE_TOKEN, "new token must differ from old");
+    assert.match(updatedToken, /^[0-9a-f]{64}$/, "new token must be 64-hex");
+    // Email must be queued to the on-file address
+    assert.equal(queuedTo, "alice@example.com");
+});
+
+test("rotate: cross-origin request → 403 (CSRF gate)", async () => {
+    const r = await rotatePost({
+        params: { token: FAKE_TOKEN },
+        env: { DB: mockDB([]), RATE_KV: kvPermissive },
+        request: new Request(`${BASE}/api/me/${FAKE_TOKEN}/rotate`, {
+            method: "POST",
+            headers: { Origin: "https://attacker.example" },
+        }),
+    });
+    assert.equal(r.status, 403);
+    const j = await r.json();
+    assert.equal(j.error, "forbidden_origin");
+});
+
+test("rotate: unknown token → 404", async () => {
+    const db = mockDB([
+        {
+            match: /FROM users WHERE dashboard_token.*deleted_at IS NULL/s,
+            handler: () => ({ first: null }),
+        },
+    ]);
+    const r = await rotatePost({
+        params: { token: SHORT_TOKEN },
+        env: { DB: db, RATE_KV: kvPermissive },
+        request: req(`${BASE}/api/me/${SHORT_TOKEN}/rotate`),
+    });
+    assert.equal(r.status, 404);
+});
+
+test("rotate: rate limit trips when KV reports 3 prior hits this hour", async () => {
+    const kvAtLimit = { get: async () => "3", put: async () => {} };
+    const db = mockDB([
+        {
+            match: /FROM users WHERE dashboard_token.*deleted_at IS NULL/s,
+            handler: () => ({ first: { id: FAKE_ULID, email: "a@example.com", legal_name: "A" } }),
+        },
+    ]);
+    const r = await rotatePost({
+        params: { token: FAKE_TOKEN },
+        env: { DB: db, RATE_KV: kvAtLimit },
+        request: req(`${BASE}/api/me/${FAKE_TOKEN}/rotate`),
+    });
+    assert.equal(r.status, 429);
 });


### PR DESCRIPTION
The dashboard URL is the user's whole credential. Until now a leaked URL
(forwarded email, screenshot, left-open laptop, lost device) had no
user-facing revocation path — /api/recover re-emails the SAME token,
which doesn't help if the old one is in the wild.

Rotate endpoint:
- POST /api/me/{token}/rotate (same CSRF + token-gated pattern as
  delete/resend-code/prefs/cert-feedback — isSameOrigin enforced)
- Mints a new 64-hex dashboard_token, UPDATE users in place
- Queues a "Dashboard link rotated" email to the address on file — the
  new URL is delivered ONLY via email, so someone who stole the old URL
  cannot silently hijack the rotation (email-possession gate, same
  philosophy as /register)
- Rate-limited 3/hour/user via the shared fail-closed helper
- Audit log captures sha256(old_token) + sha256(email) so rotations
  can be attributed without the token itself landing in the append-only
  chain
- Response: {ok, email_sent} only — no new token in the body

Dashboard UI gains a "Dashboard link security" card with a confirmation
modal; available to both pending and active users.

Tests: 4 new cases covering happy-path (update + email + no leak),
CSRF gate, unknown token, rate-limit trip. 107/107 green.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
