### PR TITLE
fix(smoke): bootstrap canary heartbeat on first run after recovery

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -60,7 +60,15 @@ jobs:
             "$ORIGIN/api/admin/heartbeat-status" \
             | python3 -c "import json,sys; d=json.load(sys.stdin); print(next((s.get('age_seconds') or 99999 for s in d.get('sources',[]) if s.get('source')=='canary'), 99999))")
           echo "canary age: ${age}s"
-          if [[ "$age" -gt 4200 ]]; then
+          # age == 99999 means no canary heartbeat row exists at all —
+          # bootstrap case (this is the first run after smoke regained the
+          # ability to execute). Let the later "Write canary heartbeat" step
+          # seed it; the NEXT hourly run will assert against a real number.
+          # Any actual age > 70min (with the row present) still fails — that
+          # catches a silently-regressed beat endpoint.
+          if [[ "$age" -ge 99999 ]]; then
+            echo "canary heartbeat absent — bootstrapping on this run; next hourly run will enforce freshness"
+          elif [[ "$age" -gt 4200 ]]; then
             echo "canary heartbeat stale (>70min) — beat endpoint may have regressed" >&2
             exit 1
           fi


### PR DESCRIPTION
After PRs #19 + #20 the smoke suite itself passes again, but the
"Assert prior canary beat is fresh" step was hardcoded to fail when
age was 99999 (no canary row at all). That is exactly the state we
end up in after a 24h outage — the beat was never written during the
dead window. Asserting that a missing beat is "stale" created a
chicken-and-egg loop: assert fails → Write step skipped → next run
still has no beat → assert fails again.

Fix: distinguish two cases at the assert.
  - age >= 99999  → no row exists; log a bootstrap notice and continue
                     so the Write step seeds a fresh beat this run.
                     Next hourly run then has a real number to check.
  - age > 4200    → row exists but is > 70min old; that is the
                     "beat endpoint silently regressed" case we
                     actually want to fail on.

After this lands, one more smoke cycle (this run's push + next hourly
cron) and the canary is back to normal steady-state.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
