### PR TITLE
fix(nav): consistent navigation across all pages

### DIFF
--- a/pages/badge.html
+++ b/pages/badge.html
@@ -36,7 +36,7 @@
 </head>
 <body>
 <main class="narrow">
-    <h1>SC-CPE Achievement Badge</h1>
+    <h1><a href="/">SC-CPE</a> — Achievement Badge</h1>
     <div id="err" class="err" hidden></div>
     <div id="body" hidden>
         <div class="badge-wrap">
@@ -56,8 +56,10 @@
             <a href="https://simplycyber.io" target="_blank" rel="noopener">Simply Cyber</a>
         </p>
         <p class="muted" style="text-align:center;margin-top:1.5rem;font-size:0.85rem;">
-            <a href="/">Register</a> · <a href="/leaderboard.html">Leaderboard</a>
-            · <a href="/links.html">Show Links</a> · <a href="/faq.html">FAQ</a>
+            <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
+            · <a href="/leaderboard.html">Leaderboard</a>
+            · <a href="/links.html">Show Links</a> · <a href="/status.html">Status</a>
+            · <a href="/verify.html">Verify a cert</a>
         </p>
     </div>
 </main>

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <main class="narrow">
-    <h1>My SC-CPE Dashboard</h1>
+    <h1><a href="/">SC-CPE</a> — My Dashboard</h1>
     <div id="err" class="err" hidden></div>
 
     <section id="login-card" class="card" hidden>
@@ -341,10 +341,10 @@
         </div>
     </section>
     <p class="muted" style="margin-top:1.5rem;font-size:0.85rem;">
-        <a href="/leaderboard.html">Leaderboard</a>
+        <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
+        · <a href="/leaderboard.html">Leaderboard</a>
         · <a href="/links.html">Show Links</a>
-        · <a href="/faq.html">FAQ</a>
-        · <a href="/status.html">Status</a>
+        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a>
     </p>
 </main>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js" defer></script>

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 <main class="narrow">
-  <h1>FAQ &amp; Known Issues</h1>
+  <h1><a href="/">SC-CPE</a> — FAQ &amp; Known Issues</h1>
   <p class="lead">Plain answers to the questions people actually ask. If
   yours isn't here, email <a href="mailto:certs@signalplane.co?subject=%5BACCOUNT%5D%20FAQ%20suggestion">certs@signalplane.co</a>
   with <code>[ACCOUNT]</code> in the subject and we'll add it. See
@@ -306,10 +306,10 @@
     or email <a href="mailto:certs@signalplane.co">certs@signalplane.co</a>.
   </p>
   <p class="muted" style="font-size:0.85rem;">
-    <a href="/">Register</a> · <a href="/leaderboard.html">Leaderboard</a>
+    <a href="/">Home</a> · <a href="/leaderboard.html">Leaderboard</a>
     · <a href="/links.html">Show Links</a>
-    · <a href="/status.html">Status</a> · <a href="/terms.html">Terms</a>
-    &amp; <a href="/privacy.html">Privacy</a>
+    · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a>
+    · <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
   </p>
 </main>
 </body>

--- a/pages/index.html
+++ b/pages/index.html
@@ -67,7 +67,6 @@
         · <a href="/status.html">Status</a>
         · <a href="/verify.html">Verify a cert</a>
         · <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
-        · <a href="/.well-known/security.txt">security.txt</a>
     </p>
 </main>
 <script src="/index.js"></script>

--- a/pages/leaderboard.html
+++ b/pages/leaderboard.html
@@ -25,7 +25,7 @@
 </head>
 <body>
 <main class="narrow">
-    <h1>Community Leaderboard</h1>
+    <h1><a href="/">SC-CPE</a> — Community Leaderboard</h1>
     <p class="lead">Top CPE earners this month — opt in from your <a href="/dashboard">dashboard</a>.</p>
     <p id="period" class="lb-period"></p>
     <div id="err" class="err" hidden></div>
@@ -41,10 +41,10 @@
         and last initial are shown — email and full name are never displayed.
     </p>
     <p class="muted" style="margin-top:1.5rem;font-size:0.85rem;">
