### PR TITLE
feat(links): Show Links Archive page

### DIFF
--- a/db/migrations/005_show_links.sql
+++ b/db/migrations/005_show_links.sql
@@ -1,0 +1,23 @@
+-- Links shared by host/moderators during the Daily Threat Briefing.
+-- Poller extracts URLs inline; purge worker enriches with page metadata.
+
+CREATE TABLE show_links (
+    id            TEXT PRIMARY KEY,
+    stream_id     TEXT NOT NULL REFERENCES streams(id),
+    url           TEXT NOT NULL,
+    domain        TEXT NOT NULL,
+    title         TEXT,
+    description   TEXT,
+    author_type   TEXT NOT NULL DEFAULT 'owner',
+    author_name   TEXT NOT NULL,
+    yt_channel_id TEXT NOT NULL,
+    yt_message_id TEXT NOT NULL,
+    posted_at     TEXT NOT NULL,
+    enriched_at   TEXT,
+    created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+
+    UNIQUE(stream_id, url)
+);
+
+CREATE INDEX idx_show_links_stream ON show_links(stream_id);
+CREATE INDEX idx_show_links_enriched ON show_links(enriched_at) WHERE enriched_at IS NULL;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -217,6 +217,27 @@ CREATE TABLE kv (
     updated_at            TEXT NOT NULL
 );
 
