### PR TITLE
docs(launch): LAUNCH_READINESS checklist + nav links to faq/status/security.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ the skeptical (which is most of this community, appropriately):
   [security.txt](https://sc-cpe-web.pages.dev/.well-known/security.txt)
   or email `security@signalplane.co` directly. 3‑day acknowledgement,
   7‑day triage, 30‑day fix plan for P0/P1 findings.
+- **Live service health.** [`/status.html`](https://sc-cpe-web.pages.dev/status.html)
+  auto‑refreshes every 30s from `/api/health` and shows per‑cron
+  staleness in plain English; [`/faq.html`](https://sc-cpe-web.pages.dev/faq.html)
+  covers the common operational questions (missing credits, email
+  delays, verification for CE‑portal auditors).
 
 ---
 

--- a/docs/LAUNCH_READINESS.md
+++ b/docs/LAUNCH_READINESS.md
@@ -1,0 +1,97 @@
+# Launch readiness checklist
+
+Durable checklist of the launch-prep work that can't be done as a code
+change — the things that require operator action, physical infrastructure,
+or deliberate human process. Track-and-check. Each item has an owner
+(just `eric` today), a due-window, and a concrete verification step.
+
+## P0 — blocks public announcement
+
+- [ ] **DMARC DNS record on `signalplane.co`** — starting policy
+      `v=DMARC1; p=quarantine; rua=mailto:dmarc-reports@signalplane.co; adkim=s; aspf=s; fo=1`.
+      Verify with `dig TXT _dmarc.signalplane.co +short`. After ~2
+      weeks of clean `rua` reports, tighten to `p=reject`.
+
+- [ ] **Discord alert webhook live** — create in the SC ops Discord,
+      push as repo secret `DISCORD_ALERT_WEBHOOK`. Fire `gh workflow
+      run watchdog.yml -R ericrihm/sc-cpe` and confirm the alert lands.
+
+- [ ] **Monitored inboxes** — `contact@`, `privacy@`, `security@`
+      all at `signalplane.co`, forwarding to an address you actively
+      watch. Simplest path: Cloudflare Email Routing on
+      `signalplane.co`. Send a test to each, confirm arrival.
+
+- [ ] **Wrangler rollback rehearsal on `email-sender`** — pick a
+      quiet weekday outside 08:00–11:00 ET. Run
+      `cd workers/email-sender && wrangler rollback` interactively,
+      time the round-trip, re-deploy. Goal: < 90 s end-to-end.
+      See `docs/RUNBOOK.md#rollback` for the full commands.
+
+## P1 — first-week operator tasks
+
+- [ ] **Dry-run monthly cert issuance at realistic volume** — fire
+      `monthly-certs.yml` via `workflow_dispatch` with a synthetic
+      period. Observe signing throughput, TSA behaviour, Resend
+      delivery rate. Expected first live run: start of next calendar
+      month, so the dry-run confirms we won't discover a regression
+      on prod month-end.
+
+- [ ] **Accessibility pass** — manual, 20 minutes per page. The four
+      public pages: register (`/`), recover (`/recover.html`), dashboard
+      (`/dashboard.html?t=...`), verify (`/verify.html`).
+      Test matrix:
+      - Mobile Safari + Chrome Android (smallest sensible width).
+      - Keyboard-only (Tab / Shift-Tab / Space / Enter through every
+        interactive element).
+      - VoiceOver or TalkBack: labels readable, landmark nav works.
+      Fix anything broken before announcement.
+
+- [ ] **Explicit SLOs document** — file a docs/SLO.md with targeted
+      monthly numbers. Starting proposals (based on the SLAs already
+      in `docs/INCIDENT_COMMS.md`):
+      - Registration email delivery: 99 % within 5 min, 99.9 % within 1 h.
+      - Per-session cert delivery: 99 % within 2 h.
+      - Verify portal availability: 99.9 %.
+      - Attendance credit: 99 % within 60 s of live chat post.
+      Re-check monthly against actuals until the numbers stabilise.
+
+## P2 — launch-month hardening
+
+- [ ] **Poller edge-case tabletop** — 1 h session. Walk through:
+      empty-page response, YouTube quota exhaustion, multiple live
+      videos visible, zero-message finalize, partial R2 purge.
+      Verify the code handles each gracefully. File issues for any
+      gap, prioritise during first post-launch sprint.
+
+- [ ] **Threat model v2** — re-run the initial codex threat model
+      (documented in session brief) 30 days post-launch with real
+      traffic patterns. Look for abuse signatures that didn't exist
+      at launch time. Update rate-limit knobs accordingly.
+
+- [ ] **Preview environment with isolated bindings** — separate D1 +
+      R2 + KV for PR preview deploys so we can enable
+      Cloudflare Pages PR previews without leaking prod state.
+      Precondition: creating a `sc-cpe-preview` D1 + R2 bucket + KV
+      namespace and threading them through `pages/wrangler.toml` as
+      preview-scoped bindings.
+
+## Verification: the "really launched" criteria
+
+Before announcing publicly, confirm all of:
+- [ ] `/status.html` — all five cron sources beating, no stale.
+- [ ] Discord pipeline: a test watchdog run delivered.
+- [ ] Email pipeline: a registration test flow end-to-end (reg → code
+      → post in chat during a live briefing → credit appears → monthly
+      cert arrives).
+- [ ] Verify portal: download a real cert, drag into `/verify.html`,
+      confirm SHA-256 match.
+- [ ] Rollback rehearsed (above).
+- [ ] FAQ, status, privacy, terms all linked from registration page.
+
+Once all boxes are ticked, announcement is safe to fire.
+
+## Owner
+
+`ericrihm@gmail.com` is sole operator today. If that changes, update
+this document AND `docs/RUNBOOK.md#owner` simultaneously — drift
+between the two was the top source of confusion in prior incidents.

--- a/pages/index.html
+++ b/pages/index.html
@@ -49,6 +49,12 @@
     <p class="muted" style="margin-top:2rem;font-size:0.9rem;">
         Lost your dashboard link? <a href="/recover.html">Recover it here</a>.
     </p>
+    <p class="muted" style="font-size:0.85rem;">
+        Questions: <a href="/faq.html">FAQ &amp; known issues</a>
+        · Service health: <a href="/status.html">status</a>
+        · Legal: <a href="/terms.html">terms</a> &amp; <a href="/privacy.html">privacy</a>
+        · Security disclosure: <a href="/.well-known/security.txt">security.txt</a>
+    </p>
 </main>
 <script>
 const ERROR_COPY = {


### PR DESCRIPTION
Two pieces that finish out the P1/P2 rollup:

1. docs/LAUNCH_READINESS.md — durable operator checklist for the
   launch work that can't be code (DMARC DNS, Discord webhook,
   inboxes, rollback rehearsal, monthly-cert dry-run, a11y pass,
   SLO doc, poller tabletop, preview-env with isolated bindings,
   threat model v2 at T+30d). Each item has a concrete verification
   step. Covers P1 #15, #19, P2 #20, #24.

2. Navigation links — the new public pages shipped in the last few
   PRs (status.html, faq.html, security.txt) weren't reachable from
   the registration page or the README. Added a subtle footer on
   index.html and a bullet in the README trust section.

This finishes the codex pre-launch checklist: every item is either
merged (code/docs PRs 2–13), on the operator's plate (LAUNCH_READINESS
checklist), or explicitly deferred (preview env, threat-model v2).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
