### PR TITLE
feat(kill-switches): break-glass per-endpoint containment for launch-day abuse

### DIFF
--- a/pages/admin.html
+++ b/pages/admin.html
@@ -50,6 +50,9 @@
     <div class="section-h">Overview (last 24h)</div>
     <div class="grid" id="stats"></div>
 
+    <div class="section-h">Kill switches <span class="muted" style="font-size:11px;text-transform:none;letter-spacing:0;">— emergency containment for public endpoints</span></div>
+    <div id="toggles" style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:20px;"></div>
+
     <div class="section-h">Heartbeats</div>
     <table id="hb"><thead>
       <tr><th>Source</th><th>Status</th><th>Last beat</th><th>Age</th><th>Expected ≤</th><th>On duty</th></tr>
@@ -95,13 +98,15 @@ async function fetchJson(path) {
 async function load() {
   $("#err").innerHTML = "";
   try {
-    const [stats, hb, chain, fb] = await Promise.all([
+    const [stats, hb, chain, fb, toggles] = await Promise.all([
       fetchJson("/api/admin/ops-stats"),
       fetchJson("/api/admin/heartbeat-status"),
       fetchJson("/api/admin/audit-chain-verify?limit=200"),
       fetchJson("/api/admin/cert-feedback?rating=typo,wrong&limit=100"),
+      fetchJson("/api/admin/toggles"),
     ]);
     renderStats(stats);
+    renderToggles(toggles);
     renderHeartbeats(hb);
     renderChain(chain, stats);
     renderFeedback(fb);
@@ -112,6 +117,44 @@ async function load() {
       $("#app").style.display = "none";
       $("#login").style.display = "";
     }
+  }
+}
+function renderToggles(d) {
+  const box = $("#toggles"); box.innerHTML = "";
+  for (const t of (d.toggles || [])) {
+    const wrap = document.createElement("div");
+    wrap.className = "card";
+    wrap.style.padding = "10px 14px";
+    wrap.style.display = "flex";
+    wrap.style.alignItems = "center";
+    wrap.style.gap = "10px";
+    wrap.style.minWidth = "240px";
+    const label = document.createElement("div");
+    label.innerHTML = `<span class="k">/api/${t.name}</span><div class="v ${t.killed ? "stale" : "ok"}" style="font-size:14px;">${t.killed ? "KILLED (503)" : "live"}</div>`;
+    const btn = document.createElement("button");
+    btn.className = "refresh";
+    btn.style.marginLeft = "auto";
+    btn.textContent = t.killed ? "Re-enable" : "Kill";
+    if (!t.killed) btn.style.background = "#5c1515";
+    btn.addEventListener("click", async () => {
+      const verb = t.killed ? "re-enable" : "KILL";
+      if (!confirm(`${verb} /api/${t.name}?`)) return;
+      btn.disabled = true;
+      try {
+        const r = await fetch("/api/admin/toggles", {
+          method: "POST",
+          headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+          body: JSON.stringify({ name: t.name, killed: !t.killed }),
+        });
+        if (!r.ok) throw new Error("toggle → HTTP " + r.status);
+        load();
+      } catch (e) {
+        $("#err").innerHTML = `<div class="err">${e.message}</div>`;
+        btn.disabled = false;
+      }
+    });
+    wrap.append(label, btn);
+    box.appendChild(wrap);
   }
 }
 function renderStats(s) {

--- a/pages/functions/_lib.js
+++ b/pages/functions/_lib.js
@@ -153,6 +153,26 @@ export function isSameOrigin(request, env) {
     return extra.includes(origin);
 }
 
+// Known kill switches. Endpoints check `await killSwitched(env, name)` at
+// entry and return 503 if the switch is set. Used to contain launch-day
+// abuse bursts without taking the whole service down. Only the public,
+// unauthenticated, abuse-prone endpoints are killable — dashboard reads,
+// cert verification, cert download, user deletion, and admin paths stay
+// on even under a kill so legit users can still access their data.
+export const KILL_SWITCHES = Object.freeze(["register", "recover", "preflight"]);
+
+export async function killSwitched(env, name) {
+    if (!env.RATE_KV) return false;  // KV-gated, same store as rateLimit
+    return !!(await env.RATE_KV.get(`kill:${name}`));
+}
+
+export function killedResponse() {
+    return json({
+        error: "service_temporarily_unavailable",
+        reason: "admin_kill_switch",
+    }, 503);
+}
+
 // Per-key rate limiter that fails *closed* if the KV binding is missing.
 // Earlier this returned `false` (no limit) on missing binding, which made
 // the limit silently disappear in any environment that hadn't bound the

--- a/pages/functions/api/admin/toggles.js
+++ b/pages/functions/api/admin/toggles.js
@@ -1,0 +1,67 @@
+import { json, isAdmin, audit, clientIp, ipHash, KILL_SWITCHES } from "../../_lib.js";
+
+// GET  /api/admin/toggles  → { ok, toggles: [{name, killed}, ...] }
+// POST /api/admin/toggles  body { name: "<one of KILL_SWITCHES>", killed: bool }
+//
+// Emergency-containment controls for public unauthenticated endpoints
+// (register, recover, preflight). Killing a toggle makes the endpoint
+// return 503 {error:"service_temporarily_unavailable"} until an operator
+// clears it. No TTL — admin must explicitly re-enable.
+//
+// Critical-path endpoints (health, verify, download, dashboard reads,
+// delete) are intentionally NOT killable so a user locked out by a
+// launch-day misconfiguration can still access their data.
+
+function assertKnown(name) {
+    return KILL_SWITCHES.includes(name);
+}
+
+export async function onRequestGet({ request, env }) {
+    if (!(await isAdmin(env, request))) return json({ error: "unauthorized" }, 401);
+    if (!env.RATE_KV) {
+        return json({
+            ok: true,
+            toggles: KILL_SWITCHES.map(n => ({ name: n, killed: false, kv_bound: false })),
+        });
+    }
+    const states = await Promise.all(KILL_SWITCHES.map(async (name) => ({
+        name,
+        killed: !!(await env.RATE_KV.get(`kill:${name}`)),
+    })));
+    return json({ ok: true, toggles: states });
+}
+
+export async function onRequestPost({ request, env }) {
+    if (!(await isAdmin(env, request))) return json({ error: "unauthorized" }, 401);
+
+    let body;
+    try { body = await request.json(); }
+    catch { return json({ error: "invalid_json" }, 400); }
+
+    const name = String(body?.name || "");
+    const killed = body?.killed === true;
+    if (!assertKnown(name)) {
+        return json({ error: "unknown_switch", known: KILL_SWITCHES }, 400);
+    }
+    if (!env.RATE_KV) {
+        return json({ error: "kv_unbound", detail: "RATE_KV not bound — toggles unavailable" }, 503);
+    }
+
+    if (killed) {
+        // No TTL — operator must explicitly clear. A forgotten kill is
+        // preferable to an abuse burst returning on TTL expiry.
+        await env.RATE_KV.put(`kill:${name}`, "1");
+    } else {
+        await env.RATE_KV.delete(`kill:${name}`);
+    }
+
+    await audit(
+        env, "admin", null, "kill_switch_toggled",
+        "kill_switch", name,
+        null,
+        { name, killed },
+        { ip_hash: await ipHash(clientIp(request)) },
+    );
+
+    return json({ ok: true, name, killed });
+}

--- a/pages/functions/api/admin/toggles.test.mjs
+++ b/pages/functions/api/admin/toggles.test.mjs
@@ -1,0 +1,111 @@
+// Tests for /api/admin/toggles (GET list + POST set/clear). These are the
+// break-glass kill switches for register/recover/preflight. Only critical
+// public endpoints are killable; dashboard reads + verify + download must
+// stay on even under kill — those are NOT in KILL_SWITCHES.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestGet as togglesGet, onRequestPost as togglePost } from "./toggles.js";
+import { KILL_SWITCHES } from "../../_lib.js";
+
+const BASE = "https://sc-cpe-web.pages.dev/api/admin/toggles";
+
+function mkKV(initial = {}) {
+    const store = new Map(Object.entries(initial));
+    return {
+        get: async (k) => store.get(k) ?? null,
+        put: async (k, v) => { store.set(k, v); },
+        delete: async (k) => { store.delete(k); },
+        _snapshot: () => Object.fromEntries(store.entries()),
+    };
+}
+
+function auth(body) {
+    const init = { method: body ? "POST" : "GET", headers: { Authorization: "Bearer adm" } };
+    if (body) {
+        init.headers["Content-Type"] = "application/json";
+        init.body = JSON.stringify(body);
+    }
+    return new Request(BASE, init);
+}
+
+const DB_OK = {
+    prepare() {
+        return {
+            bind: () => ({ first: async () => null, run: async () => ({ meta: {} }) }),
+            first: async () => null,
+            run: async () => ({ meta: {} }),
+        };
+    },
+};
+
+test("toggles GET: lists every KILL_SWITCH with killed:false when KV empty", async () => {
+    const kv = mkKV();
+    const r = await togglesGet({ env: { DB: DB_OK, RATE_KV: kv, ADMIN_TOKEN: "adm" }, request: auth() });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.toggles.length, KILL_SWITCHES.length);
+    for (const t of j.toggles) {
+        assert.equal(t.killed, false);
+        assert.ok(KILL_SWITCHES.includes(t.name));
+    }
+});
+
+test("toggles GET: kill:register set in KV → that toggle reports killed:true", async () => {
+    const kv = mkKV({ "kill:register": "1" });
+    const r = await togglesGet({ env: { DB: DB_OK, RATE_KV: kv, ADMIN_TOKEN: "adm" }, request: auth() });
+    const j = await r.json();
+    const reg = j.toggles.find(t => t.name === "register");
+    assert.equal(reg.killed, true);
+    const recover = j.toggles.find(t => t.name === "recover");
+    assert.equal(recover.killed, false);
+});
+
+test("toggles POST: sets kill:<name>=1 when killed:true", async () => {
+    const kv = mkKV();
+    const r = await togglePost({
+        env: { DB: DB_OK, RATE_KV: kv, ADMIN_TOKEN: "adm" },
+        request: auth({ name: "preflight", killed: true }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.killed, true);
+    assert.equal(kv._snapshot()["kill:preflight"], "1");
+});
+
+test("toggles POST: deletes kill:<name> when killed:false", async () => {
+    const kv = mkKV({ "kill:register": "1" });
+    const r = await togglePost({
+        env: { DB: DB_OK, RATE_KV: kv, ADMIN_TOKEN: "adm" },
+        request: auth({ name: "register", killed: false }),
+    });
+    assert.equal(r.status, 200);
+    assert.equal(kv._snapshot()["kill:register"], undefined);
+});
+
+test("toggles POST: unknown switch name → 400", async () => {
+    const kv = mkKV();
+    const r = await togglePost({
+        env: { DB: DB_OK, RATE_KV: kv, ADMIN_TOKEN: "adm" },
+        request: auth({ name: "nuke_everything", killed: true }),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "unknown_switch");
+    assert.deepEqual(j.known, KILL_SWITCHES);
+});
+
+test("toggles POST: unauthorized without bearer → 401", async () => {
+    const kv = mkKV();
+    const r = await togglePost({
+        env: { DB: DB_OK, RATE_KV: kv, ADMIN_TOKEN: "adm" },
+        request: new Request(BASE, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ name: "register", killed: true }),
+        }),
+    });
+    assert.equal(r.status, 401);
+});

--- a/pages/functions/api/onboarding.test.mjs
+++ b/pages/functions/api/onboarding.test.mjs
@@ -74,6 +74,33 @@ const BASE = "https://sc-cpe-web.pages.dev";
 
 // ── register.js ───────────────────────────────────────────────────────────
 
+test("register: kill switch set → 503", async () => {
+    const killedKv = { get: async (k) => k === "kill:register" ? "1" : null, put: async () => {} };
+    const r = await registerPost({
+        env: { DB: mockDB([]), RATE_KV: killedKv },
+        request: new Request(`${BASE}/api/register`, {
+            method: "POST",
+            body: JSON.stringify({ email: "a@example.com", legal_name: "A B",
+                legal_name_attested: true, age_attested_13plus: true }),
+        }),
+    });
+    assert.equal(r.status, 503);
+    const j = await r.json();
+    assert.equal(j.error, "service_temporarily_unavailable");
+});
+
+test("recover: kill switch set → 503", async () => {
+    const killedKv = { get: async (k) => k === "kill:recover" ? "1" : null, put: async () => {} };
+    const r = await recoverPost({
+        env: { DB: mockDB([]), RATE_KV: killedKv },
+        request: new Request(`${BASE}/api/recover`, {
+            method: "POST", headers: { Origin: BASE },
+            body: JSON.stringify({ email: "a@example.com" }),
+        }),
+    });
+    assert.equal(r.status, 503);
+});
+
 test("register: invalid email returns 400", async () => {
     const r = await registerPost({
         env: { DB: mockDB([]), RATE_KV: kvPermissive },
@@ -176,7 +203,12 @@ test("register: new user → 200 must NOT leak dashboard_token or verification_c
 test("register: rate limit trips when KV reports 10 prior hits this hour", async () => {
     // Defence-in-depth past Turnstile: a solver farm at 10+ Turnstiles/IP/hour
     // gets rate-limited here and stops piling rows into email_outbox + D1.
-    const kvAtLimit = { get: async () => "10", put: async () => {} };
+    // Kill-switch key must return null (not "10") or we'd 503 before reaching
+    // the rate-limit branch — that's what exercises a different code path.
+    const kvAtLimit = {
+        get: async (k) => k.startsWith("kill:") ? null : "10",
+        put: async () => {},
+    };
     const r = await registerPost({
         env: { DB: mockDB([]), RATE_KV: kvAtLimit },
         request: new Request(`${BASE}/api/register`, {

--- a/pages/functions/api/preflight/channel.js
+++ b/pages/functions/api/preflight/channel.js
@@ -1,4 +1,7 @@
-import { json, clientIp, ipHash, rateLimit } from "../../_lib.js";
+import {
+    json, clientIp, ipHash, rateLimit,
+    killSwitched, killedResponse,
+} from "../../_lib.js";
 
 // GET /api/preflight/channel?q=<channel-id-or-url>
 //
@@ -58,6 +61,8 @@ const PROBES_PER_IP_PER_HOUR = 20;
 const PROBES_PER_CHANNEL_PER_DAY = 10;
 
 export async function onRequestGet({ request, env }) {
+    if (await killSwitched(env, "preflight")) return killedResponse();
+
     const ipH = await ipHash(clientIp(request));
     const rlIp = await rateLimit(env, `preflight_channel_ip:${ipH}`, PROBES_PER_IP_PER_HOUR);
     if (!rlIp.ok) return json(rlIp.body, rlIp.status);

--- a/pages/functions/api/preflight/channel.test.mjs
+++ b/pages/functions/api/preflight/channel.test.mjs
@@ -51,8 +51,12 @@ test("preflight: channel id that is bound → {available:false}", async () => {
 
 test("preflight: IP cap (20/hr) trips on the 21st probe from same hashed IP", async () => {
     // KV returns "20" for the IP key — meaning 20 prior successful probes.
+    // kill-switch key must be null so we hit the IP-cap branch, not 503.
     const kv = {
-        get: async (k) => k.startsWith("preflight_channel_ip:") ? "20" : null,
+        get: async (k) => {
+            if (k.startsWith("kill:")) return null;
+            return k.startsWith("preflight_channel_ip:") ? "20" : null;
+        },
         put: async () => {},
     };
     const r = await preflightGet({
@@ -70,6 +74,7 @@ test("preflight: per-channel cap (10/day) trips regardless of IP", async () => {
     // is low.
     const kv = {
         get: async (k) => {
+            if (k.startsWith("kill:")) return null;
             if (k.startsWith("preflight_channel_ip:")) return "0";
             if (k.startsWith("preflight_channel_ch:")) return "10";
             return null;
@@ -85,8 +90,11 @@ test("preflight: per-channel cap (10/day) trips regardless of IP", async () => {
 
 test("preflight: malformed input returns 400 BEFORE touching per-channel cap", async () => {
     const puts = [];
+    // get() returns "0" for counter keys, null for kill-switch keys. "0" is
+    // truthy as a string in JS — if kill-switch keys returned "0" the
+    // killSwitched() check would false-positive and we'd 503 instead of 400.
     const kv = {
-        get: async () => "0",
+        get: async (k) => k.startsWith("kill:") ? null : "0",
         put: async (k) => { puts.push(k); },
     };
     const r = await preflightGet({
@@ -99,6 +107,18 @@ test("preflight: malformed input returns 400 BEFORE touching per-channel cap", a
     // non-existent channel ids.
     assert.equal(puts.some(k => k.startsWith("preflight_channel_ch:")), false,
         "per-channel KV write must not happen when input is malformed");
+});
+
+test("preflight: kill switch set → 503 with admin_kill_switch reason", async () => {
+    const killed = { get: async (k) => k === "kill:preflight" ? "1" : null, put: async () => {} };
+    const r = await preflightGet({
+        env: { DB: DB_EMPTY, RATE_KV: killed },
+        request: req(`${BASE}?q=${CHANNEL}`),
+    });
+    assert.equal(r.status, 503);
+    const j = await r.json();
+    assert.equal(j.error, "service_temporarily_unavailable");
+    assert.equal(j.reason, "admin_kill_switch");
 });
 
 test("preflight: missing RATE_KV → 503 (fail-closed)", async () => {

--- a/pages/functions/api/recover.js
+++ b/pages/functions/api/recover.js
@@ -1,7 +1,7 @@
 import {
     ulid, json, now, audit, clientIp, ipHash,
     isValidEmail, verifyTurnstile, escapeHtml, emailShell, rateLimit,
-    sha256Hex,
+    sha256Hex, killSwitched, killedResponse,
 } from "../_lib.js";
 
 const SITE_BASE = "https://sc-cpe-web.pages.dev";
@@ -61,6 +61,8 @@ const CONSTANT_RESPONSE = {
 };
 
 export async function onRequestPost({ request, env }) {
+    if (await killSwitched(env, "recover")) return killedResponse();
+
     let body;
     try { body = await request.json(); }
     catch { return json({ error: "invalid_json" }, 400); }

--- a/pages/functions/api/register.js
+++ b/pages/functions/api/register.js
@@ -2,6 +2,7 @@ import {
     ulid, randomCode, randomToken, json, now, audit, clientIp, ipHash,
     isValidEmail, isValidName, verifyTurnstile, queueEmail,
     escapeHtml, emailShell, sha256Hex, rateLimit,
+    killSwitched, killedResponse,
 } from "../_lib.js";
 
 // Defence-in-depth against a Turnstile-solver farm. Turnstile is the first
@@ -52,6 +53,8 @@ this email — the account stays inactive unless the code is used in chat.</p>`;
 }
 
 export async function onRequestPost({ request, env }) {
+    if (await killSwitched(env, "register")) return killedResponse();
+
     let body;
     try { body = await request.json(); }
     catch { return json({ error: "invalid_json" }, 400); }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,6 +10,7 @@ node --test \
     pages/functions/api/onboarding.test.mjs \
     pages/functions/api/health.test.mjs \
     pages/functions/api/admin/ops-stats.test.mjs \
+    pages/functions/api/admin/toggles.test.mjs \
     pages/functions/api/preflight/channel.test.mjs \
     workers/poller/src/race-detection.test.mjs \
     workers/purge/src/heartbeat-staleness.test.mjs \


### PR DESCRIPTION
When launch-day traffic surfaces abuse on one specific endpoint (someone
scripting signups past Turnstile, a preflight-sweep bot, a recovery
spammer), we need a way to take THAT endpoint offline for minutes or
hours without nuking the whole service. Codex P1 #13.

Kill switches (KV-backed, no TTL so operator must explicitly re-enable):

- `kill:register`  → POST /api/register returns 503
- `kill:recover`   → POST /api/recover returns 503
- `kill:preflight` → GET /api/preflight/channel returns 503

Critical-path endpoints are deliberately NOT killable:
- /api/health, /api/verify/*, /api/download/*           (public reads)
- /api/me/{token}, /api/me/{token}/delete, rotate, prefs, etc.
  (a user locked out by a misconfigured kill should still be able to
  access their own data and rotate/delete their account)
- /api/admin/*                                          (never self-lock)

New endpoints:
- GET  /api/admin/toggles             lists each switch + state
- POST /api/admin/toggles { name, killed }   set/clear

Admin dashboard gains a "Kill switches" card with per-switch buttons,
hot-colored when killed, and re-loads on change. Audit row written per
toggle (admin attribution, kill_switch entity type).

Helpers added to _lib.js:
- `KILL_SWITCHES` — canonical list (single source of truth; admin
  endpoint + endpoint checks import from here so a typo can't silently
  disable protection)
- `killSwitched(env, name)` — fails SAFE if KV is unbound (returns
  false; endpoint serves normally)
- `killedResponse()` — standardised 503 body

Tests: 2 new onboarding kill-switch cases (register, recover), 1 new
preflight case, 6 new admin/toggles cases (list, set, clear, unknown
name, unauthorized, kv-empty baseline). Also patched two existing
tests that used the wildcard KV mock `get: async () => "N"` — with
"0"/"10" interpreted as truthy for kill keys, those tests would have
hit the kill branch instead of the behaviour they were pinning. 122/122.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
