### PR TITLE
docs(launch): add SLO targets and a CE-auditor verifier one-pager

### DIFF
--- a/docs/SLO.md
+++ b/docs/SLO.md
@@ -1,0 +1,58 @@
+# SLO — SC-CPE service-level objectives
+
+Starting targets at launch. Reviewed weekly against actuals from
+`/api/health`, `/api/admin/heartbeat-status`, `/api/admin/ops-stats`,
+and the hourly canary. Revisited monthly — any SLO that's been
+consistently exceeded by >2× should be tightened; any chronically
+breached SLO should be loosened with a written "why" or fixed.
+
+## User-visible SLOs
+
+| Flow | Target | Measurement | Breach visibility |
+| --- | --- | --- | --- |
+| Registration email delivered | **99.0 % within 5 min**, 99.9 % within 1 h | `ops-stats.email_outbox.sent_24h` vs queued/failed | `ops-stats.warnings` → `email_queue_stalled` fires Discord via watchdog |
+| Recovery email delivered | 99.0 % within 5 min | same | same |
+| Live attendance credit | **99.0 % within 60 s** of chat post | poller heartbeat + user-dashboard refresh | `sources[poller].stale` on `/status.html` |
+| Per-session cert delivered after request | **99.0 % within 2 h** | `ops-stats.certs.oldest_pending_age_seconds` | `certs_pending_aging` / `_stalled` warning |
+| Monthly bundled cert delivered | **99.0 % within 48 h** of month-end cron | `monthly-certs.yml` run status + `certs` rows | workflow red → Discord via PR-G alert-on-failure |
+| Cert verification portal available | **99.9 %** | smoke + hourly canary | `sources[canary].stale` on `/status.html` |
+| `/api/verify/{token}` response correctness | **100 %** (any wrong answer is P0) | n/a; correctness is audit-chain-verified, not sampled | chain break in `audit-chain-verify` |
+
+## Operational SLOs
+
+| Signal | Target | Why |
+| --- | --- | --- |
+| Critical `ops-stats.warnings` → Discord | **< 15 min** from condition to alert | watchdog polls every 15 min; no batching |
+| Deploy-prod pipeline turnaround | **< 5 min** push → live | currently ~2 min; don't let it drift |
+| Rollback ETA (single Worker) | **< 90 s** interactive | see `RUNBOOK.md#rollback`; over 3 min means script it |
+| Smoke canary hourly | **< 2 breaches / month** | `smoke.yml` is read-only; a real breach is a real signal |
+
+## Non-goals at launch
+
+Explicit because chasing these without data wastes time:
+
+- **Latency percentiles.** We don't have edge telemetry aggregation today;
+  p50/p95 numbers would be guessed. Revisit after a month of real traffic.
+- **Zero-downtime guarantees.** Cloudflare Pages deploys are near-instant
+  but not formally atomic across all POPs. Acceptable for a CPE issuer;
+  escalate only if verify portal drops perceivable uptime.
+- **Per-region SLO.** Service is global; localise SLOs only if one region
+  produces anomalous breach patterns.
+
+## How to review SLOs
+
+Weekly (on the Monday after the weekly digest lands):
+
+1. Pull `ops-stats.warnings` from the past 7 days (scan your Discord
+   `SC-CPE Watchdog` + `SC-CPE Monthly` + `SC-CPE Pending` channel
+   history).
+2. For each table-row SLO, count observed breaches.
+3. If any SLO was breached > 1 % over its window: open a GitHub issue
+   with the label `slo-breach` including the warning codes or alerts
+   that fired. Triage to a code fix or an SLO relaxation in next week's
+   review.
+4. If no SLOs were breached for the whole week: the target may be too
+   loose — consider tightening in next monthly review.
+
+First monthly review: **one month after public announcement**. Numbers
+stabilise around then; tighter targets before that are premature.

