### PR TITLE
feat(ci): post-launch hardening — Dependabot + CodeQL + weekly audit-chain verify

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+
+# Post-launch dependency hygiene. Weekly cadence is a compromise: frequent
+# enough that security fixes land in reasonable time, infrequent enough
+# that PR noise doesn't drown the operator. Auto-merge stays OFF — every
+# dependency bump still runs the full test suite + gitleaks + CodeQL, and
+# landing is manual via the normal PR flow.
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+
+  - package-ecosystem: pip
+    directory: /services/certs
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - python
+
+# Notes:
+#  - No npm ecosystem: pages/functions and workers/* don't carry a
+#    package.json; runtime is Cloudflare's, not node_modules-based.
+#  - No terraform/npm-workspaces/composer/docker entries for the same
+#    reason — this repo's only dependency graphs are GH Actions YAML
+#    and services/certs/requirements.txt.

--- a/.github/workflows/audit-chain-weekly.yml
+++ b/.github/workflows/audit-chain-weekly.yml
@@ -1,0 +1,62 @@
+name: audit-chain-weekly
+
+# Runs scripts/verify_audit_chain.py against live D1 every Monday. The
+# audit chain is a core trust claim — manual operator runs are "fake
+# controls" that silently drift. This catches any chain break within
+# seven days, and the push-triggered + workflow_dispatch hooks let an
+# operator fire it on demand after a suspicious admin event.
+#
+# On failure: Discord ping. Exit-code semantics from the script:
+#   0 — chain is intact.
+#   1 — chain is broken (details on stderr).
+#   2 — precondition error (env vars missing, HTTP failure, etc.).
+# Both 1 and 2 alert; the Discord body doesn't distinguish because the
+# operator needs to investigate either way.
+
+on:
+  schedule:
+    - cron: "0 5 * * 1"  # Mon 05:00 UTC (post-schema-drift, pre-ops-morning)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: audit-chain-weekly
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify audit chain integrity
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
+      DISCORD_ALERT_WEBHOOK: ${{ secrets.DISCORD_ALERT_WEBHOOK }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install requests
+        run: python3 -m pip install --quiet requests
+
+      - name: Run audit-chain verifier
+        run: python3 scripts/verify_audit_chain.py
+
+      - name: Alert Discord on failure
+        if: failure()
+        run: |
+          if [[ -z "${DISCORD_ALERT_WEBHOOK:-}" ]]; then
+            echo "DISCORD_ALERT_WEBHOOK unset — skipping"; exit 0
+          fi
+          payload=$(jq -cn \
+            --arg c ":rotating_light: **SC-CPE: audit-chain verify FAILED** on ${{ github.sha }} — chain integrity compromised or D1 unreachable. Investigate via /api/admin/audit-chain-verify or rerun scripts/verify_audit_chain.py with live creds. See Actions run ${{ github.run_id }}." \
+            '{content: $c, username: "SC-CPE Chain"}')
+          curl -fsS --max-time 20 \
+            -H "Content-Type: application/json" \
+            -X POST -d "$payload" "$DISCORD_ALERT_WEBHOOK" >/dev/null

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,54 @@
+name: codeql
+
+# Static analysis via CodeQL. Runs on every PR to main and weekly on a
+# Monday cron. JS covers pages/functions + workers/*; Python covers
+# services/certs. gitleaks already runs in ci.yml for secret scanning —
+# CodeQL layers in taint-flow and logic-bug detection that gitleaks
+# doesn't do.
+#
+# Findings land in the repo's Security tab (Code scanning alerts).
+# High-severity findings fail the PR check; medium + low are advisory.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 4 * * 1"  # Mon 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, python]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@9887d98ae49f1f598651b556d8c8f02f3ea065cb  # v3.27.0
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@9887d98ae49f1f598651b556d8c8f02f3ea065cb  # v3.27.0
+
+      - name: Perform analysis
+        uses: github/codeql-action/analyze@9887d98ae49f1f598651b556d8c8f02f3ea065cb  # v3.27.0
+        with:
+          category: /language:${{ matrix.language }}

--- a/docs/POST_LAUNCH_HARDENING.md
+++ b/docs/POST_LAUNCH_HARDENING.md
@@ -1,0 +1,128 @@
+# Post-launch hardening roadmap
+
+Durable list of security/hardening items identified after the
+go-live. Three items (Dependabot, CodeQL, weekly audit-chain verify)
+shipped with this document; the rest are tracked here with concrete
+fix shapes so they don't drift into "someday." Ordered by codex's
+priority ranking (attacker ROI × likelihood / fix cost).
+
+## Shipped with this commit
+
+- [x] **Dependabot weekly.** `.github/dependabot.yml` — GH Actions +
+      pip ecosystems, Mon 09:00 ET cadence, auto-merge OFF (manual
+      review per bump).
+- [x] **CodeQL SAST.** `.github/workflows/codeql.yml` — JS +
+      Python on PR/push + weekly cron. High-severity fails the PR.
+- [x] **Weekly automated audit-chain verify.** `.github/workflows/
+      audit-chain-weekly.yml` — runs `scripts/verify_audit_chain.py`
+      every Monday, Discord-pings on failure.
+
+## Open (ordered by priority)
+
+### 1. CSP `unsafe-inline` removal
+
+- Location: [`pages/functions/_middleware.js:16`](../pages/functions/_middleware.js),
+  every `<style>` and inline `<script>` block across `pages/*.html`.
+- Problem: CSP still allows `'unsafe-inline'` on `script-src` and
+  `style-src`. One HTML-injection via user-rendered content = script
+  execution. The biggest remaining web-tier attack surface.
+- Fix path: externalise inline JS to `/*.js` files, externalise
+  inline CSS to `/style.css` (or per-page files), then tighten the
+  CSP header to drop `'unsafe-inline'`. Use nonces only as a last
+  resort for a handful of blocks that can't be externalised.
+- Estimate: 1–2 days, one PR per page to keep each diff reviewable.
+- Gate to starting: first-week mobile + a11y hands-on pass, so we
+  don't migrate styles that are about to change.
+
+### 2. Signed commits + signed release tags
+
+- Location: repo-wide, affects every future commit + any tag.
+- Problem: a compromised GitHub session can push unsigned commits
+  that auto-deploy. Provenance is weaker than it looks.
+- Fix path: maintainer generates GPG key, enables
+  `commit.gpgsign=true` + `tag.gpgsign=true` in their local config,
+  adds the public key to GitHub profile. Turn on the "Require signed
+  commits" branch-protection rule on `main`. Add `--verify-signatures`
+  to the deploy workflow's checkout step. Cut annotated `v1.x.y`
+  release tags per deploy for rollback clarity.
+- Estimate: ~1 hour operator setup + a small CI PR.
+
+### 3. D1 + R2 backup / DR
+
+- Location: runbook (`docs/RUNBOOK.md`) has no backup procedure; no
+  scheduled export workflow.
+- Problem: recovery posture is entirely implicit. One operator
+  `wrangler d1 execute` typo or a Cloudflare incident and we're
+  reconstructing from audit-log fragments.
+- Fix path: write RPO/RTO targets (proposal: RPO 24h, RTO 4h), add
+  a weekly workflow that runs `wrangler d1 export` + R2 object-
+  version snapshot into a separate R2 bucket with 90-day retention,
+  document the restore drill in RUNBOOK. Rehearse once.
+- Estimate: 1 day. Needs a second R2 bucket.
+
+### 4. Turnstile bootstrap SRI / drift monitoring
+
+- Location: [`pages/index.html:12`](../pages/index.html),
+  [`pages/recover.html:12`](../pages/recover.html).
+- Problem: the Turnstile `api.js` is loaded without integrity
+  attribute. If Cloudflare's CDN is compromised or they silently
+  change the bootstrap, our pages execute it.
+- Fix path: Cloudflare doesn't publish stable SRI hashes for
+  Turnstile (the bootstrap changes to ship A/B variants), so hard-
+  pinning isn't feasible. Instead: schedule a weekly hash-drift
+  check that pins the current hash, alerts on change, and requires
+  a human to re-approve. Low operational cost, eyes on a rarely-
+  changing critical boundary.
+- Estimate: 2 hours for the drift monitor.
+
+### 5. Real-traffic rate-limit re-tune plan
+
+- Location: [`register.js:12`](../pages/functions/api/register.js),
+  [`recover.js:57`](../pages/functions/api/recover.js),
+  [`preflight/channel.js:60`](../pages/functions/api/preflight/channel.js),
+  [`me/[token].js:13`](../pages/functions/api/me/[token].js).
+- Problem: rate limits are launch guesses. Two-week post-launch
+  measurement will show which caps never get hit (loosen) and
+  which produce false-positives (investigate).
+- Fix path: 14 days after launch, query `audit_log` for
+  `rate_limited` audit writes per endpoint, cross-reference against
+  any `[ACCOUNT]` support mail, adjust based on the p95 hit-rate
+  of legit flows. Write findings into `docs/SLO.md` so next
+  operator knows the reasoning.
+- Estimate: 2 hours of query + write-up at T+14 days.
+
+### 6. Deploy-path reviewer gate
+
+- Location: [`.github/workflows/deploy-prod.yml:55`](../.github/workflows/deploy-prod.yml).
+- Problem: auto-deploy from `main` means one compromised maintainer
+  session ships anything. The `production` GH environment has no
+  required reviewers configured.
+- Fix path: add one required reviewer (the operator themselves, or
+  a bot account) to the `production` environment gate. Non-tag
+  deploys require click-to-approve. Trade-off: adds ~30s of
+  operator friction per deploy. For a cert issuer, reasonable.
+- Estimate: 5 minutes of GH Settings clicks.
+
+### 7. HSTS preload submission
+
+- Location: [`_middleware.js:50`](../pages/functions/_middleware.js),
+  README trust section.
+- Problem: HSTS is on but preload isn't submitted. Browsers can be
+  downgrade-attacked on first visit.
+- Fix path: blocked on `cpe.simplycyber.io` apex DNS wiring
+  (documented as in-flight). Once the operator-controlled apex is
+  canonical, set `max-age=63072000; includeSubDomains; preload`
+  and submit at `hstspreload.org`.
+- Estimate: 5 minutes, post-DNS.
+
+## Cadence
+
+Aim: one hardening item per 1–2 week sprint for the next 60 days.
+Codex's priority ordering is the default — skip past #1 only if
+launch-day data makes one of the others more urgent (e.g., a real
+CSP escape would jump CSP to P0).
+
+## Review
+
+Re-run the codex hardening sweep at T+30 and T+90. Expect new
+items to surface once real traffic data is in; close stale ones.


### PR DESCRIPTION
Three of codex's top-10 post-launch items ship here because they're CI-
only wiring with immediate payoff and no code-surface risk. The other
seven are captured in docs/POST_LAUNCH_HARDENING.md with concrete fix
shapes so they don't drift into "someday."

1. .github/dependabot.yml — GH Actions + pip ecosystems, Mon 09:00 ET
   cadence. Auto-merge OFF (each bump still runs the full CI gate and
   lands by manual review). No npm ecosystem: pages/functions and
   workers/* don't carry package.json; runtime is Cloudflare's, not
   node_modules-based.

2. .github/workflows/codeql.yml — CodeQL on JS + Python, PR/push/weekly.
   High-severity findings fail the PR; medium/low are advisory. Layers
   taint-flow + logic-bug detection onto the existing gitleaks secret
   scan. Action pinned to github/codeql-action@v3.27.0 SHA per the
   repo's pinning convention.

3. .github/workflows/audit-chain-weekly.yml — runs
   scripts/verify_audit_chain.py every Mon 05:00 UTC, posts to Discord
   on exit != 0 (chain-break or D1-unreachable both alert). The audit
   chain is a core trust claim; "operator remembers to run the script
   weekly" is a fake control — this is a real one.

docs/POST_LAUNCH_HARDENING.md tracks the remaining codex items:
  - CSP unsafe-inline removal (biggest remaining web-tier surface)
  - Signed commits + release tags
  - D1/R2 backup + DR with RPO/RTO
  - Turnstile bootstrap hash-drift monitor
  - Rate-limit re-tune at T+14 days from real traffic
  - Deploy-path reviewer gate on the production env
  - HSTS preload after cpe.simplycyber.io apex DNS wiring

Each has file:line references, fix shape, estimate, and any
prerequisites (e.g., HSTS preload waits on apex DNS). Review cadence
documented: one item per 1–2 week sprint, full re-sweep at T+30
and T+90.

No behavioural change on the service itself. 130/130 tests still green.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
