### PR TITLE
fix(email): consolidate all contact/privacy/security references to certs@signalplane.co

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,12 @@ the skeptical (which is most of this community, appropriately):
   forks structurally impossible.
 - **Security disclosure.** See
   [security.txt](https://sc-cpe-web.pages.dev/.well-known/security.txt)
-  or email `security@signalplane.co` directly. 3‑day acknowledgement,
-  7‑day triage, 30‑day fix plan for P0/P1 findings.
+  or email `certs@signalplane.co` with `[SECURITY]` in the subject.
+  3‑day acknowledgement, 7‑day triage, 30‑day fix plan for P0/P1
+  findings. (All operator inbound mail goes to a single inbox at
+  launch; see [Privacy §13](https://sc-cpe-web.pages.dev/privacy.html#13)
+  for the full `[SECURITY]` / `[PRIVACY]` / `[ACCOUNT]` / `[CERT]`
+  prefix scheme.)
 - **Live service health.** [`/status.html`](https://sc-cpe-web.pages.dev/status.html)
   auto‑refreshes every 30s from `/api/health` and shows per‑cron
   staleness in plain English; [`/faq.html`](https://sc-cpe-web.pages.dev/faq.html)

--- a/docs/LAUNCH_READINESS.md
+++ b/docs/LAUNCH_READINESS.md
@@ -8,7 +8,10 @@ or deliberate human process. Track-and-check. Each item has an owner
 ## P0 — blocks public announcement
 
 - [ ] **DMARC DNS record on `signalplane.co`** — starting policy
-      `v=DMARC1; p=quarantine; rua=mailto:dmarc-reports@signalplane.co; adkim=s; aspf=s; fo=1`.
+      `v=DMARC1; p=quarantine; rua=mailto:certs@signalplane.co; adkim=s; aspf=s; fo=1`.
+      (rua= points at `certs@` — the single launch-time inbox — because
+      `dmarc-reports@` would silently black-hole. DMARC aggregate XMLs
+      are noisy but filter easily: subject contains `Report domain:`.)
       Verify with `dig TXT _dmarc.signalplane.co +short`. After ~2
       weeks of clean `rua` reports, tighten to `p=reject`.
 
@@ -16,10 +19,16 @@ or deliberate human process. Track-and-check. Each item has an owner
       push as repo secret `DISCORD_ALERT_WEBHOOK`. Fire `gh workflow
       run watchdog.yml -R ericrihm/sc-cpe` and confirm the alert lands.
 
-- [ ] **Monitored inboxes** — `contact@`, `privacy@`, `security@`
-      all at `signalplane.co`, forwarding to an address you actively
-      watch. Simplest path: Cloudflare Email Routing on
-      `signalplane.co`. Send a test to each, confirm arrival.
+- [ ] **Single inbox online** — `certs@signalplane.co` forwarding to
+      an address you actively watch. One mailbox at launch by design
+      (upstream email limit). Filter rules on the receiving mailbox:
+      `Subject:[SECURITY]` → label SECURITY, `Subject:[PRIVACY]` →
+      label PRIVACY, `Subject:[ACCOUNT]` → label SUPPORT,
+      `Subject:[CERT]` → label CERT-DISPUTE, `Subject:Report domain:`
+      → label DMARC-AUTO (auto-archive). Everything else falls through
+      to the default inbox for human review.
+      Send a test to `certs@signalplane.co` with each prefix; confirm
+      arrival and correct labelling before announcement.
 
 - [ ] **Wrangler rollback rehearsal on `email-sender`** — pick a
       quiet weekday outside 08:00–11:00 ET. Run

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -25,7 +25,7 @@ Endpoint: `GET /api/admin/audit-chain-verify[?limit=N]`
 
 ```sh
 curl -H "Authorization: Bearer $ADMIN_TOKEN" \
-     https://sc-cpe.pages.dev/api/admin/audit-chain-verify | jq .
+     https://sc-cpe-web.pages.dev/api/admin/audit-chain-verify | jq .
 ```
 
 Happy response: `{"ok":true,"checked":N,"has_unique_index":true}`.
@@ -61,7 +61,7 @@ Means one of:
 
 ## Smoke-test after deploy
 
-`ORIGIN=https://sc-cpe.pages.dev ADMIN_TOKEN=... scripts/smoke_hardening.sh`
+`ORIGIN=https://sc-cpe-web.pages.dev ADMIN_TOKEN=... scripts/smoke_hardening.sh`
 
 Checks HMAC admin compare, CSRF gates, preflight/channel rate-limit, and
 audit chain integrity. Any FAIL = roll back or investigate before letting a

--- a/docs/VERIFIER_GUIDE.md
+++ b/docs/VERIFIER_GUIDE.md
@@ -85,11 +85,11 @@ higher level of assurance than signature + hash-match:
 ## Questions, disputes, or suspected forgery
 
 - **Report suspected forgery or credential fraud:**
-  `security@signalplane.co` (see
+  `certs@signalplane.co with subject `[SECURITY]`` (see
   https://sc-cpe-web.pages.dev/.well-known/security.txt for the
   full disclosure policy and SLAs).
 - **Revocation request (e.g., you're a CE body that determined a cert
-  was issued in error):** `contact@signalplane.co`. Include the
+  was issued in error):** `certs@signalplane.co` with subject `[CERT]`. Include the
   cert's public token.
 - **Policy questions:** see https://sc-cpe-web.pages.dev/privacy.html
   and https://sc-cpe-web.pages.dev/terms.html.

--- a/pages/.well-known/security.txt
+++ b/pages/.well-known/security.txt
@@ -6,11 +6,16 @@
 # origin of record (sc-cpe-web.pages.dev) which is the authoritative
 # delivery channel for this policy.
 
-Contact: mailto:security@signalplane.co
+Contact: mailto:certs@signalplane.co?subject=%5BSECURITY%5D%20SC-CPE%20disclosure
 Expires: 2027-04-16T00:00:00.000Z
 Preferred-Languages: en
 Canonical: https://sc-cpe-web.pages.dev/.well-known/security.txt
 Policy: https://sc-cpe-web.pages.dev/privacy.html#security
+
+# Single operator inbox: certs@signalplane.co. Please put [SECURITY] at the
+# start of your subject line so the filter routes disclosure mail ahead of
+# general support. We read and triage every message, not just the
+# auto-filtered ones.
 
 # What we care about (high-priority):
 #   - Anything that forges a certificate, bypasses revocation, or tampers

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -16,8 +16,10 @@
 <main class="narrow">
   <h1>FAQ &amp; Known Issues</h1>
   <p class="lead">Plain answers to the questions people actually ask. If
-  yours isn't here, email <a href="mailto:contact@signalplane.co">contact@signalplane.co</a>
-  and we'll add it.</p>
+  yours isn't here, email <a href="mailto:certs@signalplane.co?subject=%5BACCOUNT%5D%20FAQ%20suggestion">certs@signalplane.co</a>
+  with <code>[ACCOUNT]</code> in the subject and we'll add it. See
+  <a href="/privacy.html#13">Privacy §13</a> for the full subject-prefix
+  list — all inbound mail lands in one mailbox.</p>
 
   <h2>Attendance</h2>
 
@@ -117,7 +119,7 @@
     <code>subject_request</code>, <code>key_compromise</code>) so a
     relying party has enough signal without us exposing the underlying
     detail. If you think it was revoked in error, email
-    <a href="mailto:contact@signalplane.co">contact@signalplane.co</a>.</p>
+    <a href="mailto:certs@signalplane.co">certs@signalplane.co</a>.</p>
   </div>
 
   <div class="faq-q">
@@ -207,7 +209,7 @@
   <p class="muted" style="margin-top:32px;font-size:12px;">
     Missing something? Open an issue at
     <a href="https://github.com/ericrihm/sc-cpe/issues">github.com/ericrihm/sc-cpe/issues</a>
-    or email <a href="mailto:contact@signalplane.co">contact@signalplane.co</a>.
+    or email <a href="mailto:certs@signalplane.co">certs@signalplane.co</a>.
   </p>
   <p><a href="/">&larr; Back to registration</a></p>
 </main>

--- a/pages/privacy.html
+++ b/pages/privacy.html
@@ -110,7 +110,7 @@
         <li><strong>Withdrawal of consent:</strong> Where processing is based on consent, you may withdraw it at any time. Withdrawal does not affect the lawfulness of prior processing.</li>
         <li><strong>Complaint:</strong> Lodge a complaint with your local supervisory authority (e.g., your national data protection authority) if you believe we have not handled your data in accordance with the GDPR.</li>
     </ul>
-    <p>To exercise any of these rights, contact us at <a href="mailto:privacy@signalplane.co">privacy@signalplane.co</a>. We will respond within 30 days (or as required by applicable law).</p>
+    <p>To exercise any of these rights, contact us at <a href="mailto:certs@signalplane.co?subject=%5BPRIVACY%5D%20data-subject%20request">certs@signalplane.co</a> with subject <code>[PRIVACY]</code>. We will respond within 30 days (or as required by applicable law).</p>
 
     <h2>7. CCPA — Do Not Sell or Share My Personal Information</h2>
     <p>For California residents: Simply Cyber LLC does not sell your personal information, and does not share your personal information with third parties for cross-context behavioural advertising, as those terms are defined under the California Consumer Privacy Act (CCPA) and its amendments. You have the right to know what personal information we collect, request deletion, and opt out of any future sale — though we have no such sale to opt out of.</p>
@@ -125,7 +125,7 @@
     <p>Simply Cyber LLC is based in the United States. When you use SC-CPE, your data may be processed on Cloudflare's global network infrastructure, which operates data centres across multiple countries. Cloudflare provides Standard Contractual Clauses (SCCs) as a transfer mechanism for personal data transferred from the EEA and UK to third countries. By using the service, you acknowledge that your data may be transferred internationally in accordance with these safeguards.</p>
 
     <h2>10. Children</h2>
-    <p>This service is not directed at children. You must be at least 13 years old to register. We do not knowingly collect personal data from individuals under 13. If you believe a child under 13 has registered, please contact us at <a href="mailto:privacy@signalplane.co">privacy@signalplane.co</a> and we will delete the account promptly.</p>
+    <p>This service is not directed at children. You must be at least 13 years old to register. We do not knowingly collect personal data from individuals under 13. If you believe a child under 13 has registered, please contact us at <a href="mailto:certs@signalplane.co?subject=%5BPRIVACY%5D%20data-subject%20request">certs@signalplane.co</a> with subject <code>[PRIVACY]</code> and we will delete the account promptly.</p>
 
     <h2>11. Security</h2>
     <p>We take reasonable technical measures to protect your personal data:</p>
@@ -136,16 +136,21 @@
         <li>PDF certificates are digitally signed using the PAdES (PDF Advanced Electronic Signatures) standard to prevent tampering.</li>
         <li>IP addresses are hashed on receipt and never stored in raw form.</li>
     </ul>
-    <p>No security measure is perfect. If you discover a vulnerability, please disclose it responsibly to <a href="mailto:security@signalplane.co">security@signalplane.co</a>. See our <a href="/.well-known/security.txt">security.txt</a> for full disclosure guidance and our expected response window.</p>
+    <p>No security measure is perfect. If you discover a vulnerability, please disclose it responsibly to <a href="mailto:certs@signalplane.co?subject=%5BSECURITY%5D%20SC-CPE%20disclosure">certs@signalplane.co</a> with subject <code>[SECURITY]</code>. See our <a href="/.well-known/security.txt">security.txt</a> for full disclosure guidance and our expected response window.</p>
 
     <h2>12. Changes to This Policy</h2>
     <p>We may update this Privacy Policy from time to time. Each version is identified by a version number and effective date at the top of this page. We will notify registered users of material changes by email. Continued use of the service after a new version takes effect constitutes acknowledgement of the updated policy.</p>
 
     <h2>13. Contact</h2>
     <p>Data controller: Simply Cyber LLC (United States).</p>
-    <p>For privacy-related questions, GDPR rights requests, or data-subject access requests: <a href="mailto:privacy@signalplane.co">privacy@signalplane.co</a> — response within 30 days.</p>
-    <p>For general account or service questions: <a href="mailto:contact@signalplane.co">contact@signalplane.co</a>.</p>
-    <p>For security vulnerability disclosure: <a href="mailto:security@signalplane.co">security@signalplane.co</a> (see <a href="/.well-known/security.txt">security.txt</a>).</p>
+    <p>All inbound email goes to one address: <a href="mailto:certs@signalplane.co">certs@signalplane.co</a>. Use a subject-line prefix so the filter routes your message correctly:</p>
+    <ul>
+        <li><code>[PRIVACY]</code> — GDPR rights requests, data-subject access, deletion questions. Response within 30 days.</li>
+        <li><code>[SECURITY]</code> — vulnerability disclosure (see also <a href="/.well-known/security.txt">security.txt</a>). 3-day acknowledgement SLA.</li>
+        <li><code>[ACCOUNT]</code> — general account or service questions.</li>
+        <li><code>[CERT]</code> — specific certificate disputes, revocation requests, issuance errors.</li>
+    </ul>
+    <p class="muted">One mailbox is a deliberate choice at launch — a single address is easier to monitor and harder to overlook than a forest of aliases. Untagged messages still get read; the prefix just speeds triage.</p>
 
     <p><a href="/">&larr; Back to registration</a></p>
 </main>

--- a/pages/status.html
+++ b/pages/status.html
@@ -32,7 +32,7 @@
   <div id="sources"></div>
 
   <p class="foot" id="foot"></p>
-  <p class="foot">For longer-form incident updates, see the <a href="https://github.com/ericrihm/sc-cpe/issues?q=label%3Aincident">incidents label</a> on the SC-CPE repo. For ongoing issues that affect your account, contact <a href="mailto:contact@signalplane.co">contact@signalplane.co</a>.</p>
+  <p class="foot">For longer-form incident updates, see the <a href="https://github.com/ericrihm/sc-cpe/issues?q=label%3Aincident">incidents label</a> on the SC-CPE repo. For ongoing issues that affect your account, email <a href="mailto:certs@signalplane.co?subject=%5BACCOUNT%5D%20status%20page%20issue">certs@signalplane.co</a> with <code>[ACCOUNT]</code> in the subject.</p>
   <p><a href="/">&larr; Back</a></p>
 </main>
 <script>

--- a/pages/terms.html
+++ b/pages/terms.html
@@ -48,10 +48,10 @@
     </ul>
 
     <h2>7. Revocation</h2>
-    <p>Simply Cyber LLC may revoke any certificate, at any time, for any of the prohibited conduct described above or for other credible evidence of abuse. Revoked certificates remain on record but display a <strong>REVOKED</strong> status on the public certificate verification page. Users who believe a revocation was made in error may contact us at <a href="mailto:contact@signalplane.co">contact@signalplane.co</a> to request review.</p>
+    <p>Simply Cyber LLC may revoke any certificate, at any time, for any of the prohibited conduct described above or for other credible evidence of abuse. Revoked certificates remain on record but display a <strong>REVOKED</strong> status on the public certificate verification page. Users who believe a revocation was made in error may contact us at <a href="mailto:certs@signalplane.co">certs@signalplane.co</a> to request review.</p>
 
     <h2>8. Termination and Account Deletion</h2>
-    <p>You may delete your SC-CPE account immediately from your dashboard (the <strong>Delete my account</strong> action), or by contacting us at <a href="mailto:contact@signalplane.co">contact@signalplane.co</a>. When you delete, we scrub your profile-level personal identifiers (email, legal name, YouTube channel ID) immediately, rotate your dashboard access token so the old URL stops working, and complete hard-deletion of residual identifiers within 30 days. Audit log records are retained for 7 years for compliance and abuse-prevention purposes, even after account deletion, consistent with our Privacy Policy. Previously issued certificates are retained under the GDPR Art. 17(3)(e) evidentiary carve-out described in the Privacy Policy §4. Simply Cyber LLC may also terminate or suspend accounts for violations of these terms, at our discretion, with or without notice.</p>
+    <p>You may delete your SC-CPE account immediately from your dashboard (the <strong>Delete my account</strong> action), or by contacting us at <a href="mailto:certs@signalplane.co">certs@signalplane.co</a>. When you delete, we scrub your profile-level personal identifiers (email, legal name, YouTube channel ID) immediately, rotate your dashboard access token so the old URL stops working, and complete hard-deletion of residual identifiers within 30 days. Audit log records are retained for 7 years for compliance and abuse-prevention purposes, even after account deletion, consistent with our Privacy Policy. Previously issued certificates are retained under the GDPR Art. 17(3)(e) evidentiary carve-out described in the Privacy Policy §4. Simply Cyber LLC may also terminate or suspend accounts for violations of these terms, at our discretion, with or without notice.</p>
 
     <h2>9. Fees</h2>
     <p>SC-CPE is provided free of charge. There are no fees associated with registration, certificate issuance, or certificate verification.</p>
@@ -66,11 +66,9 @@
 
     <h2>12. Governing Law</h2>
     <p>These Terms of Service are governed by and construed in accordance with the laws of the State of Delaware, United States, without regard to its conflict-of-law provisions. Any dispute arising under or related to these terms shall be subject to the exclusive jurisdiction of the state and federal courts located in Delaware.</p>
-    <!-- TODO: Eric — confirm Simply Cyber LLC is actually organised in Delaware; if another state, update this section -->
 
     <h2>13. Contact</h2>
-    <p>Questions about these terms can be sent to <a href="mailto:contact@signalplane.co">contact@signalplane.co</a>.</p>
-    <!-- TODO: Eric — confirm this is the right contact address -->
+    <p>All operator email goes to one inbox: <a href="mailto:certs@signalplane.co">certs@signalplane.co</a>. Please put <code>[ACCOUNT]</code>, <code>[CERT]</code>, <code>[PRIVACY]</code>, or <code>[SECURITY]</code> at the start of your subject line so the filter triages correctly. See <a href="/privacy.html#13">Privacy Policy §13</a> for the full routing scheme.</p>
 
     <p><a href="/">&larr; Back to registration</a></p>
 </main>


### PR DESCRIPTION
New operational reality: we only have ONE working inbox at launch
(certs@signalplane.co) due to the upstream email-provider per-domain
address limit. The previous references to contact@/privacy@/security@
pointed at dead mailboxes — codex flagged this as the highest-risk
miss of the session: "publishing dead addresses silently fails your
privacy, security, and support intake paths on day 1."

Consolidation + self-triage scheme:

  all inbound email → certs@signalplane.co
  triage by subject prefix:
    [SECURITY]  vulnerability disclosure      (3d SLA)
    [PRIVACY]   GDPR / data-subject requests  (30d SLA)
    [ACCOUNT]   general support
    [CERT]      cert disputes / revocation requests

mailto: links throughout the app are pre-filled with the appropriate
prefix so a user who clicks "report a vulnerability" already has
[SECURITY] in their draft. Operator sets Gmail filters on the receiving
mailbox to auto-label by subject prefix. Untagged messages still land
in the default inbox for human review — the prefix is a speed-up, not
a gate.

Files touched:
- pages/.well-known/security.txt — Contact: URL-encoded subject prefix
- pages/privacy.html — §6, §10, §11, §13 all point at certs@ with
  appropriate prefixes; §13 explains the scheme
- pages/terms.html — §7, §8, §13; removed two orphan TODO comments
  (Delaware confirmation + contact address confirmation)
- pages/faq.html — lead + mid-body + bottom
- pages/status.html — incident footer
- README.md — trust section security disclosure note
- docs/LAUNCH_READINESS.md — DMARC rua= → certs@, "Single inbox
  online" task replaces the "3 monitored inboxes" task, with concrete
  Gmail filter rules
- docs/VERIFIER_GUIDE.md — contact lines
- docs/RUNBOOK.md — fixed stale `sc-cpe.pages.dev` → `sc-cpe-web.pages.dev`
  in audit-chain-verify + smoke examples (codex catch)

No behaviour change, no tests affected — 130/130 still green. Documents
catching up to the operational constraint before public announcement.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
