### PR TITLE
fix(terms,poller): align attendance Terms with the lenient mid-stream policy the code actually enforces

### DIFF
--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,10 +1,12 @@
--- Rule v1: message length >= 3 chars (stripped), not pure emoji, publishedAt
--- between actualStartTime+15min and actualEndTime-15min. Anchored to YT API
--- actual times, NOT wall clock. Each attendance row carries this version.
+-- Rule v1: message length >= 3 chars (stripped), has at least one letter or
+-- digit, publishedAt >= actualStartTime - pre_start_grace_min. Anchored to
+-- YT API actual times, NOT wall clock. YouTube closes live chat at
+-- actualEndTime so no post-end check is needed — the platform enforces it.
+-- Each attendance row carries this rule_version so policy can evolve
+-- without rewriting history.
 INSERT INTO kv (k, v, updated_at) VALUES
     ('rule_version.current', '1', strftime('%Y-%m-%dT%H:%M:%SZ','now')),
     ('rule_version.1.min_msg_len', '3', strftime('%Y-%m-%dT%H:%M:%SZ','now')),
     ('rule_version.1.pre_start_grace_min', '15', strftime('%Y-%m-%dT%H:%M:%SZ','now')),
-    ('rule_version.1.pre_end_grace_min', '15', strftime('%Y-%m-%dT%H:%M:%SZ','now')),
     ('rule_version.1.cpe_per_day', '0.5', strftime('%Y-%m-%dT%H:%M:%SZ','now')),
     ('rule_version.1.finalize_settle_min', '5', strftime('%Y-%m-%dT%H:%M:%SZ','now'));

--- a/pages/terms.html
+++ b/pages/terms.html
@@ -24,9 +24,9 @@
     <h2>4. The Attendance Rule</h2>
     <p>A qualifying attendance is recorded when <strong>all</strong> of the following conditions are met:</p>
     <ul>
-        <li>Your registered YouTube channel posts at least one chat message containing three or more characters.</li>
-        <li>That message is posted during the <em>active window</em> of the live broadcast, defined as the period between the stream's <code>actualStartTime</code> and <code>actualEndTime</code> as reported by the YouTube Data API.</li>
-        <li>The message is posted within a mid-stream window — not in the first or last segment reserved to exclude pre-stream and post-stream chat noise (exact window parameters are set at the operator's discretion and may be adjusted to improve accuracy).</li>
+        <li>Your registered YouTube channel posts at least one chat message containing three or more characters with at least one letter or digit.</li>
+        <li>That message is posted while the broadcast is live, as reported by the YouTube Data API's <code>actualStartTime</code> and <code>actualEndTime</code> fields. A short pre-stream grace window (currently fifteen minutes) accommodates early viewers whose clients start chat slightly before the official start; messages posted more than fifteen minutes before <code>actualStartTime</code> do not qualify, and the rejection is visible on your dashboard so you know credit did not land.</li>
+        <li>Replay chat posted after the live broadcast ends does not qualify. YouTube closes live chat at <code>actualEndTime</code>, so this boundary is enforced by the platform itself rather than by a separate rule.</li>
         <li>Your YouTube channel is bound to an active, verified SC-CPE account at the time the message is posted.</li>
     </ul>
     <p>Each weekday broadcast awards at most 0.5 CPE credits per registered user, regardless of how many messages are posted. No credits are awarded for replayed, archived, or on-demand viewing.</p>

--- a/workers/poller/src/index.js
+++ b/workers/poller/src/index.js
@@ -406,7 +406,6 @@ async function loadRule(env) {
         version: v,
         min_msg_len: parseInt(m[`rule_version.${v}.min_msg_len`] || "3", 10),
         pre_start_grace_min: parseInt(m[`rule_version.${v}.pre_start_grace_min`] || "15", 10),
-        pre_end_grace_min: parseInt(m[`rule_version.${v}.pre_end_grace_min`] || "15", 10),
         cpe_per_day: parseFloat(m[`rule_version.${v}.cpe_per_day`] || "0.5"),
         finalize_settle_min: parseInt(m[`rule_version.${v}.finalize_settle_min`] || "5", 10),
     };


### PR DESCRIPTION
The attendance rule in pages/terms.html §4 promised a symmetric "not in the
first or last segment" window. The poller never enforced it:
- pre_start_grace_min is applied as a LENIENCY buffer (accepts messages
  up to 15 min BEFORE actualStartTime), not a first-segment exclusion.
- pre_end_grace_min was loaded at workers/poller/src/index.js:409 and
  never read anywhere. Dead code since it was introduced.
- The post-end boundary is enforced by YouTube itself (live chat closes
  at actualEndTime), so no in-code check is needed.

Codex's pre-launch review flagged this as policy-vs-code drift —
exactly the kind of thing a CISSP auditor grills. Option B from the
brainstorm: rewrite Terms to describe what the code actually does, drop
the dead variable, keep user-visible behavior unchanged.

Changes:
- pages/terms.html §4: explicit pre-start grace language, explicit
  note that YouTube auto-closes chat at actualEndTime so replay
  messages can't qualify. Adds the "at least one letter or digit"
  detail that the code has always enforced.
- workers/poller/src/index.js: remove the dead pre_end_grace_min load
  from loadRule().
- db/seed.sql: drop rule_version.1.pre_end_grace_min row, update the
  comment to describe the actual rule (prod D1 already has the row;
  it's now unreferenced and harmless, can be removed later via a
  migration if we care).

Zero behavioural change. Terms now truthful.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
