### PR TITLE
fix(preflight): tighten channel-binding enumeration caps — IP 20/hr, per-channel 10/day

### DIFF
--- a/pages/functions/api/preflight/channel.js
+++ b/pages/functions/api/preflight/channel.js
@@ -45,13 +45,22 @@ function extractChannelId(q) {
     return { error: "could_not_extract_channel_id" };
 }
 
+// Anti-enumeration caps. A legit user checks their own channel once or twice
+// while registering.
+//   - Per-IP, per-hour: blocks a single host from sweeping a channel list.
+//   - Per-channel, per-UTC-day: blocks a distributed attacker from targeting
+//     ONE channel across rotating IPs to answer "is victim X's channel
+//     bound?" After PROBES_PER_CHANNEL_PER_DAY total probes against the same
+//     channel id in a 24h window, further probes of THAT channel return 429
+//     regardless of source IP.
+// Both caps fail-closed via rateLimit(); a missing RATE_KV returns 503.
+const PROBES_PER_IP_PER_HOUR = 20;
+const PROBES_PER_CHANNEL_PER_DAY = 10;
+
 export async function onRequestGet({ request, env }) {
-    // Anonymous endpoint that answers "is this YouTube channel bound to an
-    // SC-CPE account?" → it's an account-enumeration oracle for anyone with
-    // a list of channel IDs to test. Cap probes per IP per hour.
     const ipH = await ipHash(clientIp(request));
-    const rl = await rateLimit(env, `preflight_channel:${ipH}`, 60);
-    if (!rl.ok) return json(rl.body, rl.status);
+    const rlIp = await rateLimit(env, `preflight_channel_ip:${ipH}`, PROBES_PER_IP_PER_HOUR);
+    if (!rlIp.ok) return json(rlIp.body, rlIp.status);
 
     const url = new URL(request.url);
     const q = url.searchParams.get("q");
@@ -60,6 +69,16 @@ export async function onRequestGet({ request, env }) {
     if (parsed.error) {
         return json({ valid: false, error: parsed.error }, 400);
     }
+
+    // Per-channel-id cap works across IPs. Keyed by normalised id + UTC day
+    // so a legit user re-checking tomorrow (after fixing their account)
+    // still succeeds.
+    const day = new Date().toISOString().slice(0, 10);
+    const rlChan = await rateLimit(env,
+        `preflight_channel_ch:${parsed.id}:${day}`,
+        PROBES_PER_CHANNEL_PER_DAY,
+        86_400 + 60);
+    if (!rlChan.ok) return json(rlChan.body, rlChan.status);
 
     const taken = await env.DB.prepare(
         "SELECT id FROM users WHERE yt_channel_id = ?1 AND state = 'active'"

--- a/pages/functions/api/preflight/channel.test.mjs
+++ b/pages/functions/api/preflight/channel.test.mjs
@@ -1,0 +1,110 @@
+// Tests for GET /api/preflight/channel. Guards the enumeration-oracle
+// caps added after codex's pre-launch review: a single IP can only probe
+// 20/hour, and any single channel id can only be probed 10/UTC-day across
+// all IPs combined.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestGet as preflightGet } from "./channel.js";
+
+const BASE = "https://sc-cpe-web.pages.dev/api/preflight/channel";
+const CHANNEL = "UC1234567890abcdefghijkl"; // 22 chars after UC
+const DB_EMPTY = {
+    prepare() {
+        return { bind: () => ({ first: async () => null }) };
+    },
+};
+
+function req(url) { return new Request(url); }
+
+test("preflight: valid channel id, not taken → {valid:true, available:true}", async () => {
+    const kv = { get: async () => null, put: async () => {} };
+    const r = await preflightGet({
+        env: { DB: DB_EMPTY, RATE_KV: kv },
+        request: req(`${BASE}?q=${CHANNEL}`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.valid, true);
+    assert.equal(j.available, true);
+    assert.equal(j.normalized, CHANNEL);
+});
+
+test("preflight: channel id that is bound → {available:false}", async () => {
+    const kv = { get: async () => null, put: async () => {} };
+    const db = {
+        prepare() {
+            return { bind: () => ({ first: async () => ({ id: "01HUSER" }) }) };
+        },
+    };
+    const r = await preflightGet({
+        env: { DB: db, RATE_KV: kv },
+        request: req(`${BASE}?q=${CHANNEL}`),
+    });
+    const j = await r.json();
+    assert.equal(j.available, false);
+    // Must NOT leak which user owns it.
+    assert.equal(j.user_id, undefined);
+    assert.equal(j.owner, undefined);
+});
+
+test("preflight: IP cap (20/hr) trips on the 21st probe from same hashed IP", async () => {
+    // KV returns "20" for the IP key — meaning 20 prior successful probes.
+    const kv = {
+        get: async (k) => k.startsWith("preflight_channel_ip:") ? "20" : null,
+        put: async () => {},
+    };
+    const r = await preflightGet({
+        env: { DB: DB_EMPTY, RATE_KV: kv },
+        request: req(`${BASE}?q=${CHANNEL}`),
+    });
+    assert.equal(r.status, 429);
+    const j = await r.json();
+    assert.equal(j.error, "rate_limited");
+});
+
+test("preflight: per-channel cap (10/day) trips regardless of IP", async () => {
+    // IP key fresh, but per-channel key reports 10 — a distributed attacker
+    // rotating IPs hits this wall even though their individual IP counter
+    // is low.
+    const kv = {
+        get: async (k) => {
+            if (k.startsWith("preflight_channel_ip:")) return "0";
+            if (k.startsWith("preflight_channel_ch:")) return "10";
+            return null;
+        },
+        put: async () => {},
+    };
+    const r = await preflightGet({
+        env: { DB: DB_EMPTY, RATE_KV: kv },
+        request: req(`${BASE}?q=${CHANNEL}`),
+    });
+    assert.equal(r.status, 429);
+});
+
+test("preflight: malformed input returns 400 BEFORE touching per-channel cap", async () => {
+    const puts = [];
+    const kv = {
+        get: async () => "0",
+        put: async (k) => { puts.push(k); },
+    };
+    const r = await preflightGet({
+        env: { DB: DB_EMPTY, RATE_KV: kv },
+        request: req(`${BASE}?q=not-a-channel`),
+    });
+    assert.equal(r.status, 400);
+    // IP cap was touched (unavoidable), but per-channel should NOT be —
+    // otherwise sending garbage input would burn the daily cap for
+    // non-existent channel ids.
+    assert.equal(puts.some(k => k.startsWith("preflight_channel_ch:")), false,
+        "per-channel KV write must not happen when input is malformed");
+});
+
+test("preflight: missing RATE_KV → 503 (fail-closed)", async () => {
+    const r = await preflightGet({
+        env: { DB: DB_EMPTY /* no RATE_KV */ },
+        request: req(`${BASE}?q=${CHANNEL}`),
+    });
+    assert.equal(r.status, 503);
+});

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,6 +10,7 @@ node --test \
     pages/functions/api/onboarding.test.mjs \
     pages/functions/api/health.test.mjs \
     pages/functions/api/admin/ops-stats.test.mjs \
+    pages/functions/api/preflight/channel.test.mjs \
     workers/poller/src/race-detection.test.mjs \
     workers/purge/src/heartbeat-staleness.test.mjs \
     workers/purge/src/purge-expired.test.mjs \


### PR DESCRIPTION
Before: 60 probes/hour/IP, unbounded per-channel. An IP-rotating attacker
could sweep a list of YouTube channel ids to answer "is victim X bound to
SC-CPE?" at effectively unlimited throughput by fanning across proxies.
Codex pre-launch review flagged this as a P1 enumeration oracle.

New caps:
- PROBES_PER_IP_PER_HOUR = 20  (was 60). A legit registering user checks
  their own channel once or twice; 20 is comfortable. A solver farm at
  10 residential proxies still only gets 200/hour — an order of
  magnitude reduction.
- PROBES_PER_CHANNEL_PER_DAY = 10 (was unbounded). This one matters
  most: even across rotating IPs, any single target channel can only be
  probed 10 times per UTC day. Stops the focused "does this specific
  person have an SC-CPE account" probe.

Malformed input returns 400 BEFORE touching the per-channel cap, so
sending garbage inputs doesn't burn capacity for real channels.

Both caps fail-closed — a missing RATE_KV binding returns 503 rather
than silently disabling the limiter (matching the existing rateLimit()
helper contract).

Tests: 6 new cases — happy path (available true/false, no owner leak),
IP cap trip, per-channel cap trip regardless of IP, malformed-input
short-circuit, fail-closed on missing KV.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