-        <a href="/">Register</a> · <a href="/links.html">Show Links</a>
-        · <a href="/faq.html">FAQ</a>
-        · <a href="/status.html">Status</a> · <a href="/terms.html">Terms</a>
-        &amp; <a href="/privacy.html">Privacy</a>
+        <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
+        · <a href="/links.html">Show Links</a>
+        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a>
+        · <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
     </p>
 </main>
 <script src="/leaderboard.js"></script>

--- a/pages/links.html
+++ b/pages/links.html
@@ -15,7 +15,7 @@
 </head>
 <body>
 <main class="narrow">
-    <h1>Show Links Archive</h1>
+    <h1><a href="/">SC-CPE</a> — Show Links Archive</h1>
     <p class="lead">Links shared by the host and moderators during the Daily Threat Briefing.</p>
 
     <div id="date-nav" class="date-nav" hidden>
@@ -31,8 +31,9 @@
     <p id="no-data" class="links-empty" hidden>No show links have been archived yet. Check back after the next briefing!</p>
 
     <p class="muted" style="margin-top:1.5rem;font-size:0.85rem;">
-        <a href="/">Register</a> · <a href="/leaderboard.html">Leaderboard</a>
-        · <a href="/faq.html">FAQ</a> · <a href="/status.html">Status</a>
+        <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
+        · <a href="/leaderboard.html">Leaderboard</a>
+        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a>
         · <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
     </p>
 </main>

--- a/pages/privacy.html
+++ b/pages/privacy.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <main class="narrow">
-    <h1>Privacy Policy</h1>
+    <h1><a href="/">SC-CPE</a> — Privacy Policy</h1>
     <p class="lead">This policy explains what personal data SC-CPE collects, why, how long it is kept, and what rights you have over it. We aim to be direct and specific — if anything is unclear, contact us.</p>
     <p><strong>Last updated:</strong> 2026-04-14 &nbsp;|&nbsp; <strong>Version:</strong> v1</p>
 
@@ -157,7 +157,13 @@
     </ul>
     <p class="muted">One mailbox is a deliberate choice at launch — a single address is easier to monitor and harder to overlook than a forest of aliases. Untagged messages still get read; the prefix just speeds triage.</p>
 
-    <p><a href="/">&larr; Back to registration</a></p>
+    <p class="muted" style="margin-top:2rem;font-size:0.85rem;">
+        <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
+        · <a href="/leaderboard.html">Leaderboard</a>
+        · <a href="/links.html">Show Links</a>
+        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a>
+        · <a href="/terms.html">Terms</a>
+    </p>
 </main>
 </body>
 </html>

--- a/pages/recover.html
+++ b/pages/recover.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 <main class="narrow">
-    <h1>Recover your dashboard link</h1>
+    <h1><a href="/">SC-CPE</a> — Recover your dashboard link</h1>
     <p class="lead">Your dashboard URL is the only way to access your attendance and certificates. Enter the email you registered with and we'll send you the link if it's on file.</p>
 
     <form id="f">
@@ -34,10 +34,11 @@
     </section>
 
     <p class="muted" style="margin-top:2rem;font-size:0.85rem;">
-        <a href="/">Register</a> · <a href="/faq.html">FAQ</a>
+        <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
+        · <a href="/leaderboard.html">Leaderboard</a>
         · <a href="/links.html">Show Links</a>
-        · <a href="/status.html">Status</a> · <a href="/terms.html">Terms</a>
-        &amp; <a href="/privacy.html">Privacy</a>
+        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a>
+        · <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
     </p>
 </main>
 <script src="/recover.js"></script>

--- a/pages/status.html
+++ b/pages/status.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 <main class="narrow">
-  <h1>SC-CPE — Service Status</h1>
+  <h1><a href="/">SC-CPE</a> — Service Status</h1>
   <p class="lead">Automated. Polled every 30 seconds from <code>/api/health</code>. If something below is red, the relevant cron or worker is not beating within its expected cadence.</p>
 
   <div id="hero" class="status-hero loading">checking…</div>
