### PR TITLE
fix(nav): add Show Links to all page footers

### DIFF
--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -317,6 +317,12 @@
             </p>
         </div>
     </section>
+    <p class="muted" style="margin-top:1.5rem;font-size:0.85rem;">
+        <a href="/leaderboard.html">Leaderboard</a>
+        · <a href="/links.html">Show Links</a>
+        · <a href="/faq.html">FAQ</a>
+        · <a href="/status.html">Status</a>
+    </p>
 </main>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js" defer></script>
 <script src="/dashboard.js"></script>

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -307,6 +307,7 @@
   </p>
   <p class="muted" style="font-size:0.85rem;">
     <a href="/">Register</a> · <a href="/leaderboard.html">Leaderboard</a>
+    · <a href="/links.html">Show Links</a>
     · <a href="/status.html">Status</a> · <a href="/terms.html">Terms</a>
     &amp; <a href="/privacy.html">Privacy</a>
   </p>

--- a/pages/index.html
+++ b/pages/index.html
@@ -63,6 +63,7 @@
     <p class="muted" style="font-size:0.85rem;">
         <a href="/faq.html">FAQ</a>
         · <a href="/leaderboard.html">Leaderboard</a>
+        · <a href="/links.html">Show Links</a>
         · <a href="/status.html">Status</a>
         · <a href="/verify.html">Verify a cert</a>
         · <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>

--- a/pages/recover.html
+++ b/pages/recover.html
@@ -35,6 +35,7 @@
 
     <p class="muted" style="margin-top:2rem;font-size:0.85rem;">
         <a href="/">Register</a> · <a href="/faq.html">FAQ</a>
+        · <a href="/links.html">Show Links</a>
         · <a href="/status.html">Status</a> · <a href="/terms.html">Terms</a>
         &amp; <a href="/privacy.html">Privacy</a>
     </p>

--- a/pages/status.html
+++ b/pages/status.html
@@ -23,7 +23,7 @@
 
   <p class="foot" id="foot"></p>
   <p class="foot">For longer-form incident updates, see the <a href="https://github.com/ericrihm/sc-cpe/issues?q=label%3Aincident">incidents label</a> on the SC-CPE repo. For ongoing issues that affect your account, email <a href="mailto:certs@signalplane.co?subject=%5BACCOUNT%5D%20status%20page%20issue">certs@signalplane.co</a> with <code>[ACCOUNT]</code> in the subject.</p>
-  <p><a href="/">&larr; Back</a></p>
+  <p><a href="/">&larr; Back</a> · <a href="/links.html">Show Links</a></p>
 </main>
 <script src="/status.js"></script>
 </body>

--- a/pages/verify.html
+++ b/pages/verify.html
@@ -53,6 +53,7 @@
     </section>
     <p class="muted" style="margin-top:2rem;font-size:0.85rem;">
         <a href="/">Register</a> · <a href="/faq.html">FAQ</a>
+        · <a href="/links.html">Show Links</a>
         · <a href="/status.html">Status</a>
     </p>
 </main>


### PR DESCRIPTION
## Summary
- Adds "Show Links" nav link to index, FAQ, recover, verify, status, and dashboard pages
- Was previously only linked from badge and leaderboard

## Test plan
- [x] Verify link appears in footer of every public page
- [ ] Post-deploy smoke passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)