### PR TITLE
fix(smoke): rotate preflight channel per-RUN (not per-hour) to absorb push bursts

### DIFF
--- a/scripts/smoke_hardening.sh
+++ b/scripts/smoke_hardening.sh
@@ -47,13 +47,15 @@ check "me/delete cross-origin → 403" 403 "$(code -X POST \
     "$ORIGIN/api/me/$FAKE_TOKEN/delete")"
 
 echo "== preflight/channel rate limit =="
-# Smoke runs hourly. The per-channel cap (hardened to 10/day in PR #9)
-# would trip if we reused one channel ID across 24 hourly probes, so we
-# rotate the probe target on the UTC hour: UC + SMOKE + YYYYMMDDHH + 7
-# zeros = 24 chars total, matching /^UC[0-9A-Za-z_-]{22}$/. Channel IDs
-# that start with SMOKE aren't real YouTube IDs, so the probe always
-# returns available=true (no binding in prod).
-SMOKE_CH="UCSMOKE$(date -u +%Y%m%d%H)0000000"
+# The per-channel cap (10/day from PR #9) gates enumeration of ONE
+# target channel across rotating IPs. Smoke needs to probe the endpoint
+# without contributing to that cap, so we generate a FRESH random
+# 22-char suffix per run — 11 pushes within an hour each get their own
+# channel id, no cap collision. The first-post-deploy-smoke +
+# every-hourly-cron + every-push-to-main cadence otherwise piles up in
+# a single UTC hour when launch traffic is busy. Random is fine; the
+# endpoint only checks format + uniqueness, not YouTube reachability.
+SMOKE_CH="UC$(tr -dc '0-9A-Za-z_-' </dev/urandom | head -c 22)"
 check "well-formed channel probe → 200" 200 "$(code "$ORIGIN/api/preflight/channel?q=$SMOKE_CH")"
 
 echo "== audit-chain-verify =="


### PR DESCRIPTION
PR #20 rotated the smoke probe's channel id by UTC hour to dodge the
10/day per-channel cap. That's enough for steady-state: one hourly cron
run = one probe per hour per channel, comfortably under 10.

Breaks under launch-day push bursts. A day with 9 PR merges fires
roughly 9 post-deploy-smoke runs PLUS 9 push-triggered smoke runs
(both use scripts/smoke_hardening.sh) PLUS the hourly cron — all
hitting the same UTC-hour-derived channel id. 10th probe returns 429,
deploy-prod goes red, Discord alerts fire on a healthy deploy.

Per-RUN rotation fixes this: generate a fresh random 22-char suffix
every smoke invocation. 9 PRs in an hour now hit 9 different channel
ids, none approach the cap. /dev/urandom filtered to the YouTube
channel-id charset (0-9A-Za-z_-) gives a valid id on every run.

The endpoint's rate-limit semantic (10/day per channel across all
IPs) is intentional as an anti-enumeration signal against real user
channels; smoke's synthetic SMOKE-prefixed ids weren't the target.
Random ids are equally synthetic and don't collide with legit traffic.

Closes the second of three collateral smoke issues surfaced while
verifying Discord alerts (PR #19: YAML parse silent-fail fixed; PR
#20: per-hour rotation — superseded by this; PR #21: canary
bootstrap — unchanged).

No test changes; smoke is CI-only.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