+-- Links shared by host/moderators during the Daily Threat Briefing.
+CREATE TABLE show_links (
+    id            TEXT PRIMARY KEY,
+    stream_id     TEXT NOT NULL REFERENCES streams(id),
+    url           TEXT NOT NULL,
+    domain        TEXT NOT NULL,
+    title         TEXT,
+    description   TEXT,
+    author_type   TEXT NOT NULL DEFAULT 'owner',
+    author_name   TEXT NOT NULL,
+    yt_channel_id TEXT NOT NULL,
+    yt_message_id TEXT NOT NULL,
+    posted_at     TEXT NOT NULL,
+    enriched_at   TEXT,
+    created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+
+    UNIQUE(stream_id, url)
+);
+CREATE INDEX idx_show_links_stream ON show_links(stream_id);
+CREATE INDEX idx_show_links_enriched ON show_links(enriched_at) WHERE enriched_at IS NULL;
+
 -- Cert-correctness feedback. See db/migrations/002_cert_feedback.sql for rationale.
 CREATE TABLE cert_feedback (
     id              TEXT PRIMARY KEY,

--- a/docs/superpowers/specs/2026-04-22-show-links-archive-design.md
+++ b/docs/superpowers/specs/2026-04-22-show-links-archive-design.md
@@ -1,0 +1,186 @@
+# Show Links Archive — Design Spec
+
+**Date:** 2026-04-22
+**Requested by:** Gerry (Simply Cyber)
+**Status:** Approved
+
+## Summary
+
+A public page that archives all links shared by the host and moderators during the Daily Threat Briefing livestream, organized by show date. Links are extracted inline by the poller, enriched with page titles/descriptions asynchronously by the purge worker, and served via a new public API endpoint.
+
+## Scope
+
+**MVP (this spec):**
+- Extract URLs from owner + moderator chat messages in the poller
+- Persist to a new `show_links` D1 table
+- Enrich with page title + og:description via the purge worker's daily run
+- New public API endpoint `GET /api/links`
+- New public page `links.html` with date-based navigation
+
+**Future (out of scope):**
+- Viewer-submitted links (author_type = 'viewer') — schema supports it, filter change only
+- Search/filter across all dates
+- Domain-based grouping or icons
+
+## Database Schema
+
+Migration `005_show_links.sql`:
+
+```sql
+CREATE TABLE show_links (
+  id            TEXT PRIMARY KEY,
+  stream_id     TEXT NOT NULL REFERENCES streams(id),
+  url           TEXT NOT NULL,
+  domain        TEXT NOT NULL,
+  title         TEXT,
+  description   TEXT,
+  author_type   TEXT NOT NULL DEFAULT 'owner',
+  author_name   TEXT NOT NULL,
+  yt_channel_id TEXT NOT NULL,
+  yt_message_id TEXT NOT NULL,
+  posted_at     TEXT NOT NULL,
+  enriched_at   TEXT,
+  created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+
+  UNIQUE(stream_id, url)
+);
+
+CREATE INDEX idx_show_links_stream ON show_links(stream_id);
+CREATE INDEX idx_show_links_enriched ON show_links(enriched_at) WHERE enriched_at IS NULL;
+```
+
+- `UNIQUE(stream_id, url)` deduplicates the same link posted multiple times per stream.
+- `author_type` is app-enforced: `'owner'` | `'moderator'` (MVP), `'viewer'` (future).
+- `domain` is pre-extracted for frontend display grouping.
+- `enriched_at` is set even on fetch failure to prevent infinite retry.
+
+## Poller Changes
+
+In `workers/poller/src/index.js`, after the existing message processing loop:
+
+1. For each message where `isOwner === true` or `isModerator === true`:
+2. Extract URLs via regex: `https?://[^\s<>"')\]]+`
+3. For each URL:
+   - Skip if `new URL(url)` throws (malformed)
+   - Extract `domain` via `new URL(url).hostname`
+   - `INSERT OR IGNORE INTO show_links` with ULID, stream_id, url, domain, author metadata, posted_at
+4. Batch with existing D1 writes — no new round trips.
+
+No outbound fetches. No title resolution. Poller stays fast.
+
+## Enrichment in Purge Worker
+
+New block in `workers/purge/src/index.js`, runs during the daily 09:00 UTC execution:
+
+1. `SELECT id, url FROM show_links WHERE enriched_at IS NULL LIMIT 50`
+2. For each row:
+   - `fetch(url)` with 5-second timeout
+   - Parse HTML for `og:title` (preferred) or `<title>`, and `og:description`
+   - `UPDATE show_links SET title = ?, description = ?, enriched_at = ? WHERE id = ?`
+3. On fetch failure: set `enriched_at = now`, leave `title` NULL. No infinite retries.
+4. Write heartbeat row for `link_enrichment`.
+
+Budget: 50 rows per run. Typical show produces 5-15 links.
+
+Add `link_enrichment: 86400` to `EXPECTED_CADENCE_S` in both:
+- `pages/functions/_heartbeat.js`
+- `workers/purge/src/index.js`
+
+No audit log entries for enrichment — metadata decoration, not a state change.
+
+## API Endpoint
+
+New file: `pages/functions/api/links.js`
+
+**`GET /api/links`**
+- Public, no auth
+- Rate-limited: 120 req/hr per IP
+- Query params:
+  - `date` (YYYY-MM-DD) — optional, defaults to most recent stream with links
+  - `limit` (int) — optional, max 30, default 30
+  - `offset` (int) — optional, default 0
+
+**Response:**
+```json
+{
+  "date": "2026-04-22",
+  "stream": {
+    "title": "Daily Threat Briefing — April 22, 2026",
+    "yt_video_id": "dQw4w9WgXcQ"
+  },
+  "links": [
+    {
+      "url": "https://www.cisa.gov/news/...",
+      "domain": "www.cisa.gov",
+      "title": "CISA Warns of Critical Vulnerability in...",
+      "description": "The Cybersecurity and Infrastructure...",
+      "author_type": "owner",
+      "author_name": "Gerald Auger",
+      "posted_at": "2026-04-22T12:34:56Z"
+    }
+  ],
+  "available_dates": ["2026-04-22", "2026-04-21", "2026-04-18"]
+}
+```
+
+**SQL:**
+- Links query: join `show_links` on `streams` where `streams.scheduled_date = ?` and `streams.state IN ('live','complete')`, ordered by `posted_at ASC`.
+- Available dates: `SELECT DISTINCT s.scheduled_date FROM streams s WHERE s.id IN (SELECT stream_id FROM show_links) ORDER BY s.scheduled_date DESC LIMIT 60`.
+
+## Frontend
+
+New files: `pages/links.html`, `pages/links.js`, `pages/links.css`
+
+**Layout:**
+- Header: "Show Links Archive" title + subtitle
+- Date navigator: left/right arrows stepping through `available_dates`, current date displayed
+- Link list: each link as a card showing:
+  - Domain pill (e.g., `cisa.gov`)
+  - Title (bold, clickable, opens in new tab) — falls back to raw URL if title is NULL
+  - Description (truncated ~2 lines, if present)
+  - Author label ("Host" / "Moderator") + name
+  - Time posted
+- Empty state: "No links for this date"
+- Nav links to leaderboard and other pages
+
+**Characteristics:**
+- No auth, no tokens, no localStorage
+- Deep-linkable: `links.html?date=2026-04-22`
+- CSP compliant: external JS/CSS only
+- `available_dates` from API drives the date navigator client-side
+
+**Nav integration:** Add "Links" entry to nav on `leaderboard.html` and `badge.html`.
+
+## Deployment
+
+**Migration first:** Apply `005_show_links.sql` to D1 before code deploy.
+
+**Deploy order (automatic via deploy-prod.yml):**
+1. Migration 005 via `wrangler d1 execute`
+2. Poller worker (starts capturing links)
+3. Purge worker (starts enriching)
+4. Pages (API + frontend go live)
+
+**No backfill.** Archive starts from first show after deploy. Links from past streams in the 7-day R2 window are not worth the backfill complexity.
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `db/migrations/005_show_links.sql` | New — migration |
+| `db/schema.sql` | Add `show_links` table definition |
+| `workers/poller/src/index.js` | URL extraction from owner/mod messages |
+| `workers/purge/src/index.js` | Enrichment block + heartbeat |
+| `pages/functions/_heartbeat.js` | Add `link_enrichment` cadence |
+| `pages/functions/api/links.js` | New — API endpoint |
+| `pages/links.html` | New — public page |
+| `pages/links.js` | New — page JS |
+| `pages/links.css` | New — page CSS |
+| `pages/leaderboard.html` | Add nav link |
+| `pages/badge.html` | Add nav link |
+
+## Future Expansion
+
+- **Viewer links:** Change poller filter to include all messages (remove isOwner/isModerator gate). `author_type = 'viewer'` rows appear. Frontend can filter/tab by author_type.
+- **Search:** Add `GET /api/links?q=...` with `LIKE` on title/url/description. Add search bar to page.
+- **Domain grouping:** Frontend groups by `domain` column, optionally with favicon fetch.

--- a/pages/badge.html
+++ b/pages/badge.html
@@ -57,7 +57,7 @@
         </p>
         <p class="muted" style="text-align:center;margin-top:1.5rem;font-size:0.85rem;">
             <a href="/">Register</a> · <a href="/leaderboard.html">Leaderboard</a>
-            · <a href="/faq.html">FAQ</a>
+            · <a href="/links.html">Show Links</a> · <a href="/faq.html">FAQ</a>
         </p>
     </div>
 </main>

--- a/pages/functions/_heartbeat.js
+++ b/pages/functions/_heartbeat.js
@@ -16,6 +16,7 @@ export const EXPECTED_CADENCE_S = {
     email_sender: 300,      // cron=*/2min continuous
     canary: 3600,           // hourly synthetic smoke
     monthly_digest: 2678400, // ~31 days; fires 1st of month
+    link_enrichment: 86400, // daily; piggybacks on purge
 };
 
 // True when `now` falls inside the poller's ET weekday window. Vars come from

--- a/pages/functions/api/links.js
+++ b/pages/functions/api/links.js
@@ -1,0 +1,75 @@
+import { json, clientIp, ipHash, rateLimit } from "../_lib.js";
+
+export async function onRequestGet({ env, request }) {
+    const ipH = await ipHash(clientIp(request));
+    const rl = await rateLimit(env, `links:${ipH}`, 120);
+    if (!rl.ok) return json(rl.body, rl.status);
+
+    const url = new URL(request.url);
+    const dateParam = url.searchParams.get("date");
+    const limit = Math.min(Math.max(parseInt(url.searchParams.get("limit") || "30", 10) || 30, 1), 30);
+    const offset = Math.max(parseInt(url.searchParams.get("offset") || "0", 10) || 0, 0);
+
+    let date = dateParam;
+    if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+        const latest = await env.DB.prepare(`
+            SELECT s.scheduled_date
+              FROM streams s
+             WHERE s.id IN (SELECT stream_id FROM show_links)
+               AND s.state IN ('live','complete')
+          ORDER BY s.scheduled_date DESC
+             LIMIT 1
+        `).first();
+        date = latest?.scheduled_date || null;
+    }
+
+    if (!date) {
+        return json({ date: null, stream: null, links: [], available_dates: [] });
+    }
+
+    const stream = await env.DB.prepare(`
+        SELECT id, title, yt_video_id
+          FROM streams
+         WHERE scheduled_date = ?1
+           AND state IN ('live','complete')
+         LIMIT 1
+    `).bind(date).first();
+
+    let links = [];
+    if (stream) {
+        const rows = await env.DB.prepare(`
+            SELECT url, domain, title, description, author_type,
+                   author_name, posted_at
+              FROM show_links
+             WHERE stream_id = ?1
+          ORDER BY posted_at ASC
+             LIMIT ?2 OFFSET ?3
+        `).bind(stream.id, limit, offset).all();
+        links = (rows.results || []).map(r => ({
+            url: r.url,
+            domain: r.domain,
+            title: r.title,
+            description: r.description,
+            author_type: r.author_type,
+            author_name: r.author_name,
+            posted_at: r.posted_at,
+        }));
+    }
+
+    const datesRs = await env.DB.prepare(`
+        SELECT DISTINCT s.scheduled_date
+          FROM streams s
+         WHERE s.id IN (SELECT stream_id FROM show_links)
+           AND s.state IN ('live','complete')
+      ORDER BY s.scheduled_date DESC
+         LIMIT 60
+    `).all();
+    const available_dates = (datesRs.results || []).map(r => r.scheduled_date);
+
+    return json({
+        date,
+        stream: stream ? { title: stream.title, yt_video_id: stream.yt_video_id } : null,
+        links,
+        available_dates,
+    });
+}

