### PR TITLE
feat(deploy): auto-apply D1 migrations in pipeline

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -4,8 +4,9 @@ name: deploy-prod
 # with the hardening smoke suite. Replaces the manual `wrangler pages deploy`
 # / `wrangler deploy` workflow documented in README.md.
 #
-# Ordering: tests -> Pages -> Workers -> verify-deploy.
-# Pages first so a new API shape is live before any Worker that might call it;
+# Ordering: tests -> D1 migrations -> Pages -> Workers -> verify-deploy.
+# Migrations first so the schema is ready before code that depends on it.
+# Pages next so a new API shape is live before any Worker that might call it;
 # Workers are matrix-parallel. Every step must tolerate ONE rev of Pages↔Worker
 # skew during the ~30s window between them.
 #
@@ -44,9 +45,57 @@ jobs:
       - name: Run tests
         run: bash scripts/test.sh
 
+  migrate-d1:
+    name: Apply D1 migrations
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: production
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: "20"
+      - name: Install wrangler
+        run: npm install -g wrangler
+      - name: Apply pending migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_DEPLOY_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          wrangler d1 execute sc-cpe --remote --command \
+            "CREATE TABLE IF NOT EXISTS _applied_migrations (filename TEXT PRIMARY KEY, applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')))"
+
+          APPLIED=$(wrangler d1 execute sc-cpe --remote --json --command \
+            "SELECT filename FROM _applied_migrations ORDER BY filename" \
+            | jq -r '.[0].results[].filename' 2>/dev/null || echo "")
+
+          APPLIED_COUNT=0
+          NEW_COUNT=0
+
+          for f in $(ls db/migrations/*.sql 2>/dev/null | sort); do
+            fname=$(basename "$f")
+            if echo "$APPLIED" | grep -qxF "$fname"; then
+              echo "::notice::⏭ $fname (already applied)"
+              APPLIED_COUNT=$((APPLIED_COUNT + 1))
+            else
+              echo "::group::Applying $fname"
+              wrangler d1 execute sc-cpe --remote --file "$f"
+              wrangler d1 execute sc-cpe --remote --command \
+                "INSERT INTO _applied_migrations (filename) VALUES ('$fname')"
+              echo "::endgroup::"
+              echo "::notice::✅ $fname applied"
+              NEW_COUNT=$((NEW_COUNT + 1))
+            fi
+          done
+
+          echo "### D1 Migration Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Already applied: $APPLIED_COUNT" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Newly applied: $NEW_COUNT" >> "$GITHUB_STEP_SUMMARY"
+
   deploy-pages:
     name: Deploy Cloudflare Pages
-    needs: test
+    needs: migrate-d1
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: production
@@ -144,7 +193,7 @@ jobs:
 
   alert-on-failure:
     name: Discord alert on deploy failure
-    needs: [test, deploy-pages, deploy-workers, verify-deploy]
+    needs: [test, migrate-d1, deploy-pages, deploy-workers, verify-deploy]
     # github.run_attempt == 1 suppresses re-pings when an operator
     # reruns a failed run — the first attempt's alert already
     # delivered the signal. Complements PR #39's step-level retry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,8 +120,11 @@ All new pure-logic code should get a `node --test` file wired into
 ## Deploying
 
 Pages + Workers auto-deploy on every merge to `main` via
-`.github/workflows/deploy-prod.yml` (tests → Pages → Workers matrix →
-post-deploy smoke). `main` is branch-protected: PRs required, status
+`.github/workflows/deploy-prod.yml` (tests → D1 migrations → Pages →
+Workers matrix → post-deploy smoke). D1 migrations in `db/migrations/`
+are applied automatically — the pipeline tracks applied files in an
+`_applied_migrations` table and only runs new ones. No manual
+`wrangler d1 execute` needed. `main` is branch-protected: PRs required, status
 checks `Node test suite` + `Secret scan (gitleaks)` must be green,
 no force-push, no deletions. `enforce_admins: false` is deliberate —
 admin (owner) can break-glass push if CI itself is broken; otherwise

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -254,3 +254,9 @@ CREATE TABLE cert_feedback (
 );
 CREATE UNIQUE INDEX cert_feedback_unique ON cert_feedback(user_id, cert_id);
 CREATE INDEX cert_feedback_rating_idx ON cert_feedback(rating) WHERE rating != 'ok';
+
+-- Deploy-pipeline migration tracking (not app data).
+CREATE TABLE _applied_migrations (
+    filename    TEXT PRIMARY KEY,
+    applied_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);


### PR DESCRIPTION
## Summary
- Adds `migrate-d1` job to deploy-prod.yml between test and deploy-pages
- Tracks applied migrations in `_applied_migrations` D1 table
- Applies only new `db/migrations/*.sql` files in sorted order
- No more manual `wrangler d1 execute` before deploys

## How it works
1. Bootstrap: `CREATE TABLE IF NOT EXISTS _applied_migrations`
2. Query already-applied filenames
3. Loop `db/migrations/*.sql` sorted — skip known, apply new
4. Record each newly applied file
5. Write summary to GitHub step summary

Live D1 already has the tracking table seeded with all 5 existing migrations.

## Test plan
- [x] All 132 tests pass locally
- [ ] First pipeline run should show 5 "already applied", 0 "newly applied"
- [ ] Next migration (006+) should auto-apply on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)