### PR TITLE
docs(cpe): correct duration math — briefing is ~1h wall-clock, ~30 min instructional

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,11 @@ by hand doesn't scale past a few dozen people. SC‑CPE does it end‑to‑end:
        without talking to us; the file never leaves the browser.
 ```
 
-**0.5 CEU / CPE per 30‑minute session** · up to ~20 sessions/month · per‑session
-or bundled (or both) · full reissue flow if your name or email is wrong.
+**0.5 CEU / CPE per qualifying briefing** (the stream runs ~1h;
+Simply Cyber scopes the instructional portion to ~30 min, which maps
+cleanly to 0.5 credit under ISC2 / ISACA / CompTIA accounting) · up
+to ~20 briefings/month · per‑session or bundled (or both) · full
+reissue flow if your name or email is wrong.
 
 Your YouTube channel auto‑links the first time the poller matches your code in
 a live briefing chat. If credits are granted manually (admin reconciliation —

--- a/docs/VERIFIER_GUIDE.md
+++ b/docs/VERIFIER_GUIDE.md
@@ -10,7 +10,10 @@ independently — without contacting the issuer.
 An SC-CPE certificate proves that the named recipient's registered
 YouTube channel posted at least one qualifying chat message during each
 Daily Threat Briefing on the stated date(s), during the live broadcast
-window. One 30-minute briefing = 0.5 CPE / CEU.
+window. Each qualifying briefing yields 0.5 CPE / CEU — the stream
+runs ~1 hour of wall-clock, but the CPE-countable instructional
+portion is scoped to ~30 minutes (opens, ads, and audience Q&A are
+not instructional minutes under ISC2 / ISACA / CompTIA accounting).
 
 ## Three-step verification
 
@@ -100,6 +103,7 @@ higher level of assurance than signature + hash-match:
 > Simply Cyber Daily Threat Briefing. The certificate is
 > cryptographically signed (PAdES-T with RFC-3161 timestamp), anchored
 > to an append-only hash-chained audit log, and independently verifiable
-> at https://sc-cpe-web.pages.dev/verify.html. One 30-minute briefing
-> yields 0.5 CPE / CEU in the "webinar / web-based training" category.
-> Issued by Simply Cyber LLC.
+> at https://sc-cpe-web.pages.dev/verify.html. Each live attendance
+> qualifies for 0.5 CPE / CEU in the "webinar / web-based training"
+> category, reflecting the ~30 minutes of instructional content per
+> briefing. Issued by Simply Cyber LLC.

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -53,11 +53,17 @@
 
   <div class="faq-q">
     <h3>Why 0.5 CPE per session?</h3>
-    <p>Continuing-education programs (ISC2, ISACA, CompTIA) count one
-    full CPE per hour of instruction. The briefing runs roughly 30
-    minutes, so each session yields 0.5 CPE. Over a typical month of
-    ~20 weekday briefings, that's <strong>10 CPE</strong> with no
-    extra effort.</p>
+    <p>CE bodies count <em>instruction time</em>, not video time. The
+    Daily Threat Briefing is about an hour of wall-clock, but Simply
+    Cyber conservatively scopes the CPE-countable instructional
+    portion to roughly 30 minutes per briefing — opens, ads, audience
+    Q&amp;A, and sign-off don't contribute to instructional minutes.
+    Thirty minutes maps cleanly to 0.5 CPE under ISC2 / ISACA /
+    CompTIA accounting, and using a conservative instructional-minutes
+    figure keeps the certificate defensible if an auditor ever asks
+    why a 60-minute stream yielded half a credit.</p>
+    <p>Twenty weekday briefings per month still totals
+    <strong>10 CPE</strong>.</p>
   </div>
 
   <div class="faq-q">


### PR DESCRIPTION
FAQ previously said "the briefing runs roughly 30 minutes" — wrong on
the wall-clock side. The Daily Threat Briefing actually runs about an
hour; Simply Cyber scopes the CPE-countable instructional portion to
~30 minutes (opens, ads, audience Q&A, and sign-off don't contribute
to instructional minutes). That scoping is actually more defensible
than the old wording: CE bodies count *instruction time*, not video
time, so explicit 30-min instructional scoping is the honest answer
if an auditor asks why a 60-minute stream yields half a credit.

Three consistent updates so the math story is the same everywhere:
- pages/faq.html §"Why 0.5 CPE per session?" — full rewrite
- README.md — the calendar bullet now says "~1h stream, ~30 min
  instructional portion" instead of "30-minute session"
- docs/VERIFIER_GUIDE.md — one-sentence attestation AND the CE
  portal quick-copy paragraph both updated

No behavioural change, no cert-face copy change (the cert just says
"0.5 CPE" which remains correct regardless of the explanation), no
tests affected. 130/130.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
