### PR TITLE
fix(docs): CE-authority audit framing + add favicon

### DIFF
--- a/pages/admin.html
+++ b/pages/admin.html
@@ -6,6 +6,8 @@
 <title>SC-CPE Admin</title>
 <meta name="robots" content="noindex,nofollow">
 <link rel="stylesheet" href="/style.css">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="theme-color" content="#0b3d5c">
 <style>
   body { font-family: ui-sans-serif, system-ui, sans-serif; margin: 0; background: #0b0f14; color: #e5ecf2; }
   .wrap { max-width: 980px; margin: 0 auto; padding: 24px; }

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -5,6 +5,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>SC-CPE — My Dashboard</title>
 <link rel="stylesheet" href="/style.css">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="theme-color" content="#0b3d5c">
 <style>
 .cal-nav { display: flex; align-items: center; gap: 12px; margin: 8px 0 10px; }
 .cal-nav button { min-width: 32px; padding: 2px 8px; font-size: 18px; cursor: pointer; }
@@ -209,9 +211,10 @@
         <div class="card" id="prefs-card" hidden>
             <h2>Certificate delivery</h2>
             <p class="muted" style="font-size:12px;">
-                Most auditors (including (ISC)²) accept the bundled monthly
-                certificate. Pick individual per-session certs if your
-                employer's CPE auditor requires per-activity documentation.
+                Most certification bodies (including (ISC)²) accept the
+                bundled monthly certificate. Pick individual per-session
+                certs only if your certification body specifically asks
+                for per-activity documentation at audit — uncommon.
                 You can also request a one-off per-session cert on any
                 attendance row below.
             </p>

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -5,6 +5,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>SC-CPE — FAQ &amp; Known Issues</title>
 <link rel="stylesheet" href="/style.css">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="theme-color" content="#0b3d5c">
 <style>
   .faq-q { margin-top: 22px; }
   .faq-q h3 { margin-bottom: 6px; }
@@ -81,10 +83,13 @@
     <p><strong>Monthly bundle</strong> (default) is best for most users.
     One PDF per month listing every session you attended, plus total
     hours. Easiest to upload to (ISC)² / ISACA / CompTIA CE portals.</p>
-    <p>Pick <strong>per-session</strong> if your employer's CPE audit
-    requires one certificate per activity (uncommon). Or pick <strong>both</strong>
-    if you want the monthly bundle AND an on-demand per-session PDF for
-    any briefing. Per-session certs are signed within 2 hours of request.</p>
+    <p>Pick <strong>per-session</strong> if your certification body's
+    audit process asks for one record per CPE activity — this is
+    uncommon; ISC2, ISACA, and CompTIA all accept bundled multi-activity
+    records under their standard CPE submission categories. Or pick
+    <strong>both</strong> if you want the monthly bundle AND an
+    on-demand per-session PDF for any briefing. Per-session certs are
+    signed within 2 hours of request.</p>
   </div>
 
   <div class="faq-q">

--- a/pages/favicon.svg
+++ b/pages/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Simply Cyber CPE">
+  <title>Simply Cyber CPE</title>
+  <!-- Shield outline: evokes attestation / certification without leaning on a
+       specific cert-body wordmark. Rounded base, straight shoulders. -->
+  <path d="M32 4 L10 12 V32 C10 46 20 56 32 60 C44 56 54 46 54 32 V12 Z"
+        fill="#0b3d5c"/>
+  <!-- Checkmark path, stroked so it renders crisply at 16px without
+       sub-pixel fill artefacts. Stroke width generous enough to stay
+       visible even when the browser downscales aggressively. -->
+  <path d="M21 33 L29 41 L44 23"
+        fill="none" stroke="#f4d66a" stroke-width="6"
+        stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/pages/index.html
+++ b/pages/index.html
@@ -5,6 +5,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>SC-CPE — Register for CPE Credits</title>
 <link rel="stylesheet" href="/style.css">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="theme-color" content="#0b3d5c">
 <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
 </head>
 <body>

--- a/pages/privacy.html
+++ b/pages/privacy.html
@@ -5,6 +5,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Privacy Policy — SC-CPE</title>
 <link rel="stylesheet" href="/style.css">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="theme-color" content="#0b3d5c">
 </head>
 <body>
 <main class="narrow">
@@ -74,7 +76,7 @@
             <tr>
                 <td>Certificate records (including the <em>recipient name snapshot</em> that appears on each issued certificate)</td>
                 <td>Retained indefinitely, even after account deletion</td>
-                <td>Evidentiary artefact — third parties (employers, (ISC)²/ISACA auditors) rely on these to verify CPE submissions years after issuance. Retained under GDPR Art. 17(3)(e) for the establishment, exercise or defence of legal claims.</td>
+                <td>Evidentiary artefact — third parties (certification bodies like (ISC)² / ISACA / CompTIA during CPE audit; employers or compliance reviewers requesting continuing-education records) rely on these to verify CPE submissions years after issuance. Retained under GDPR Art. 17(3)(e) for the establishment, exercise or defence of legal claims.</td>
             </tr>
             <tr>
                 <td>Audit log</td>
@@ -89,7 +91,7 @@
         </tbody>
     </table>
     <p>When you request account deletion, we scrub your profile-level personal identifiers (email, legal name, YouTube channel ID, most-recent display name) and rotate your dashboard access token so the account becomes inaccessible. Audit log entries referencing your account are retained for 7 years but are not used for any purpose other than integrity and fraud review. Profile scrubbing is completed immediately on request; a hard-delete of residual identifiers is completed within 30 days.</p>
-    <p><strong>Evidentiary carve-out for issued certificates.</strong> Each certificate we issue contains a <em>recipient name snapshot</em> fixed at the moment of issuance. That snapshot, together with the certificate's hash and signature, is an evidentiary record relied upon by third parties (employers, (ISC)²/ISACA, ISC2 chapter CPE reviewers) to verify CPE attendance — often years later. If we erased or modified those records on account deletion, every certificate you had previously been issued would become unverifiable and we would lose the ability to defend the integrity of the programme. We therefore retain issued certificate records, including the recipient name snapshot, indefinitely under GDPR Art. 17(3)(e) ("establishment, exercise or defence of legal claims") even after you delete your account. The snapshot does <em>not</em> update to reflect your deletion; it reflects the name that was on the certificate at issuance.</p>
+    <p><strong>Evidentiary carve-out for issued certificates.</strong> Each certificate we issue contains a <em>recipient name snapshot</em> fixed at the moment of issuance. That snapshot, together with the certificate's hash and signature, is an evidentiary record relied upon by third parties (certification bodies such as (ISC)², ISACA, and CompTIA during CPE audit cycles; employers or compliance reviewers requesting continuing-education records) to verify CPE attendance — often years later. If we erased or modified those records on account deletion, every certificate you had previously been issued would become unverifiable and we would lose the ability to defend the integrity of the programme. We therefore retain issued certificate records, including the recipient name snapshot, indefinitely under GDPR Art. 17(3)(e) ("establishment, exercise or defence of legal claims") even after you delete your account. The snapshot does <em>not</em> update to reflect your deletion; it reflects the name that was on the certificate at issuance.</p>
 
     <h2>5. Who We Share Data With</h2>
     <p>We do not sell your personal data. We share data only with the following sub-processors, who act on our instructions:</p>

--- a/pages/recover.html
+++ b/pages/recover.html
@@ -5,6 +5,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>SC-CPE — Recover your dashboard link</title>
 <link rel="stylesheet" href="/style.css">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="theme-color" content="#0b3d5c">
 <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
 </head>
 <body>

--- a/pages/status.html
+++ b/pages/status.html
@@ -5,6 +5,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>SC-CPE — Status</title>
 <link rel="stylesheet" href="/style.css">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="theme-color" content="#0b3d5c">
 <style>
   .status-hero { padding: 18px 24px; border-radius: 6px; margin: 12px 0 20px; font-weight: 600; }
   .status-hero.ok { background: #0e3a1a; border: 1px solid #1e6b3a; color: #9beab2; }

--- a/pages/terms.html
+++ b/pages/terms.html
@@ -5,6 +5,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Terms of Service — SC-CPE</title>
 <link rel="stylesheet" href="/style.css">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="theme-color" content="#0b3d5c">
 </head>
 <body>
 <main class="narrow">

--- a/pages/verify.html
+++ b/pages/verify.html
@@ -5,6 +5,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>SC-CPE — Verify Certificate</title>
 <link rel="stylesheet" href="/style.css">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="theme-color" content="#0b3d5c">
 </head>
 <body>
 <main class="narrow">


### PR DESCRIPTION
Two things in one PR.

1. "employer's CPE audit" was wrong in four places. It's CERTIFICATION
   BODIES (ISC2, ISACA, CompTIA) that audit CPE submissions, not
   employers. Employers may reference the cert for reimbursement or
   performance-review purposes, but they don't run formal CPE audits.
   A CISSP reading the old copy would spot this immediately.

   Fixed in:
   - pages/faq.html §per-session-vs-bundle — reframes the trigger for
     per-session certs as "your certification body's audit process,"
     not the employer's, and notes ISC2/ISACA/CompTIA all accept
     bundled multi-activity records so per-session is almost never
     required.
   - pages/dashboard.html cert-style picker copy — same reframe.
   - pages/privacy.html §4 retention table + Art. 17(3)(e) carve-out
     paragraph — acknowledges employers as third-party READERS of the
     cert (legitimate use case — reimbursement, compliance review) but
     names certification bodies as the actual AUDITORS.

2. Favicon: every HTML page had no favicon, so browser tabs were
   anonymous globes. Added:
   - pages/favicon.svg — path-based SVG (no font dependency, renders
     clean at 16px through 512px) with a shield-and-checkmark in the
     admin navy #0b3d5c + cert gold #f4d66a palette. Evokes
     attestation without leaning on a specific cert-body wordmark.
   - <link rel="icon" type="image/svg+xml" href="/favicon.svg"> and
     <meta name="theme-color" content="#0b3d5c"> injected into every
     public HTML page (9 files). theme-color gives the mobile browser
     chrome the same navy accent.

No behaviour change. 130/130 tests still green.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
