### PR TITLE
feat(ops): budget + health warnings in ops-stats (codex P1 #16)

### DIFF
--- a/pages/admin.html
+++ b/pages/admin.html
@@ -46,6 +46,7 @@
     <button class="refresh" id="refresh">Refresh</button>
     <span class="muted" id="ts" style="margin-left:10px;font-size:12px;"></span>
     <div id="err"></div>
+    <div id="warnings" style="display:flex;flex-direction:column;gap:6px;margin:10px 0;"></div>
 
     <div class="section-h">Overview (last 24h)</div>
     <div class="grid" id="stats"></div>
@@ -105,6 +106,7 @@ async function load() {
       fetchJson("/api/admin/cert-feedback?rating=typo,wrong&limit=100"),
       fetchJson("/api/admin/toggles"),
     ]);
+    renderWarnings(stats);
     renderStats(stats);
     renderToggles(toggles);
     renderHeartbeats(hb);
@@ -117,6 +119,19 @@ async function load() {
       $("#app").style.display = "none";
       $("#login").style.display = "";
     }
+  }
+}
+function renderWarnings(s) {
+  const box = $("#warnings"); box.innerHTML = "";
+  for (const w of (s.warnings || [])) {
+    const row = document.createElement("div");
+    const isCritical = w.level === "critical";
+    row.style.cssText = `padding:8px 14px;border-radius:4px;font-size:13px;border:1px solid;` +
+      (isCritical
+        ? "background:#3a1818;border-color:#6b2a2a;color:#ffb4b4;"
+        : "background:#3a2f18;border-color:#6b5a2a;color:#ffe4a4;");
+    row.innerHTML = `<strong>${isCritical ? "CRITICAL" : "warn"}</strong> · <code style="font-size:11px;">${w.code}</code> — ${w.detail}`;
+    box.appendChild(row);
   }
 }
 function renderToggles(d) {

--- a/pages/functions/api/admin/ops-stats.js
+++ b/pages/functions/api/admin/ops-stats.js
@@ -51,7 +51,7 @@ export async function onRequestGet({ request, env }) {
         "SELECT COUNT(*) AS n FROM users WHERE deleted_at IS NULL AND (email LIKE '%@example.com' OR email LIKE '%@example.org' OR email LIKE '%@test.invalid')",
     ).first();
 
-    return json({
+    const payload = {
         ok: true,
         now: new Date().toISOString(),
         since_24h: since24h,
@@ -88,5 +88,85 @@ export async function onRequestGet({ request, env }) {
             attendance: fixtureAttendance?.n ?? 0,
             users: fixtureUsers?.n ?? 0,
         },
-    });
+    };
+    payload.warnings = computeWarnings(payload);
+    return json(payload);
+}
+
+// Launch-day budget + health warnings. Pure function so the admin
+// dashboard and any future external monitor can render from the same
+// source. Each warning is {level: "warn"|"critical", code, detail}.
+//
+// Thresholds are tuned for the free-tier infrastructure (Resend 3k/day,
+// Cloudflare D1 free limits). Update the constants if we upgrade a tier.
+export function computeWarnings(s) {
+    const w = [];
+    const push = (level, code, detail) => w.push({ level, code, detail });
+
+    // Resend free tier: 3000 emails/day. Warn at 80%, critical at 95%.
+    const RESEND_DAILY_QUOTA = 3000;
+    const sent = s.email_outbox.sent_24h;
+    if (sent >= RESEND_DAILY_QUOTA * 0.95) {
+        push("critical", "resend_quota_95pct",
+            `${sent}/${RESEND_DAILY_QUOTA} Resend emails in last 24h — approaching daily quota`);
+    } else if (sent >= RESEND_DAILY_QUOTA * 0.8) {
+        push("warn", "resend_quota_80pct",
+            `${sent}/${RESEND_DAILY_QUOTA} Resend emails in last 24h`);
+    }
+
+    // Queue age > 10min = email-sender looks stalled (runs every 2min).
+    const qAge = s.email_outbox.oldest_queued_age_seconds;
+    if (qAge != null && qAge > 1800) {
+        push("critical", "email_queue_stalled",
+            `Oldest queued email is ${Math.floor(qAge / 60)} min old — email-sender may be down`);
+    } else if (qAge != null && qAge > 600) {
+        push("warn", "email_queue_aging",
+            `Oldest queued email is ${Math.floor(qAge / 60)} min old`);
+    }
+
+    // Queue depth warnings (sender drains ~750/hour — burst above this floods).
+    if (s.email_outbox.queued > 500) {
+        push("critical", "email_queue_deep",
+            `${s.email_outbox.queued} queued — exceeds single-hour drain capacity`);
+    } else if (s.email_outbox.queued > 100) {
+        push("warn", "email_queue_elevated", `${s.email_outbox.queued} queued`);
+    }
+
+    // Any permanently-failed email is worth noticing.
+    if (s.email_outbox.failed > 0) {
+        push("warn", "email_failures",
+            `${s.email_outbox.failed} email(s) in 'failed' state — non-transient delivery errors`);
+    }
+
+    // Pending certs: cron runs every 2h. > 4h old = cron stalled.
+    const cpAge = s.certs.oldest_pending_age_seconds;
+    if (cpAge != null && cpAge > 12 * 3600) {
+        push("critical", "certs_pending_stalled",
+            `Oldest pending cert is ${Math.floor(cpAge / 3600)}h old — cert-sign-pending may be down`);
+    } else if (cpAge != null && cpAge > 4 * 3600) {
+        push("warn", "certs_pending_aging",
+            `Oldest pending cert is ${Math.floor(cpAge / 3600)}h old`);
+    }
+
+    // Signup abuse signal: high pending ratio (signups without verifications).
+    // Only fires past a minimum volume to avoid noisy early-stage warnings.
+    if (s.users.pending > 100 && s.users.active > 0 && s.users.pending > 5 * s.users.active) {
+        push("warn", "signup_abuse_pattern",
+            `${s.users.pending} pending vs ${s.users.active} active — unusually high unverified signup rate`);
+    }
+
+    // Open appeals: anything open > 0 is worth an admin eyeball.
+    if (s.appeals_open > 0) {
+        push("warn", "appeals_open",
+            `${s.appeals_open} open appeal(s) awaiting admin review`);
+    }
+
+    // Fixture pollution in prod — test data leaked into production DB.
+    const fp = s.fixture_pollution;
+    if (fp.streams + fp.attendance + fp.users > 0) {
+        push("warn", "fixture_pollution",
+            `Test fixtures detected in DB: ${fp.streams} streams, ${fp.attendance} attendance, ${fp.users} users`);
+    }
+
+    return w;
 }