--- a/pages/leaderboard.html
+++ b/pages/leaderboard.html
@@ -41,7 +41,8 @@
         and last initial are shown — email and full name are never displayed.
     </p>
     <p class="muted" style="margin-top:1.5rem;font-size:0.85rem;">
-        <a href="/">Register</a> · <a href="/faq.html">FAQ</a>
+        <a href="/">Register</a> · <a href="/links.html">Show Links</a>
+        · <a href="/faq.html">FAQ</a>
         · <a href="/status.html">Status</a> · <a href="/terms.html">Terms</a>
         &amp; <a href="/privacy.html">Privacy</a>
     </p>

--- a/pages/links.css
+++ b/pages/links.css
@@ -1,0 +1,131 @@
+.date-nav {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    margin: 1.5rem 0;
+}
+.date-btn {
+    min-height: 2.25rem;
+    min-width: 2.25rem;
+    padding: 0.4rem 0.75rem;
+    font-size: 1rem;
+    background: var(--card);
+    color: var(--fg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    cursor: pointer;
+    touch-action: manipulation;
+}
+.date-btn:hover { background: var(--hover-bg); filter: none; }
+.date-btn:disabled { opacity: 0.3; cursor: default; }
+.date-btn:disabled:hover { background: var(--card); }
+.date-label {
+    font-size: 1.1rem;
+    font-weight: 600;
+    min-width: 180px;
+    text-align: center;
+}
+.stream-info {
+    text-align: center;
+    margin-bottom: 1.5rem;
+    font-size: 0.85rem;
+    color: var(--muted);
+}
+.stream-info a { color: var(--accent); text-decoration: none; }
+.stream-info a:hover { text-decoration: underline; }
+
+.link-card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.85rem 1rem;
+    margin: 0.75rem 0;
+    transition: border-color 0.15s;
+}
+.link-card:hover { border-color: var(--border-strong); }
+@media (min-width: 640px) {
+    .link-card { padding: 1rem 1.25rem; }
+}
+.link-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 4px;
+}
+.link-domain {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--accent);
+    background: var(--accent-soft-bg);
+    padding: 2px 8px;
+    border-radius: 4px;
+    white-space: nowrap;
+}
+.link-author {
+    font-size: 11px;
+    color: var(--muted);
+    margin-left: auto;
+    white-space: nowrap;
+}
+.link-author-badge {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 1px 5px;
+    border-radius: 3px;
+    margin-right: 4px;
+}
+.link-author-badge.owner {
+    background: var(--warn-soft-bg);
+    color: var(--warn-soft-text);
+    border: 1px solid var(--warn-soft-border);
+}
+.link-author-badge.moderator {
+    background: var(--info-soft-bg);
+    color: var(--info-soft-text);
+    border: 1px solid var(--info-soft-border);
+}
+.link-title {
+    font-weight: 600;
+    font-size: 1rem;
+    line-height: 1.4;
+}
+.link-title a {
+    color: var(--fg-strong);
+    text-decoration: none;
+}
+.link-title a:hover { color: var(--accent); }
+.link-desc {
+    color: var(--muted);
+    font-size: 0.85rem;
+    line-height: 1.45;
+    margin-top: 4px;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+.link-url {
+    font-size: 0.8rem;
+    color: var(--muted);
+    margin-top: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.link-time {
+    font-size: 0.75rem;
+    color: var(--muted);
+}
+.links-empty {
+    text-align: center;
+    color: var(--muted);
+    padding: 3rem 1rem;
+}

--- a/pages/links.html
+++ b/pages/links.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+<title>SC-CPE — Show Links Archive</title>
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/links.css">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="theme-color" content="#0b3d5c">
+<meta property="og:title" content="SC-CPE Show Links Archive">
+<meta property="og:description" content="Links shared during Simply Cyber's Daily Threat Briefing, archived by date.">
+<meta property="og:type" content="website">
+<script src="/theme.js"></script>
+</head>
+<body>
+<main class="narrow">
+    <h1>Show Links Archive</h1>
+    <p class="lead">Links shared by the host and moderators during the Daily Threat Briefing.</p>
+
+    <div id="date-nav" class="date-nav" hidden>
+        <button id="prev-date" class="date-btn" aria-label="Previous date">&larr;</button>
+        <span id="date-label" class="date-label"></span>
+        <button id="next-date" class="date-btn" aria-label="Next date">&rarr;</button>
+    </div>
+
+    <div id="stream-info" class="stream-info" hidden></div>
+    <div id="err" class="err" hidden></div>
+    <div id="links-list"></div>
+    <p id="empty" class="links-empty" hidden>No links were shared during this show.</p>
+    <p id="no-data" class="links-empty" hidden>No show links have been archived yet. Check back after the next briefing!</p>
+
+    <p class="muted" style="margin-top:1.5rem;font-size:0.85rem;">
+        <a href="/">Register</a> · <a href="/leaderboard.html">Leaderboard</a>
+        · <a href="/faq.html">FAQ</a> · <a href="/status.html">Status</a>
+        · <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
+    </p>
+</main>
+<script src="/links.js"></script>
+</body>
+</html>

--- a/pages/links.js
+++ b/pages/links.js
@@ -1,0 +1,177 @@
+let availableDates = [];
+let currentIndex = 0;
+
+async function load(date) {
+    const errEl = document.getElementById("err");
+    const listEl = document.getElementById("links-list");
+    const emptyEl = document.getElementById("empty");
+    const noDataEl = document.getElementById("no-data");
+    const navEl = document.getElementById("date-nav");
+    const streamEl = document.getElementById("stream-info");
+
+    errEl.hidden = true;
+    emptyEl.hidden = true;
+    noDataEl.hidden = true;
+    listEl.textContent = "";
+    streamEl.hidden = true;
+    streamEl.textContent = "";
+
+    try {
+        const params = date ? `?date=${encodeURIComponent(date)}` : "";
+        const r = await fetch(`/api/links${params}`);
+        if (!r.ok) {
+            errEl.textContent = `Error loading links (${r.status}).`;
+            errEl.hidden = false;
+            return;
+        }
+        const d = await r.json();
+
+        if (!d.date || d.available_dates.length === 0) {
+            noDataEl.hidden = false;
+            return;
+        }
+
+        availableDates = d.available_dates;
+        currentIndex = availableDates.indexOf(d.date);
+        if (currentIndex === -1) currentIndex = 0;
+
+        updateNav();
+        navEl.hidden = false;
+
+        if (d.stream) {
+            if (d.stream.title) {
+                streamEl.appendChild(document.createTextNode(d.stream.title));
+            }
+            if (d.stream.yt_video_id) {
+                if (d.stream.title) streamEl.appendChild(document.createTextNode(" · "));
+                const ytLink = document.createElement("a");
+                ytLink.href = "https://www.youtube.com/watch?v=" + encodeURIComponent(d.stream.yt_video_id);
+                ytLink.target = "_blank";
+                ytLink.rel = "noopener";
+                ytLink.textContent = "Watch on YouTube";
+                streamEl.appendChild(ytLink);
+            }
+            streamEl.hidden = false;
+        }
+
+        const links = d.links || [];
+        if (links.length === 0) {
+            emptyEl.hidden = false;
+            return;
+        }
+
+        for (const link of links) {
+            listEl.appendChild(renderCard(link));
+        }
+    } catch {
+        errEl.textContent = "Failed to load links.";
+        errEl.hidden = false;
+    }
+}
+
+function renderCard(link) {
+    const card = document.createElement("div");
+    card.className = "link-card";
+
+    const title = link.title || link.url;
+    const authorLabel = link.author_type === "owner" ? "Host" : "Mod";
+    const time = formatTime(link.posted_at);
+
+    var header = document.createElement("div");
+    header.className = "link-header";
+
+    var domain = document.createElement("span");
+    domain.className = "link-domain";
+    domain.textContent = link.domain;
+    header.appendChild(domain);
+
+    var timeEl = document.createElement("span");
+    timeEl.className = "link-time";
+    timeEl.textContent = time;
+    header.appendChild(timeEl);
+
+    var author = document.createElement("span");
+    author.className = "link-author";
+    var badge = document.createElement("span");
+    badge.className = "link-author-badge " + link.author_type;
+    badge.textContent = authorLabel;
+    author.appendChild(badge);
+    author.appendChild(document.createTextNode(link.author_name));
+    header.appendChild(author);
+
+    card.appendChild(header);
+
+    var titleDiv = document.createElement("div");
+    titleDiv.className = "link-title";
+    var titleLink = document.createElement("a");
+    titleLink.href = link.url;
+    titleLink.target = "_blank";
+    titleLink.rel = "noopener";
+    titleLink.textContent = title;
+    titleDiv.appendChild(titleLink);
+    card.appendChild(titleDiv);
+
+    if (link.description) {
+        var desc = document.createElement("div");
+        desc.className = "link-desc";
+        desc.textContent = link.description;
+        card.appendChild(desc);
+    }
+
+    if (link.title) {
+        var urlDiv = document.createElement("div");
+        urlDiv.className = "link-url";
+        urlDiv.textContent = link.url;
+        card.appendChild(urlDiv);
+    }
+
+    return card;
+}
+
+function updateNav() {
+    var label = document.getElementById("date-label");
+    var prev = document.getElementById("prev-date");
+    var next = document.getElementById("next-date");
+
+    var d = availableDates[currentIndex];
+    label.textContent = formatDate(d);
+    prev.disabled = currentIndex >= availableDates.length - 1;
+    next.disabled = currentIndex <= 0;
+
+    var newUrl = new URL(window.location);
+    newUrl.searchParams.set("date", d);
+    history.replaceState(null, "", newUrl);
+}
+
+function formatDate(iso) {
+    var parts = iso.split("-").map(Number);
+    var y = parts[0], m = parts[1], day = parts[2];
+    var months = ["January","February","March","April","May","June",
+        "July","August","September","October","November","December"];
+    var days = ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"];
+    var dt = new Date(y, m - 1, day);
+    return days[dt.getDay()] + ", " + months[m - 1] + " " + day + ", " + y;
+}
+
+function formatTime(iso) {
+    if (!iso) return "";
+    var d = new Date(iso);
+    return d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit", hour12: true });
+}
+
+document.getElementById("prev-date").addEventListener("click", function() {
+    if (currentIndex < availableDates.length - 1) {
+        currentIndex++;
+        load(availableDates[currentIndex]);
+    }
+});
+
+document.getElementById("next-date").addEventListener("click", function() {
+    if (currentIndex > 0) {
+        currentIndex--;
+        load(availableDates[currentIndex]);
+    }
+});
+
+var params = new URLSearchParams(window.location.search);
+load(params.get("date") || null);

--- a/workers/poller/src/index.js
+++ b/workers/poller/src/index.js
@@ -6,6 +6,7 @@ const YT = "https://www.googleapis.com/youtube/v3";
 const TOKEN_URL = "https://oauth2.googleapis.com/token";
 // Matches both old SC-CPE-XXXXXXXX and new SC-CPE{XXXX-XXXX} formats.
 const CODE_RE = /SC-CPE[-{]([0-9A-HJKMNP-TV-Z]{4})-?([0-9A-HJKMNP-TV-Z]{4})\}?/i;
+const URL_RE = /https?:\/\/[^\s<>"')\]]+/gi;
 
 let cachedToken = null;
 let cachedTokenExpiry = 0;
@@ -231,6 +232,7 @@ async function pollOnePage(env, session, now) {
     await appendRawJsonl(env, session, items);
     await processCodeMatches(env, session, items, now);
     await processAttendance(env, session, items, now);
+    await extractShowLinks(env, session, items, now);
 
     await env.DB.prepare("UPDATE streams SET messages_scanned = messages_scanned + ?1 WHERE id = ?2")
         .bind(items.length, session.stream_id).run();
@@ -437,6 +439,41 @@ async function processAttendance(env, session, items, now) {
         await audit(env, "poller", userId, "attendance_credited", "attendance",
             `${userId}:${session.stream_id}`, null,
             { stream_id: session.stream_id, cpe: rule.cpe_per_day, rule_version: rule.version });
+    }
+}
+
+async function extractShowLinks(env, session, items, now) {
+    for (const m of items) {
+        const isOwner = m.authorDetails?.isOwner === true;
+        const isMod = m.authorDetails?.isModerator === true;
+        if (!isOwner && !isMod) continue;
+
+        const text = m.snippet?.displayMessage || "";
+        const urls = text.match(URL_RE);
+        if (!urls) continue;
+
+        for (const raw of urls) {
+            let parsed;
+            try { parsed = new URL(raw); } catch { continue; }
+
+            await env.DB.prepare(`
+                INSERT OR IGNORE INTO show_links
+                  (id, stream_id, url, domain, author_type, author_name,
+                   yt_channel_id, yt_message_id, posted_at, created_at)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            `).bind(
+                ulid(),
+                session.stream_id,
+                raw,
+                parsed.hostname,
+                isOwner ? "owner" : "moderator",
+                m.authorDetails?.displayName || "Unknown",
+                m.authorDetails?.channelId || "",
+                m.id,
+                m.snippet?.publishedAt || now.toISOString(),
+                now.toISOString(),
+            ).run();
+        }
     }
 }
 

--- a/workers/purge/src/heartbeat-staleness.test.mjs
+++ b/workers/purge/src/heartbeat-staleness.test.mjs
@@ -17,7 +17,7 @@ function ago(s) { return new Date(NOW_MS - s * 1000).toISOString(); }
 test("staleHeartbeats: empty table → every known non-poller source stale", () => {
     const out = staleHeartbeats([], NOW_MS);
     const sources = out.map(r => r.source).sort();
-    assert.deepEqual(sources, ["canary", "email_sender", "monthly_digest", "purge", "security_alerts"]);
+    assert.deepEqual(sources, ["canary", "email_sender", "link_enrichment", "monthly_digest", "purge", "security_alerts"]);
     assert.ok(out.every(r => r.reason === "never_beat"));
 });
 
@@ -28,6 +28,7 @@ test("staleHeartbeats: fresh beats → none stale", () => {
         { source: "email_sender", last_beat_at: ago(60), last_status: "ok" },
         { source: "canary", last_beat_at: ago(600), last_status: "ok" },
         { source: "monthly_digest", last_beat_at: ago(86400), last_status: "ok" },
+        { source: "link_enrichment", last_beat_at: ago(3600), last_status: "ok" },
     ];
     assert.deepEqual(staleHeartbeats(rows, NOW_MS), []);
 });
@@ -39,6 +40,7 @@ test("staleHeartbeats: email_sender 11 min old → stale", () => {
         { source: "email_sender", last_beat_at: ago(660), last_status: "ok" },
         { source: "canary", last_beat_at: ago(600), last_status: "ok" },
         { source: "monthly_digest", last_beat_at: ago(86400), last_status: "ok" },
+        { source: "link_enrichment", last_beat_at: ago(3600), last_status: "ok" },
     ];
     const out = staleHeartbeats(rows, NOW_MS);
     assert.equal(out.length, 1);
@@ -55,6 +57,7 @@ test("staleHeartbeats: poller excluded regardless of staleness", () => {
         { source: "email_sender", last_beat_at: ago(60), last_status: "ok" },
         { source: "canary", last_beat_at: ago(600), last_status: "ok" },
         { source: "monthly_digest", last_beat_at: ago(86400), last_status: "ok" },
+        { source: "link_enrichment", last_beat_at: ago(3600), last_status: "ok" },
     ];
     assert.deepEqual(staleHeartbeats(rows, NOW_MS), []);
 });
@@ -66,6 +69,7 @@ test("staleHeartbeats: unknown source ignored", () => {
         { source: "email_sender", last_beat_at: ago(60), last_status: "ok" },
         { source: "canary", last_beat_at: ago(600), last_status: "ok" },
         { source: "monthly_digest", last_beat_at: ago(86400), last_status: "ok" },
+        { source: "link_enrichment", last_beat_at: ago(3600), last_status: "ok" },
         { source: "mystery_cron", last_beat_at: ago(7 * 86400), last_status: "ok" },
     ];
     assert.deepEqual(staleHeartbeats(rows, NOW_MS), []);

--- a/workers/purge/src/index.js
+++ b/workers/purge/src/index.js
@@ -39,6 +39,11 @@ export default {
                 await heartbeat(env, "monthly_digest", "ok",
                     { at: now, ...out.monthly_digest });
             }
+            if (only === "all" || only === "link_enrichment") {
+                out.link_enrichment = await enrichShowLinks(env, now);
+                await heartbeat(env, "link_enrichment", "ok",
+                    { at: now, ...out.link_enrichment });
+            }
             return new Response(JSON.stringify({ ok: true, now, ...out }),
                 { headers: { "content-type": "application/json" }});
         } catch (err) {
@@ -102,6 +107,17 @@ export default {
                     at: now, msg: String(err && err.message || err),
                 });
             }
+        }
+
+        // Show-link metadata enrichment — runs every day. Fetches page
+        // titles for URLs the poller extracted but hasn't enriched yet.
+        try {
+            const enriched = await enrichShowLinks(env, now);
+            await heartbeat(env, "link_enrichment", "ok", { at: now, ...enriched });
+        } catch (err) {
+            await heartbeat(env, "link_enrichment", "error", {
+                at: now, msg: String(err && err.message || err),
+            });
         }
 
         // Monthly user digest — fires on the 1st of each month. Queues a
