### PR TITLE
feat(ui): responsive fixes from real-device pass

### DIFF
--- a/pages/admin.html
+++ b/pages/admin.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
 <title>SC-CPE Admin</title>
 <meta name="robots" content="noindex,nofollow">
 <link rel="stylesheet" href="/style.css">

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
 <title>SC-CPE — My Dashboard</title>
 <link rel="stylesheet" href="/style.css">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
 <title>SC-CPE — FAQ &amp; Known Issues</title>
 <link rel="stylesheet" href="/style.css">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/pages/index.html
+++ b/pages/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
 <title>SC-CPE — Register for CPE Credits</title>
 <link rel="stylesheet" href="/style.css">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -27,15 +27,15 @@
         </label>
         <label class="check">
             <input type="checkbox" name="legal_name_attested" required>
-            I certify the name above is my legal name and matches the name on my professional certifications.
+            <span>I certify the name above is my legal name and matches the name on my professional certifications.</span>
         </label>
         <label class="check">
             <input type="checkbox" name="age_attested_13plus" required>
-            I am 13 years of age or older.
+            <span>I am 13 years of age or older.</span>
         </label>
         <label class="check">
             <input type="checkbox" name="tos" required>
-            I accept the <a href="/terms.html">Terms of Service</a> and <a href="/privacy.html">Privacy Policy</a>.
+            <span>I accept the <a href="/terms.html">Terms of Service</a> and <a href="/privacy.html">Privacy Policy</a>.</span>
         </label>
         <div class="cf-turnstile" data-sitekey="0x4AAAAAAC9lHHxbfTKNzdFN" data-theme="auto"></div>
         <button type="submit">Register</button>

--- a/pages/privacy.html
+++ b/pages/privacy.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
 <title>Privacy Policy — SC-CPE</title>
 <link rel="stylesheet" href="/style.css">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/pages/recover.html
+++ b/pages/recover.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
 <title>SC-CPE — Recover your dashboard link</title>
 <link rel="stylesheet" href="/style.css">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/pages/status.html
+++ b/pages/status.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
 <title>SC-CPE — Status</title>
 <link rel="stylesheet" href="/style.css">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/pages/style.css
+++ b/pages/style.css
@@ -58,10 +58,18 @@ body {
 main.narrow {
     max-width: 640px;
     margin: 1rem auto;               /* mobile-default; bumped up at ≥640px below */
-    padding: 0 1rem;
+    /* Bottom padding absorbs iOS home-indicator safe area + gives the
+       submit button clearance from Safari/Chrome mobile's URL bar, which
+       otherwise visually covers the button at scroll-bottom. */
+    padding: 0 1rem max(1.5rem, env(safe-area-inset-bottom) + 1rem);
 }
 @media (min-width: 640px) {
     main.narrow { margin: 2rem auto; }
+}
+/* Wider viewports: nudge max-width up so the column doesn't feel lost in
+   a 1440px+ browser, while staying within readable measure (~80ch). */
+@media (min-width: 960px) {
+    main.narrow { max-width: 720px; }
 }
 h1 { font-size: 1.75rem; margin-bottom: .25rem; line-height: 1.2; }
 h2 { font-size: 1.25rem; margin-top: 1.5rem; line-height: 1.3; }
@@ -92,7 +100,12 @@ form .check {
     font-weight: 400;
     margin-bottom: .75rem;
 }
-form .check input { margin-top: .25rem; }
+form .check input { margin-top: .25rem; flex: 0 0 auto; }
+/* The text (and any nested links) must live in a single child so the
+   flex container doesn't split it into per-word items that wrap into
+   pseudo-columns on narrow screens. min-width:0 lets it actually shrink
+   inside the flex row instead of forcing horizontal overflow. */
+form .check > span { flex: 1 1 auto; min-width: 0; }
 button {
     /* 44px floor matches the iOS HIG + WCAG 2.5.5 (enhanced) target size.
        rem-based so user text-scaling grows it too. */

--- a/pages/terms.html
+++ b/pages/terms.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
 <title>Terms of Service — SC-CPE</title>
 <link rel="stylesheet" href="/style.css">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/pages/verify.html
+++ b/pages/verify.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
 <title>SC-CPE — Verify Certificate</title>
 <link rel="stylesheet" href="/style.css">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">


### PR DESCRIPTION
## Summary

Three issues surfaced from real-device screenshots (iPhone dark-mode + Edge desktop dark-mode):

1. **Tri-part ToS checkbox wrapped into pseudo-columns on mobile.** Flex container was splitting each text node + nested link into separate flex items, so "I accept the" / "Terms of Service" / "and" / "Privacy Policy" wrapped as independent columns. Wrapped the full label text in a `<span>` so it becomes a single inline-flow item that wraps as prose. Applied to all three `.check` labels for consistent markup. CSS gained a defensive `form .check > span { flex: 1 1 auto; min-width: 0 }` rule.

2. **Register button hidden under iOS Safari URL bar.** `main.narrow` now has `padding-bottom: max(1.5rem, env(safe-area-inset-bottom) + 1rem)`. Added `viewport-fit=cover` to every page's viewport meta so the `safe-area-inset-*` values actually resolve on iOS.

3. **640px column looked lost at 1440px+ viewports.** New `@media (min-width: 960px)` bumps `main.narrow` max-width to 720px — still within readable-measure (~80ch), just visually more comfortable on desktop monitors.

## Test plan

- [x] `bash scripts/test.sh` → 130/130 green
- [ ] Check on iPhone Safari: Register button clears URL bar at scroll-bottom, ToS checkbox wraps as a single paragraph
- [ ] Check on desktop Edge at 1920px: content column feels less lost but still reads comfortably
- [ ] Check dashboard/admin/verify pages: no regressions from the viewport-meta update or extra bottom padding
- [ ] Smoke run post-deploy: `ADMIN_TOKEN=… ORIGIN=https://sc-cpe-web.pages.dev scripts/smoke_hardening.sh`