### PR TITLE
feat(ops): public status page + incident-comms playbook (codex P1 #18)

### DIFF
--- a/docs/INCIDENT_COMMS.md
+++ b/docs/INCIDENT_COMMS.md
@@ -1,0 +1,124 @@
+# Incident communications playbook
+
+Short, opinionated, actionable. Use during any user-visible outage or
+security event. If you're following this playbook you're already past the
+"is this a real incident" bar — act fast.
+
+## Decision tree
+
+1. **Something looks broken in production.**
+   - First: reload `/api/health` and `/status.html`. Confirm the signal is real.
+   - Check `/api/admin/ops-stats.warnings` on the admin dashboard.
+   - If you got a Discord alert, the timestamp there is your incident start.
+2. **Is user data or cert integrity at risk?** (exposed PII, forged or
+   revoked certs passing verify, audit chain fork)
+   - Treat as P0. Kill the relevant public endpoint via the admin
+     dashboard's kill-switch panel (`register`, `recover`, `preflight`)
+     — buys you time.
+   - Then follow the full comms cycle below.
+3. **Is the service degraded but intact?** (email backlog, poller stale,
+   cert-sign-pending slow)
+   - Treat as P1. Short Discord ping only; no public status-page note
+     needed unless it exceeds the user-visible SLA (see §2).
+
+## User-visible SLAs (for scoring severity)
+
+| Surface | User-visible SLA | Source of truth |
+| --- | --- | --- |
+| Registration email | within 5 min | `/api/admin/ops-stats.email_outbox.oldest_queued_age_seconds` |
+| Recovery email | within 5 min | same |
+| Monthly cert delivery | within 48h of month-end cron | `/api/admin/ops-stats.certs.oldest_pending_age_seconds` |
+| Per-session cert delivery | within 2h of request | same |
+| Live-attendance credit | within 60s of chat post | poller heartbeat + user dashboard |
+| Cert verification portal | always on | `/api/health.sources[source=poller,canary]` |
+
+A cert-verification outage is P0 *regardless* of scale — relying parties
+need that endpoint more than users do. Kill-switches do not apply to verify
+or download; those stay on.
+
+## Comms cycle (P0 / P1)
+
+### T + 0 to 5 min
+
+1. Post in Discord ops channel. Template:
+   ```
+   :rotating_light: SC-CPE P0 — <one-line summary>
+   Started: <UTC timestamp>
+   Impact: <who / what breaks>
+   I'm investigating. Next update in 15 min.
+   ```
+2. If any public endpoint is killed: note which, so colleagues know the
+   503s are deliberate.
+
+### T + 15 min
+
+- Update Discord. Keep it factual: what you've found, what you've tried,
+  what's next.
+- If duration > 15 min AND verify-portal-impacting: post a pinned GitHub
+  issue with the `incident` label. Link it in Discord.
+- Template for the GitHub issue:
+  ```
+  Title: [P0 incident] <summary>
+  Body: started <ts>; impact <desc>; current status <what's tried>;
+        ETA <best guess>. Will update this issue until resolved.
+  ```
+
+### During mitigation
+
+- Every state change deserves a Discord line: "attempted X, result Y".
+- If you kill-switch an endpoint, say so in Discord and on the GitHub
+  issue. If you un-kill, say that too. No silent toggles during an
+  incident.
+
+### At resolution
+
+- Discord: "Resolved at <ts>. Root cause: <one line>. User impact: <one
+  line>. Post-mortem: <link to issue>."
+- Close the GitHub issue with a short post-mortem comment (what, why,
+  what we'll do differently).
+- Remove any pinned status.html badge you added (when the status page
+  grows one).
+- Update `/api/admin/ops-stats.warnings` code list if a new class of
+  warning would have caught this sooner.
+
+## Pre-written templates
+
+### Registration / recovery outage (users can't sign up or recover)
+```
+SC-CPE registration/recovery is temporarily unavailable due to a
+service issue. Existing accounts and certificates are unaffected —
+you can still log in with your dashboard URL and your existing
+certificates remain valid and verifiable. We'll post here when it's
+back.
+```
+
+### Mass email delay
+```
+Certificate / recovery emails are queued but delayed. We're working
+on delivery. No emails will be lost — they're durably queued and
+will send as soon as the delay clears.
+```
+
+### Verify portal issue
+```
+The public certificate verification portal is experiencing issues.
+Auditors can still verify certificates manually by comparing the
+SHA-256 printed on the cert against their own copy. We're treating
+this as our highest-priority issue. Next update in 15 min.
+```
+
+### Audit-chain integrity alert
+```
+We detected a potential discrepancy in the certificate audit chain.
+Out of an abundance of caution we've paused new certificate issuance
+while we investigate. Previously issued certificates are unaffected
+and remain verifiable. No user action required.
+```
+
+## After any P0
+
+Within 48 hours, open a follow-up issue:
+- Five whys analysis.
+- One concrete code or process change that would have prevented the
+  incident or caught it sooner.
+- Wire the change into the next sprint — don't leave it in limbo.

--- a/pages/status.html
+++ b/pages/status.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>SC-CPE — Status</title>
+<link rel="stylesheet" href="/style.css">
+<style>
+  .status-hero { padding: 18px 24px; border-radius: 6px; margin: 12px 0 20px; font-weight: 600; }
+  .status-hero.ok { background: #0e3a1a; border: 1px solid #1e6b3a; color: #9beab2; }
+  .status-hero.stale { background: #3a1818; border: 1px solid #6b2a2a; color: #ffb4b4; }
+  .status-hero.loading { background: #1e2833; border: 1px solid #2a3644; color: #95a4b3; }
+  .src-row { display: flex; align-items: center; gap: 14px; padding: 10px 14px; border: 1px solid #ddd; border-radius: 4px; margin-bottom: 6px; }
+  .src-row.stale { background: #fff3f3; border-color: #e0b4b4; }
+  .src-name { font-family: monospace; font-weight: 600; width: 180px; }
+  .src-badge { font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; padding: 3px 8px; border-radius: 10px; }
+  .src-badge.ok { background: #dbf4e4; color: #0a6c2a; }
+  .src-badge.stale { background: #fbd4d4; color: #a7161a; }
+  .src-badge.offduty { background: #e8e8e8; color: #555; }
+  .src-meta { color: #6b7a8a; font-size: 12px; margin-left: auto; font-family: monospace; }
+  .foot { color: #888; font-size: 12px; margin-top: 24px; }
+</style>
+</head>
+<body>
+<main class="narrow">
+  <h1>SC-CPE — Service Status</h1>
+  <p class="lead">Automated. Polled every 30 seconds from <code>/api/health</code>. If something below is red, the relevant cron or worker is not beating within its expected cadence.</p>
+
+  <div id="hero" class="status-hero loading">checking…</div>
+
+  <h2>Components</h2>
+  <div id="sources"></div>
+
+  <p class="foot" id="foot"></p>
+  <p class="foot">For longer-form incident updates, see the <a href="https://github.com/ericrihm/sc-cpe/issues?q=label%3Aincident">incidents label</a> on the SC-CPE repo. For ongoing issues that affect your account, contact <a href="mailto:contact@signalplane.co">contact@signalplane.co</a>.</p>
+  <p><a href="/">&larr; Back</a></p>
+</main>
+<script>
+const FRIENDLY = {
+  poller: {
+    label: "YouTube chat poller",
+    help: "Credits attendance while the Daily Threat Briefing is live. Only on duty ET Mon–Fri 08:00–11:00.",
+  },
+  purge: {
+    label: "Daily chat purge",
+    help: "Cleans raw chat logs from R2. Runs once a day.",
+  },
+  email_sender: {
+    label: "Email delivery",
+    help: "Drains registration, recovery, and monthly certificate emails. Runs every 2 minutes.",
+  },
+  security_alerts: {
+    label: "Security alerts digest",
+    help: "Scans the audit log daily for anything suspicious. Piggybacks on the purge cron.",
+  },
+  canary: {
+    label: "Hourly canary",
+    help: "External synthetic smoke from GitHub Actions. Beats every hour.",
+  },
+};
+function fmtAge(s) {
+  if (s == null) return "—";
+  if (s < 60) return s + "s";
+  if (s < 3600) return Math.floor(s/60) + "m " + (s%60) + "s";
+  return Math.floor(s/3600) + "h " + Math.floor((s%3600)/60) + "m";
+}
+async function refresh() {
+  const hero = document.getElementById("hero");
+  try {
+    const r = await fetch("/api/health", { cache: "no-store" });
+    const d = await r.json();
+    hero.className = "status-hero " + (d.any_stale ? "stale" : "ok");
+    hero.textContent = d.any_stale
+      ? "Some components are stale — see below"
+      : "All systems operational";
+    const box = document.getElementById("sources"); box.innerHTML = "";
+    for (const s of d.sources) {
+      const row = document.createElement("div");
+      row.className = "src-row" + (s.stale ? " stale" : "");
+      const fri = FRIENDLY[s.source] || { label: s.source, help: "" };
+      const badgeCls = !s.expected ? "offduty" : s.stale ? "stale" : "ok";
+      const badgeText = !s.expected ? "off duty" : s.stale ? "stale" : "ok";
+      row.innerHTML =
+        `<div class="src-name">${fri.label}</div>` +
+        `<span class="src-badge ${badgeCls}">${badgeText}</span>` +
+        `<div style="flex:1;font-size:12px;color:#555;">${fri.help}</div>` +
+        `<div class="src-meta">last ${s.last_beat_at ? fmtAge(s.age_seconds) + " ago" : "never"}</div>`;
+      box.appendChild(row);
+    }
+    document.getElementById("foot").textContent =
+      "Last checked " + new Date(d.now).toLocaleString() +
+      " · poll window active: " + (d.poll_window_active ? "yes" : "no");
+  } catch (e) {
+    hero.className = "status-hero stale";
+    hero.textContent = "Could not fetch status — the status endpoint itself may be down.";
+    document.getElementById("foot").textContent = "Error: " + (e && e.message || e);
+  }
+}
+refresh();
+setInterval(refresh, 30_000);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Silent outages are worse than loud ones for a security-community service:
users default to assuming compromise when they see nothing. Two pieces:

1. /status.html — public, no auth, auto-refreshes every 30s from
   /api/health. Renders each cron source (poller / purge / email_sender /
   security_alerts / canary) with plain-English labels and help text,
   colour-codes stale vs ok vs off-duty, and shows last-beat age.
   Users (and auditors) can link to it when they wonder whether the
   thing they're looking at is broken or they are.

2. docs/INCIDENT_COMMS.md — short opinionated playbook.
   - Severity scoring (is user data/cert integrity at risk → P0; else P1).
   - User-visible SLA table (reg/recovery email 5min, monthly cert 48h,
     per-session 2h, live credit 60s, verify portal always-on).
   - T+0 / T+15 / during / resolution comms cycle with exact Discord
     templates.
   - Pre-written outage templates for the common cases (registration
     down, email delay, verify issue, audit-chain alert).
   - 48h post-mortem obligation.

No behavioural changes; docs + one new HTML page. 130/130 tests still
green.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