@@ -440,6 +456,7 @@ const EXPECTED_CADENCE_S = {
     email_sender: 300,
     canary: 3600,
     monthly_digest: 2678400,
+    link_enrichment: 86400,
 };
 
 function staleHeartbeats(rows, nowMs) {
@@ -557,6 +574,50 @@ async function runSecurityAlerts(env, nowIso) {
         stale_heartbeats: stale.length,
         cursor_ts: rows.length ? rows[rows.length - 1].ts : since,
     };
+}
+
+const ENRICH_BATCH = 50;
+const ENRICH_TIMEOUT_MS = 5000;
+
+async function enrichShowLinks(env, nowIso) {
+    const rows = (await env.DB.prepare(
+        "SELECT id, url FROM show_links WHERE enriched_at IS NULL LIMIT ?1"
+    ).bind(ENRICH_BATCH).all()).results || [];
+
+    let enriched = 0, failed = 0;
+    for (const row of rows) {
+        let title = null, description = null;
+        try {
+            const controller = new AbortController();
+            const timer = setTimeout(() => controller.abort(), ENRICH_TIMEOUT_MS);
+            const res = await fetch(row.url, {
+                signal: controller.signal,
+                headers: { "User-Agent": "SC-CPE-LinkEnricher/1.0" },
+                redirect: "follow",
+            });
+            clearTimeout(timer);
+            if (res.ok) {
+                const html = await res.text();
+                const ogTitle = html.match(/<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']+)["']/i)
+                    || html.match(/<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:title["']/i);
+                const pageTitle = html.match(/<title[^>]*>([^<]+)<\/title>/i);
+                title = (ogTitle?.[1] || pageTitle?.[1] || "").trim().slice(0, 500) || null;
+
+                const ogDesc = html.match(/<meta[^>]+property=["']og:description["'][^>]+content=["']([^"']+)["']/i)
+                    || html.match(/<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:description["']/i);
+                description = (ogDesc?.[1] || "").trim().slice(0, 1000) || null;
+                enriched++;
+            } else {
+                failed++;
+            }
+        } catch {
+            failed++;
+        }
+        await env.DB.prepare(
+            "UPDATE show_links SET title = ?1, description = ?2, enriched_at = ?3 WHERE id = ?4"
+        ).bind(title, description, nowIso, row.id).run();
+    }
+    return { candidates: rows.length, enriched, failed };
 }
 
 // Exported for tests.


### PR DESCRIPTION
## Summary
- **New `show_links` table** (migration 005) stores URLs extracted from host/moderator YouTube chat messages, with dedup via `UNIQUE(stream_id, url)`
- **Poller** extracts URLs inline during message processing — zero latency impact (regex + `INSERT OR IGNORE` on the small owner/mod subset)
- **Purge worker** enriches unenriched links daily with page title + og:description via a new `enrichShowLinks` block (50-link batch, 5s timeout per fetch, fail-safe `enriched_at` set even on failure)
- **New public API** `GET /api/links?date=YYYY-MM-DD` returns links + stream metadata + available dates for navigation
- **New public page** `links.html` with date-based navigation, link cards (domain pill, title, description, author badge), deep-linkable via `?date=`
- **Heartbeat** `link_enrichment` added to both `_heartbeat.js` and purge worker mirror; existing tests updated
- **Nav links** added to leaderboard and badge pages

## Pre-deploy step
Apply migration before merge:
```
wrangler d1 execute sc-cpe --file=db/migrations/005_show_links.sql
```

## Post-deploy
Optionally trigger immediate enrichment instead of waiting for 09:00 UTC:
```
curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
  "https://sc-cpe-purge.ericrihm.workers.dev/?only=link_enrichment"
```

## Test plan
- [x] All 132 existing tests pass (heartbeat staleness tests updated for new `link_enrichment` source)
- [ ] Apply migration 005 to D1
- [ ] Verify `links.html` loads with empty state ("No show links archived yet")
- [ ] After next live stream, verify links appear in the archive
- [ ] Trigger enrichment manually and verify titles populate
- [ ] Test date navigation with `?date=` param

🤖 Generated with [Claude Code](https://claude.com/claude-code)