### PR TITLE
feat(ops): wire Discord alerts for monthly-certs, cert-sign-pending, and critical ops-stats warnings

### DIFF
--- a/.github/workflows/cert-sign-pending.yml
+++ b/.github/workflows/cert-sign-pending.yml
@@ -68,3 +68,24 @@ jobs:
       - name: Run pending pickup
         working-directory: services/certs
         run: python generate.py --pending-only
+
+  alert-on-failure:
+    name: Discord alert on cert-sign-pending failure
+    needs: pickup
+    if: failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Notify Discord
+        env:
+          DISCORD_ALERT_WEBHOOK: ${{ secrets.DISCORD_ALERT_WEBHOOK }}
+        run: |
+          if [[ -z "${DISCORD_ALERT_WEBHOOK:-}" ]]; then
+            echo "DISCORD_ALERT_WEBHOOK unset — skipping"; exit 0
+          fi
+          payload=$(jq -cn \
+            --arg c ":warning: **SC-CPE cert-sign-pending FAILED** on ${{ github.sha }}. Pending per-session / reissue certs did not drain. See Actions run ${{ github.run_id }}." \
+            '{content: $c, username: "SC-CPE Pending"}')
+          curl -fsS --max-time 20 \
+            -H "Content-Type: application/json" \
+            -X POST -d "$payload" "$DISCORD_ALERT_WEBHOOK" >/dev/null

--- a/.github/workflows/monthly-certs.yml
+++ b/.github/workflows/monthly-certs.yml
@@ -93,3 +93,24 @@ jobs:
         working-directory: services/certs
         run: |
           python generate.py
+
+  alert-on-failure:
+    name: Discord alert on monthly-certs failure
+    needs: generate
+    if: failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Notify Discord
+        env:
+          DISCORD_ALERT_WEBHOOK: ${{ secrets.DISCORD_ALERT_WEBHOOK }}
+        run: |
+          if [[ -z "${DISCORD_ALERT_WEBHOOK:-}" ]]; then
+            echo "DISCORD_ALERT_WEBHOOK unset — skipping"; exit 0
+          fi
+          payload=$(jq -cn \
+            --arg c ":rotating_light: **SC-CPE monthly-certs FAILED** on ${{ github.sha }} (period=${{ github.event.inputs.period_yyyymm || 'auto' }}). Month-end cert issuance did not complete. See Actions run ${{ github.run_id }}." \
+            '{content: $c, username: "SC-CPE Monthly"}')
+          curl -fsS --max-time 20 \
+            -H "Content-Type: application/json" \
+            -X POST -d "$payload" "$DISCORD_ALERT_WEBHOOK" >/dev/null

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -1,13 +1,14 @@
 name: watchdog
 
-# External liveness check. Polls /api/health every 15 minutes and alerts
-# Discord when any monitored source goes stale. Alert dedup state lives in
-# Cloudflare KV (via /api/watchdog-state) so we send one "down" message per
-# stale event and one "recovered" message when it clears — no spam.
-#
-# What counts as stale is computed server-side by /api/health, which is
-# window-aware: a silent poller outside the ET weekday 08:00-11:00 window
-# is not an incident.
+# External liveness + warnings check. Every 15 minutes:
+#   1. Poll /api/health for per-cron staleness.
+#   2. Poll /api/admin/ops-stats for runtime warnings (email queue stalled,
+#      cert-sign-pending stalled, Resend quota near cap, etc — anything
+#      flagged level=critical by computeWarnings() in ops-stats.js).
+# Alert dedup state lives in Cloudflare KV (/api/watchdog-state) so we send
+# one "down" message per event and one "recovered" per clear — no spam.
+# Heartbeat sources and warning codes share the same dedup namespace
+# (warning entries keyed "warn:<code>" to avoid collision).
 
 on:
   schedule:
@@ -30,6 +31,7 @@ jobs:
       HEALTH_URL: ${{ vars.HEALTH_URL }}
       WATCHDOG_STATE_URL: ${{ vars.WATCHDOG_STATE_URL }}
       WATCHDOG_SECRET: ${{ secrets.WATCHDOG_SECRET }}
+      ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
       DISCORD_ALERT_WEBHOOK: ${{ secrets.DISCORD_ALERT_WEBHOOK }}
     steps:
       - name: Check liveness and alert on transitions