@@ -23,7 +23,13 @@
 
   <p class="foot" id="foot"></p>
   <p class="foot">For longer-form incident updates, see the <a href="https://github.com/ericrihm/sc-cpe/issues?q=label%3Aincident">incidents label</a> on the SC-CPE repo. For ongoing issues that affect your account, email <a href="mailto:certs@signalplane.co?subject=%5BACCOUNT%5D%20status%20page%20issue">certs@signalplane.co</a> with <code>[ACCOUNT]</code> in the subject.</p>
-  <p><a href="/">&larr; Back</a> · <a href="/links.html">Show Links</a></p>
+  <p class="muted" style="font-size:0.85rem;">
+    <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
+    · <a href="/leaderboard.html">Leaderboard</a>
+    · <a href="/links.html">Show Links</a>
+    · <a href="/verify.html">Verify a cert</a>
+    · <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
+  </p>
 </main>
 <script src="/status.js"></script>
 </body>

--- a/pages/style.css
+++ b/pages/style.css
@@ -72,6 +72,8 @@ main.narrow {
     main.narrow { max-width: 720px; }
 }
 h1 { font-size: 1.75rem; margin-bottom: .25rem; line-height: 1.2; }
+h1 a { color: inherit; text-decoration: none; }
+h1 a:hover { color: var(--accent); }
 h2 { font-size: 1.25rem; margin-top: 1.5rem; line-height: 1.3; }
 .lead { color: var(--muted); margin-bottom: 2rem; }
 .muted { color: var(--muted); }

--- a/pages/terms.html
+++ b/pages/terms.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <main class="narrow">
-    <h1>Terms of Service</h1>
+    <h1><a href="/">SC-CPE</a> — Terms of Service</h1>
     <p class="lead">These terms govern your use of SC-CPE, the automated CPE certificate issuance service operated by Simply Cyber LLC. Please read them before registering.</p>
     <p><strong>Last updated:</strong> 2026-04-14 &nbsp;|&nbsp; <strong>Version:</strong> v1</p>
 
@@ -74,7 +74,13 @@
     <h2>13. Contact</h2>
     <p>All operator email goes to one inbox: <a href="mailto:certs@signalplane.co">certs@signalplane.co</a>. Please put <code>[ACCOUNT]</code>, <code>[CERT]</code>, <code>[PRIVACY]</code>, or <code>[SECURITY]</code> at the start of your subject line so the filter triages correctly. See <a href="/privacy.html#13">Privacy Policy §13</a> for the full routing scheme.</p>
 
-    <p><a href="/">&larr; Back to registration</a></p>
+    <p class="muted" style="margin-top:2rem;font-size:0.85rem;">
+        <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
+        · <a href="/leaderboard.html">Leaderboard</a>
+        · <a href="/links.html">Show Links</a>
+        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a>
+        · <a href="/privacy.html">Privacy</a>
+    </p>
 </main>
 </body>
 </html>

--- a/pages/verify.html
+++ b/pages/verify.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 <main class="narrow">
-    <h1>Verify an SC-CPE Certificate</h1>
+    <h1><a href="/">SC-CPE</a> — Verify a Certificate</h1>
     <p class="verify-hero">Every SC-CPE certificate is cryptographically signed and hash-chained. This portal lets anyone — employers, auditors, certification bodies — independently verify a certificate's authenticity without contacting us.</p>
     <p class="lead">Paste a certificate token or open a link containing one.</p>
 
@@ -52,9 +52,11 @@
         </div>
     </section>
     <p class="muted" style="margin-top:2rem;font-size:0.85rem;">
-        <a href="/">Register</a> · <a href="/faq.html">FAQ</a>
+        <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
+        · <a href="/leaderboard.html">Leaderboard</a>
         · <a href="/links.html">Show Links</a>
         · <a href="/status.html">Status</a>
+        · <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
     </p>
 </main>
 <script src="/verify.js"></script>


### PR DESCRIPTION
## Summary
- H1 on every secondary page is now a clickable home link: `SC-CPE — Page Title`
- Standardized footer nav across all 11 public pages
- Dashboard, badge, status, terms, privacy all get full nav they were missing

## Test plan
- [ ] Click SC-CPE in h1 on any page → goes to home
- [ ] Hover h1 link → accent color, no underline
- [ ] Footer links consistent on every page
- [ ] Index.html h1 unchanged (is already home)

🤖 Generated with [Claude Code](https://claude.com/claude-code)