### PR TITLE
fix(links): include flagged streams in show links API

### DIFF
--- a/pages/functions/api/links.js
+++ b/pages/functions/api/links.js
@@ -16,7 +16,7 @@ export async function onRequestGet({ env, request }) {
             SELECT s.scheduled_date
               FROM streams s
              WHERE s.id IN (SELECT stream_id FROM show_links)
-               AND s.state IN ('live','complete')
+               AND s.state IN ('live','complete','flagged')
           ORDER BY s.scheduled_date DESC
              LIMIT 1
         `).first();
@@ -31,7 +31,7 @@ export async function onRequestGet({ env, request }) {
         SELECT id, title, yt_video_id
           FROM streams
          WHERE scheduled_date = ?1
-           AND state IN ('live','complete')
+           AND state IN ('live','complete','flagged')
          LIMIT 1
     `).bind(date).first();
 
@@ -60,7 +60,7 @@ export async function onRequestGet({ env, request }) {
         SELECT DISTINCT s.scheduled_date
           FROM streams s
          WHERE s.id IN (SELECT stream_id FROM show_links)
-           AND s.state IN ('live','complete')
+           AND s.state IN ('live','complete','flagged')
       ORDER BY s.scheduled_date DESC
          LIMIT 60
     `).all();

--- a/scripts/refresh_oauth_token.mjs
+++ b/scripts/refresh_oauth_token.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Quick OAuth refresh: gets a new refresh token and stores it on the poller worker.
+import { createServer } from "http";
+import { execFileSync } from "child_process";
+
+const CLIENT_ID = process.env.YOUTUBE_OAUTH_CLIENT_ID;
+const CLIENT_SECRET = process.env.YOUTUBE_OAUTH_CLIENT_SECRET;
+if (!CLIENT_ID || !CLIENT_SECRET) {
+    console.error("Set YOUTUBE_OAUTH_CLIENT_ID and YOUTUBE_OAUTH_CLIENT_SECRET env vars first.");
+    process.exit(1);
+}
+const REDIRECT_URI = "http://localhost:3000/callback";
+
+const authUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
+authUrl.searchParams.set("client_id", CLIENT_ID);
+authUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+authUrl.searchParams.set("response_type", "code");
+authUrl.searchParams.set("scope", "https://www.googleapis.com/auth/youtube.readonly");
+authUrl.searchParams.set("access_type", "offline");
+authUrl.searchParams.set("prompt", "consent");
+
+const server = createServer(async (req, res) => {
+    if (!req.url.startsWith("/callback")) { res.writeHead(404); res.end(); return; }
+    const code = new URL(req.url, "http://localhost:3000").searchParams.get("code");
+    if (!code) { res.writeHead(400); res.end("No code"); server.close(); return; }
+
+    const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ code, client_id: CLIENT_ID, client_secret: CLIENT_SECRET, redirect_uri: REDIRECT_URI, grant_type: "authorization_code" }),
+    });
+    const data = await tokenRes.json();
+    if (data.error) { console.error("Token error:", data.error, data.error_description); res.writeHead(500); res.end(data.error); server.close(); process.exit(1); }
+
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end("<h1>Done - close this tab</h1>");
+
+    console.log("\nRefresh token obtained. Storing on poller worker...\n");
+    try {
+        execFileSync("npx", ["wrangler", "secret", "put", "YOUTUBE_OAUTH_REFRESH_TOKEN", "--name", "sc-cpe-poller"], {
+            input: data.refresh_token,
+            stdio: ["pipe", "inherit", "inherit"],
+            shell: true,
+        });
+        console.log("\nDone! Refresh token stored. Poller will use it on next cron firing.");
+    } catch (e) {
+        console.error("Failed to store secret:", e.message);
+        console.log("\nManual fallback:");
+        console.log(`echo '${data.refresh_token}' | npx wrangler secret put YOUTUBE_OAUTH_REFRESH_TOKEN --name sc-cpe-poller`);
+    }
+    server.close();
+    process.exit(0);
+});
+
+server.listen(3000, () => {
+    console.log("Opening browser for OAuth consent...");
+    try { execFileSync("powershell.exe", ["-Command", `Start-Process '${authUrl.toString()}'`], { stdio: "ignore" }); }
+    catch { console.log(`Open manually: ${authUrl.toString()}`); }
+});
+
+setTimeout(() => { console.error("Timeout"); server.close(); process.exit(1); }, 120_000);


### PR DESCRIPTION
## Summary
- Include `flagged` streams in the links API query — streams where the poller couldn't read chat still had real shows with links shared
- Add `scripts/refresh_oauth_token.mjs` for one-shot YouTube OAuth token renewal (reads credentials from env vars)
- Backfilled 9 show links (Apr 15-21) from Discord live-chat via Restream Bot

## Test plan
- [ ] Verify `/api/links?date=2026-04-16` returns huntress.com link
- [ ] Verify `/api/links` available_dates includes Apr 15, 16, 17, 21
- [ ] Verify links.html shows all backfilled dates in date picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)