### PR TITLE
fix(ci): alert-on-failure jobs — dedupe on first attempt only

### DIFF
--- a/.github/workflows/audit-chain-weekly.yml
+++ b/.github/workflows/audit-chain-weekly.yml
@@ -49,7 +49,7 @@ jobs:
         run: python3 scripts/verify_audit_chain.py
 
       - name: Alert Discord on failure
-        if: failure()
+        if: failure() && github.run_attempt == 1   # silence on manual rerun
         run: |
           if [[ -z "${DISCORD_ALERT_WEBHOOK:-}" ]]; then
             echo "DISCORD_ALERT_WEBHOOK unset — skipping"; exit 0

--- a/.github/workflows/cert-sign-pending.yml
+++ b/.github/workflows/cert-sign-pending.yml
@@ -72,7 +72,7 @@ jobs:
   alert-on-failure:
     name: Discord alert on cert-sign-pending failure
     needs: pickup
-    if: failure()
+    if: failure() && github.run_attempt == 1   # silence on manual rerun
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -144,7 +144,12 @@ jobs:
   alert-on-failure:
     name: Discord alert on deploy failure
     needs: [test, deploy-pages, deploy-workers, verify-deploy]
-    if: failure()
+    # github.run_attempt == 1 suppresses re-pings when an operator
+    # reruns a failed run — the first attempt's alert already
+    # delivered the signal. Complements PR #39's step-level retry
+    # (which catches in-run transient flakes) by covering the
+    # manual-rerun case.
+    if: failure() && github.run_attempt == 1
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/monthly-certs.yml
+++ b/.github/workflows/monthly-certs.yml
@@ -97,7 +97,7 @@ jobs:
   alert-on-failure:
     name: Discord alert on monthly-certs failure
     needs: generate
-    if: failure()
+    if: failure() && github.run_attempt == 1   # silence on manual rerun
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/schema-drift.yml
+++ b/.github/workflows/schema-drift.yml
@@ -35,7 +35,7 @@ jobs:
           : "${D1_DATABASE_ID:?set secret}"
           bash scripts/check_schema.sh --http
       - name: Alert Discord on drift
-        if: failure()
+        if: failure() && github.run_attempt == 1   # silence on manual rerun
         run: |
           if [[ -z "${DISCORD_ALERT_WEBHOOK:-}" ]]; then
             echo "DISCORD_ALERT_WEBHOOK not set — skipping"


### PR DESCRIPTION
Operator got 3 identical Discord pings for the same failed
deploy-prod run (545580a9) today because we manually reran that
workflow three times to chase a CF Workers API 503. Every rerun
re-fires the alert-on-failure job — that's noise amplification,
not signal.

Added `github.run_attempt == 1` to every alert step/job that fires
on `if: failure()`:

  .github/workflows/deploy-prod.yml       (alert-on-failure job)
  .github/workflows/monthly-certs.yml     (alert-on-failure job)
  .github/workflows/cert-sign-pending.yml (alert-on-failure job)
  .github/workflows/schema-drift.yml      (inline Alert Discord step)
  .github/workflows/audit-chain-weekly.yml (inline Alert Discord step)

Not touched:
  smoke.yml    — already rate-limited by the hourly cron cadence;
                 per-attempt guard is wrong shape for the cron.
  watchdog.yml — has full source-level dedup via /api/watchdog-state
                 KV; smarter than per-attempt.

Complements PR #39 (retry-with-backoff on wrangler deploy steps):
  - PR #39 suppresses in-run step flakes (CF transient 503 on first
    attempt is silently retried).
  - This PR suppresses cross-attempt spam (manual rerun of a fully-
    failed run doesn't re-ping).

Together: operator gets exactly one Discord message per *actual*
failure, regardless of CF-side flakes or rerun clicks.

No behaviour change on successful runs. No code touched.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
