### PR TITLE
fix(ci): retry-with-backoff on wrangler deploy steps to tolerate CF API flake

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -52,7 +52,25 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      # Same retry-with-backoff pattern as the worker deploys below.
       - name: wrangler pages deploy
+        id: pages_deploy
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd  # v3.15.0
+        continue-on-error: true
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_DEPLOY_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: pages
+          command: pages deploy . --project-name sc-cpe-web --branch main --commit-dirty=true
+
+      - name: Wait before retry
+        if: steps.pages_deploy.outcome == 'failure'
+        run: |
+          echo "First wrangler pages deploy attempt failed — CF API may be flaky. Waiting 20s before retry."
+          sleep 20
+
+      - name: wrangler pages deploy (retry)
+        if: steps.pages_deploy.outcome == 'failure'
         uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd  # v3.15.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_DEPLOY_TOKEN }}
@@ -72,7 +90,32 @@ jobs:
         worker: [purge, poller, email-sender]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      # First attempt. continue-on-error so a transient CF Workers API
+      # 503 (e.g. wrangler's pre-publish GET to /workers/services/...)
+      # doesn't immediately fail the job — we give it one retry below.
+      # PR #29 launch-day: CF 503'd on sc-cpe-purge's pre-publish GET
+      # three times in a row even though the worker itself was healthy.
+      # A single retry with 20s backoff recovered every subsequent CF
+      # blip observed during the first launch week.
       - name: wrangler deploy
+        id: deploy
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd  # v3.15.0
+        continue-on-error: true
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_DEPLOY_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: workers/${{ matrix.worker }}
+          command: deploy
+
+      - name: Wait before retry
+        if: steps.deploy.outcome == 'failure'
+        run: |
+          echo "First wrangler deploy attempt failed — CF API may be flaky. Waiting 20s before retry."
+          sleep 20
+
+      - name: wrangler deploy (retry)
+        if: steps.deploy.outcome == 'failure'
         uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd  # v3.15.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_DEPLOY_TOKEN }}


### PR DESCRIPTION
Triggered by the PR #29 deploy failure: Cloudflare's Workers API
returned 503 three times in a row on wrangler's pre-publish GET to
/workers/services/sc-cpe-purge, blocking the overall deploy-prod run
even though the purge worker itself was healthy (heartbeat ok, not
stale) and PR #29 didn't touch worker code at all — it was a zero-
change redeploy that CF couldn't confirm.

Pattern applied to every wrangler-action step in deploy-prod.yml:

  - id: <step>            # continue-on-error: true
    wrangler deploy
  - if: step outcome == failure → sleep 20
  - if: step outcome == failure → wrangler deploy (retry)

If the first attempt succeeds, the retry steps are skipped. If the
first fails, continue-on-error keeps the job running, a 20-second
backoff sleeps, then the second attempt runs. Only if both attempts
fail does the job fail for real.

Applied to:
  - deploy-pages job's wrangler pages deploy
  - deploy-workers matrix job's wrangler deploy (per worker)

Not applied to verify-deploy's smoke step — smoke failures are signal,
not noise; retrying a smoke run can mask a real regression.

No behaviour change on successful deploys. No test changes.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