--- a/docs/VERIFIER_GUIDE.md
+++ b/docs/VERIFIER_GUIDE.md
@@ -1,0 +1,105 @@
+# Verifier guide — for CE-portal auditors and relying parties
+
+You received an SC-CPE certificate (PDF) from someone who claims live
+attendance at the Simply Cyber Daily Threat Briefing. This one-page guide
+explains exactly what the certificate attests to and how to verify it
+independently — without contacting the issuer.
+
+## The one-sentence answer
+
+An SC-CPE certificate proves that the named recipient's registered
+YouTube channel posted at least one qualifying chat message during each
+Daily Threat Briefing on the stated date(s), during the live broadcast
+window. One 30-minute briefing = 0.5 CPE / CEU.
+
+## Three-step verification
+
+### 1. Check the PDF signature
+
+The cert is signed using the **PAdES-T** standard (PDF Advanced Electronic
+Signatures with trusted timestamp). Any PAdES-aware PDF reader — Adobe
+Acrobat, Foxit, recent macOS Preview, pdfsig on Linux — will show the
+signer's certificate and timestamp. Confirm:
+
+- **Signer common name** = `Simply Cyber LLC` (or the current key holder
+  named on the PDF itself).
+- **Signing-cert SHA-256 fingerprint** matches the value printed on the
+  face of the certificate. If the reader shows a different fingerprint,
+  the PDF was re-signed by someone else; reject it.
+- **RFC 3161 timestamp** is present. This is what makes the signature
+  outlive the signer's cert expiry — without a timestamp, the signature
+  stops verifying when the signer cert expires.
+
+### 2. Confirm the PDF matches our registered hash
+
+Open https://sc-cpe-web.pages.dev/verify.html and paste the certificate's
+**public token** (printed on the PDF under the QR code). You'll see the
+recipient name, period, CPE total, and the **registered SHA-256 of the
+issued PDF**.
+
+Then drag the PDF onto the page. Your browser computes its SHA-256
+locally (nothing leaves your device) and compares. A green "matches the
+certificate registered under that token" confirms the PDF you're holding
+is the exact artefact we issued. A red mismatch means the token is
+registered but the PDF isn't — you have a lookalike, not a real cert.
+
+### 3. Check revocation
+
+The same verify page surfaces revocation status. If the certificate is
+marked **REVOKED**, the page shows a revocation reason class
+(`issued_in_error`, `superseded`, `subject_request`, `key_compromise`,
+`other`). Additionally, a public revocation list is available at
+https://sc-cpe-web.pages.dev/api/crl.json — machine-readable, same data.
+
+## What this cert does *not* attest to
+
+- **Identity verification.** We do not perform KYC or government-ID
+  checks. Identity is established by possession of the email address
+  provided at registration and the YouTube channel bound via
+  out-of-band code exchange. We attest that a *channel-holder* who
+  attested to the given legal name posted qualifying messages — not
+  that the channel-holder is who they say they are.
+- **Continuous viewing.** Attendance is a binary signal: one qualifying
+  chat message during the live window earns credit for the whole
+  session.
+- **Acceptance by your CE body.** (ISC)², ISACA, CompTIA, and others
+  accept self-attested continuing education; the SC-CPE cert format
+  matches the category these programs define. We cannot guarantee
+  acceptance — that remains each body's policy call.
+
+## Audit chain
+
+Every state transition in SC-CPE — registration, chat-code match,
+attendance credit, cert issuance, delivery, revocation — writes an
+append-only row to a SHA-256 hash-chained audit log. A `UNIQUE INDEX` on
+`prev_hash` makes chain forks structurally impossible. If you need a
+higher level of assurance than signature + hash-match:
+
+- `GET /api/admin/audit-chain-verify` (admin-gated) walks the full chain
+  and confirms no tampering. Contact the issuer for a one-shot verify if
+  an auditor specifically requests it.
+- The offline verifier `scripts/verify_audit_chain.py` in the public
+  [SC-CPE source repo](https://github.com/ericrihm/sc-cpe) replays the
+  chain against a D1 export independently of the running service.
+
+## Questions, disputes, or suspected forgery
+
+- **Report suspected forgery or credential fraud:**
+  `security@signalplane.co` (see
+  https://sc-cpe-web.pages.dev/.well-known/security.txt for the
+  full disclosure policy and SLAs).
+- **Revocation request (e.g., you're a CE body that determined a cert
+  was issued in error):** `contact@signalplane.co`. Include the
+  cert's public token.
+- **Policy questions:** see https://sc-cpe-web.pages.dev/privacy.html
+  and https://sc-cpe-web.pages.dev/terms.html.
+
+## Quick-copy explanation for CE portal upload forms
+
+> Simply Cyber CPE (SC-CPE) certificate of live attendance at the
+> Simply Cyber Daily Threat Briefing. The certificate is
+> cryptographically signed (PAdES-T with RFC-3161 timestamp), anchored
+> to an append-only hash-chained audit log, and independently verifiable
+> at https://sc-cpe-web.pages.dev/verify.html. One 30-minute briefing
+> yields 0.5 CPE / CEU in the "webinar / web-based training" category.
+> Issued by Simply Cyber LLC.


### PR DESCRIPTION
Two docs that finish out the post-launch / launch-week paper trail.

docs/SLO.md — starting targets so "launch went fine" stops being vibes.
Targets split into user-visible (reg/recovery email 5min / 1h, per-session
cert 2h, monthly 48h, attendance credit 60s, verify 99.9 %, verify
correctness 100 %) and operational (warning → Discord < 15min, deploy
pipeline < 5min, rollback < 90s, smoke canary < 2 breaches/mo). Explicit
non-goals (latency percentiles, zero-downtime promises, per-region SLO)
so we don't chase the wrong numbers before we have data. Review cadence:
weekly scan of Discord, monthly tightening after one month of actuals.

docs/VERIFIER_GUIDE.md — the one-page for (ISC)²/ISACA/CompTIA auditors
who receive an SC-CPE cert and want to verify it without contacting us.
Three steps: (1) check the PAdES-T signature + RFC-3161 timestamp in any
PDF reader, (2) drag the PDF onto /verify.html for a client-side SHA-256
match, (3) check revocation via the same portal or /api/crl.json. Also
explicit about what the cert doesn't attest to (KYC, continuous
viewing, CE-body acceptance guarantee) plus a quick-copy paragraph for
CE portal upload forms.

Closes codex's P2-A #4 (verifier-facing explainer) and launch-readiness
SLO task. No code, no tests.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