--- a/pages/functions/api/admin/ops-stats.test.mjs
+++ b/pages/functions/api/admin/ops-stats.test.mjs
@@ -7,7 +7,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { onRequestGet as opsStatsGet } from "./ops-stats.js";
+import { onRequestGet as opsStatsGet, computeWarnings } from "./ops-stats.js";
 
 const BASE = "https://sc-cpe-web.pages.dev";
 
@@ -115,6 +115,78 @@ test("ops-stats: pending certs — oldest_pending_age_seconds surfaces cron-stuc
     const age = j.certs.oldest_pending_age_seconds;
     assert.ok(age >= 6 * 3600 - 30 && age <= 6 * 3600 + 30, `expected ~21600s, got ${age}`);
 });
+
+// ── computeWarnings (pure) ──────────────────────────────────────────────
+
+function baseStats(overrides = {}) {
+    return {
+        users: { total: 42, active: 30, pending: 2, ...overrides.users },
+        last_24h: { attendance: 17, certs_issued: 4, ...overrides.last_24h },
+        certs_total: 20,
+        appeals_open: 0,
+        email_outbox: {
+            queued: 0, failed: 0, sent_24h: 100,
+            oldest_queued_age_seconds: null, oldest_failed_age_seconds: null,
+            ...overrides.email_outbox,
+        },
+        certs: { pending: 0, oldest_pending_age_seconds: null, ...overrides.certs },
+        fixture_pollution: { streams: 0, attendance: 0, users: 0, ...overrides.fixture_pollution },
+        ...overrides,
+    };
+}
+
+test("computeWarnings: clean state → no warnings", () => {
+    const w = computeWarnings(baseStats());
+    assert.equal(w.length, 0);
+});
+
+test("computeWarnings: Resend quota 80% → warn, 95% → critical", () => {
+    const warnSet = computeWarnings(baseStats({ email_outbox: { sent_24h: 2500 } }));
+    assert.equal(warnSet.find(x => x.code === "resend_quota_80pct")?.level, "warn");
+    const critSet = computeWarnings(baseStats({ email_outbox: { sent_24h: 2900 } }));
+    assert.equal(critSet.find(x => x.code === "resend_quota_95pct")?.level, "critical");
+});
+
+test("computeWarnings: oldest queued > 10min warns, > 30min critical", () => {
+    const warn = computeWarnings(baseStats({ email_outbox: { oldest_queued_age_seconds: 700 } }));
+    assert.equal(warn.find(x => x.code === "email_queue_aging")?.level, "warn");
+    const crit = computeWarnings(baseStats({ email_outbox: { oldest_queued_age_seconds: 2000 } }));
+    assert.equal(crit.find(x => x.code === "email_queue_stalled")?.level, "critical");
+});
+
+test("computeWarnings: queued > 100 warns, > 500 critical", () => {
+    const warn = computeWarnings(baseStats({ email_outbox: { queued: 150 } }));
+    assert.equal(warn.find(x => x.code === "email_queue_elevated")?.level, "warn");
+    const crit = computeWarnings(baseStats({ email_outbox: { queued: 600 } }));
+    assert.equal(crit.find(x => x.code === "email_queue_deep")?.level, "critical");
+});
+
+test("computeWarnings: any failed email triggers warn", () => {
+    const w = computeWarnings(baseStats({ email_outbox: { failed: 1 } }));
+    assert.equal(w.find(x => x.code === "email_failures")?.level, "warn");
+});
+
+test("computeWarnings: pending cert > 4h warns, > 12h critical", () => {
+    const warn = computeWarnings(baseStats({ certs: { oldest_pending_age_seconds: 5 * 3600 } }));
+    assert.equal(warn.find(x => x.code === "certs_pending_aging")?.level, "warn");
+    const crit = computeWarnings(baseStats({ certs: { oldest_pending_age_seconds: 13 * 3600 } }));
+    assert.equal(crit.find(x => x.code === "certs_pending_stalled")?.level, "critical");
+});
+
+test("computeWarnings: signup abuse — >100 pending and pending > 5× active", () => {
+    const w = computeWarnings(baseStats({ users: { total: 200, active: 15, pending: 150 } }));
+    assert.equal(w.find(x => x.code === "signup_abuse_pattern")?.level, "warn");
+    // Below threshold — low volume should NOT fire
+    const none = computeWarnings(baseStats({ users: { total: 50, active: 5, pending: 40 } }));
+    assert.equal(none.find(x => x.code === "signup_abuse_pattern"), undefined);
+});
+
+test("computeWarnings: fixture pollution in prod triggers warn", () => {
+    const w = computeWarnings(baseStats({ fixture_pollution: { streams: 2, attendance: 0, users: 0 } }));
+    assert.equal(w.find(x => x.code === "fixture_pollution")?.level, "warn");
+});
+
+// ── ops-stats response integration ──────────────────────────────────────
 
 test("ops-stats: unauthorized (wrong bearer) → 401", async () => {
     const r = await opsStatsGet({


### PR DESCRIPTION
Launch-day without explicit thresholds means counts are visible but their
meaning isn't. "120 emails queued" is fine if we just started; it's an
outage if it's been that way for 30 minutes. "2700 Resend sent in 24h"
is fine; "2950" is burning down the free tier.

ops-stats now returns a `warnings` array, each entry:
  {level: "warn"|"critical", code: string, detail: string}

Conditions encoded (pure function `computeWarnings`, exported for test
reuse):
  - resend_quota_80pct / 95pct      (Resend free tier = 3000/day)
  - email_queue_aging / _stalled    (> 10min / > 30min oldest queued)
  - email_queue_elevated / _deep    (> 100 / > 500 rows)
  - email_failures                  (any row in 'failed')
  - certs_pending_aging / _stalled  (> 4h / > 12h oldest pending)
  - signup_abuse_pattern            (> 100 pending AND > 5× active,
                                     floor of 100 to avoid early-stage
                                     false positives)
  - appeals_open                    (anything > 0)
  - fixture_pollution               (test fixtures leaked into prod DB)

Admin dashboard renders them as a coloured banner above the overview
cards — warn (amber) and critical (red) visually distinct.

Tests: 9 new computeWarnings cases covering each code + a clean-state
baseline. 130/130 green.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