@@ -90,5 +92,57 @@ jobs:
 
             else
               echo "$source: stale=$stale alerted=${already_alerted:-none} (no change)"
+            fi
+          done
+
+          # ── ops-stats warnings ────────────────────────────────────────
+          # Poll the admin ops-stats endpoint for level=critical runtime
+          # warnings (email_queue_stalled, certs_pending_stalled,
+          # resend_quota_95pct, etc). Same dedup state; keys prefixed
+          # "warn:" to avoid collision with heartbeat source names.
+          if [[ -z "${ADMIN_TOKEN:-}" ]]; then
+            echo "ADMIN_TOKEN unset — skipping ops-stats warnings poll"
+            exit 0
+          fi
+          ops_stats_url="${HEALTH_URL%/api/health}/api/admin/ops-stats"
+          ops=$(curl -fsS --max-time 20 \
+            -H "Authorization: Bearer $ADMIN_TOKEN" \
+            "$ops_stats_url" || echo "")
+          if [[ -z "$ops" ]]; then
+            echo "ops-stats poll failed — skipping warnings check"
+            exit 0
+          fi
+          echo "ops-stats.warnings count: $(echo "$ops" | jq '.warnings | length')"
+
+          # Current critical warnings (code|detail each line)
+          mapfile -t crit_lines < <(echo "$ops" | jq -r '.warnings[]? | select(.level=="critical") | "\(.code)|\(.detail)"')
+
+          # Fire alerts for any critical warning not yet alerted
+          for line in "${crit_lines[@]}"; do
+            IFS='|' read -r code detail <<< "$line"
+            dedup_key="warn:$code"
+            already_alerted=$(echo "$state" | jq -r --arg s "$dedup_key" '.alerted[$s] // ""')
+            if [[ -z "$already_alerted" ]]; then
+              echo "ALERT: warning $code — $detail"
+              post_discord ":rotating_light: **SC-CPE warning: $code** — $detail"
+              set_state "$dedup_key" "$(jq -cn --arg s "$dedup_key" '{source: $s}')"
+            else
+              echo "warn:$code alerted=$already_alerted (no change)"
+            fi
+          done
+
+          # Clear any previously-alerted warnings no longer in the critical list
+          mapfile -t prev_warn_keys < <(echo "$state" | jq -r '.alerted // {} | keys[] | select(startswith("warn:"))')
+          mapfile -t active_codes < <(echo "$ops" | jq -r '.warnings[]? | select(.level=="critical") | .code')
+          for k in "${prev_warn_keys[@]}"; do
+            code="${k#warn:}"
+            still_active=false
+            for ac in "${active_codes[@]}"; do
+              [[ "$ac" == "$code" ]] && still_active=true
+            done
+            if [[ "$still_active" == "false" ]]; then
+              echo "RECOVERED: warning $code cleared"
+              post_discord ":white_check_mark: **SC-CPE warning cleared: $code**"
+              set_state "$k" "$(jq -cn --arg s "$k" '{source: $s, clear: true}')"
             fi
           done


### PR DESCRIPTION
Now that the Discord webhook secret is set, every cron that touches
cert state should light up the channel on failure — and dashboard-only
warnings should too, otherwise a critical condition lives on the
admin page until someone looks.

Three changes:

1. .github/workflows/monthly-certs.yml — new `alert-on-failure` job
   that mirrors deploy-prod.yml's pattern. Posts a :rotating_light:
   Discord message naming the SHA and period if the monthly issuance
   run fails. Silent skip if webhook unset.

2. .github/workflows/cert-sign-pending.yml — same pattern for the
   2h pending pickup cron. :warning: (not rotating_light) because
   a single missed run is less severe than a month-end failure —
   the next 2h cron drains the same pending rows.

3. .github/workflows/watchdog.yml — extended to also poll
   /api/admin/ops-stats every 15 min. For each level=critical warning
   (email_queue_stalled, certs_pending_stalled, resend_quota_95pct,
   email_queue_deep from computeWarnings), fire a Discord alert
   once on first observation and a clear message once on recovery.
   Dedup state shares the existing watchdog-state KV — keys prefixed
   "warn:" so they don't collide with heartbeat source names. Skips
   gracefully if ADMIN_TOKEN is unset.

No test changes (all three files are CI-only). 130/130 still green.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
