### PR TITLE
fix(smoke): one-line the python heredoc so YAML actually parses

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -45,18 +45,20 @@ jobs:
         # Catches the case where smoke itself passes but canary-beat silently
         # regressed. Smoke is hourly, so the prior beat should be <70min old.
         # Skipped on manual dispatch runs (they may fire off-cadence).
+        #
+        # IMPORTANT: the python must be a single line. A multi-line heredoc
+        # inside a YAML block literal silently breaks the whole workflow:
+        # lines at column 0 terminate the `run: |` block, and GitHub rejects
+        # the workflow with a 0-second-duration failure AND no steps execute
+        # (so Discord alerts on failure never fire). See commit history on
+        # this file if you're tempted to re-expand this — 2026-04-15 to
+        # 2026-04-16 the hourly canary was dead and nobody noticed.
         if: github.event_name != 'workflow_dispatch'
         run: |
           age=$(curl -fsS --max-time 20 \
             -H "Authorization: Bearer $ADMIN_TOKEN" \
-            "$ORIGIN/api/admin/heartbeat-status" | \
-            python3 -c 'import json,sys
-d=json.load(sys.stdin)
-for s in d.get("sources",[]):
-    if s["source"]=="canary":
-        print(s.get("age_seconds") or 99999); break
-else:
-    print(99999)')
+            "$ORIGIN/api/admin/heartbeat-status" \
+            | python3 -c "import json,sys; d=json.load(sys.stdin); print(next((s.get('age_seconds') or 99999 for s in d.get('sources',[]) if s.get('source')=='canary'), 99999))")
           echo "canary age: ${age}s"
           if [[ "$age" -gt 4200 ]]; then
             echo "canary heartbeat stale (>70min) — beat endpoint may have regressed" >&2


### PR DESCRIPTION
The hourly canary has been silently broken since ~2026-04-15 16:38
(last green run) and NOBODY noticed — every smoke run since has
completed in 0 seconds with conclusion=failure and zero jobs executed.
Because no jobs ran, the "Alert Discord on failure" step never fired.

Root cause: the python heredoc inside the canary-age-check step had
lines beginning at column 0, terminating the containing `run: |`
block literal early. GitHub's YAML parser rejected the workflow but
still created run records that were marked failed with no output,
so it looked like "flaky" failures in the Actions tab — not a hard
parse error.

Reproduced locally with js-yaml, which errors:
  can not read a block mapping entry; a multiline key may not be an
  implicit key (55:29)

The python was doing: iterate heartbeat sources, find canary, print
age or 99999 fallback. Rewritten as a single-line expression using
next() + generator, same semantics, no multiline heredoc.

Added a LARGE comment explaining why this can't be re-expanded — the
whole-workflow-parse-fail behaviour is a foot-gun that would bite a
future maintainer otherwise.

Consequence of the fix:
- Hourly smoke canary resumes actually running.
- Any future real smoke failure now DOES fire Discord via the alert
  step that landed in the original smoke.yml design.
- The "deliberately break SMOKE_ORIGIN to test Discord" E2E can now
  actually complete end-to-end.

Nothing else in the repo referenced the removed multi-line form.
130/130 tests still green (smoke.yml isn't executed by the node suite;
yaml validation was done with js-yaml).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
