### PR TITLE
fix(pages): complete footer nav polish + dashboard bug fixes

### DIFF
--- a/pages/badge.html
+++ b/pages/badge.html
@@ -59,7 +59,8 @@
             <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
             · <a href="/leaderboard.html">Leaderboard</a>
             · <a href="/links.html">Show Links</a> · <a href="/status.html">Status</a>
-            · <a href="/verify.html">Verify a cert</a>
+            · <a href="/verify.html">Verify a cert</a><br>
+            <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
         </p>
     </div>
 </main>

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -344,7 +344,8 @@
         <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
         · <a href="/leaderboard.html">Leaderboard</a>
         · <a href="/links.html">Show Links</a>
-        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a>
+        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a><br>
+        <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
     </p>
 </main>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js" defer></script>

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -33,6 +33,7 @@ if (!token) {
     if (saved) token = saved.token;
 }
 var err = document.getElementById("err");
+var loadInProgress = false;
 
 function showLogin() {
     document.getElementById("skel").hidden = true;
@@ -40,7 +41,10 @@ function showLogin() {
 }
 
 async function load() {
+    if (loadInProgress) return;
     if (!token) { showLogin(); return; }
+    loadInProgress = true;
+    try {
     var r = await fetch("/api/me/" + encodeURIComponent(token));
     if (!r.ok) {
         if (r.status === 404) clearSession();
@@ -137,6 +141,7 @@ async function load() {
     if (d.user.state === "active") {
         renderRenewalTracker(d.user.email_prefs, Number(d.total_cpe_earned != null ? d.total_cpe_earned : 0));
     }
+    } finally { loadInProgress = false; }
 }
 
 function formatDateTime(iso) {
@@ -242,28 +247,29 @@ function renderAttendance(items) {
             '<div class="att-actions">' + actions + "</div>";
         host.appendChild(row);
     }
-    host.addEventListener("click", async function (e) {
-        var btn = e.target.closest(".att-ps-btn");
-        if (!btn || btn.disabled) return;
-        btn.disabled = true;
-        var stream = btn.dataset.stream;
-        var original = btn.textContent;
-        btn.textContent = "sending\u2026";
-        try {
-            var r = await fetch(
-                "/api/me/" + encodeURIComponent(token) + "/cert-per-session/" + encodeURIComponent(stream),
-                { method: "POST", headers: { "Content-Type": "application/json" } },
-            );
-            var j = await r.json().catch(function () { return {}; });
-            if (!r.ok) throw new Error(j.error || "HTTP " + r.status);
-            btn.outerHTML = '<span class="att-ps-done">' + (j.existing ? "already issued" : "queued \u2014 arrives within ~2h") + "</span>";
-        } catch (err) {
-            btn.disabled = false;
-            btn.textContent = original;
-            btn.title = String(err.message || err);
-        }
-    });
 }
+
+document.getElementById("att").addEventListener("click", async function (e) {
+    var btn = e.target.closest(".att-ps-btn");
+    if (!btn || btn.disabled) return;
+    btn.disabled = true;
+    var stream = btn.dataset.stream;
+    var original = btn.textContent;
+    btn.textContent = "sending\u2026";
+    try {
+        var r = await fetch(
+            "/api/me/" + encodeURIComponent(token) + "/cert-per-session/" + encodeURIComponent(stream),
+            { method: "POST", headers: { "Content-Type": "application/json" } },
+        );
+        var j = await r.json().catch(function () { return {}; });
+        if (!r.ok) throw new Error(j.error || "HTTP " + r.status);
+        btn.outerHTML = '<span class="att-ps-done">' + (j.existing ? "already issued" : "queued \u2014 arrives within ~2h") + "</span>";
+    } catch (err) {
+        btn.disabled = false;
+        btn.textContent = original;
+        btn.title = String(err.message || err);
+    }
+});
 
 function formatPeriod(yyyymm) {
     if (!/^\d{6}$/.test(yyyymm)) return yyyymm;
@@ -505,6 +511,7 @@ document.getElementById("rotate-btn").addEventListener("click", async function (
         var d = await r.json().catch(function () { return {}; });
         if (r.ok) {
             clearSession();
+            if (refreshTimer) { clearTimeout(refreshTimer); refreshTimer = null; }
             msg.textContent = "Rotated. Check your email for the new link \u2014 this one stops working shortly.";
             msg.style.color = "var(--ok-soft-text)";
             btn.textContent = "Rotated \u2713";
@@ -601,12 +608,12 @@ function renderToday(today) {
         var credits = (calData.attendance || []).length;
         var lastCredit = credits
             ? calData.attendance.slice().sort(function (a, b) {
-                return (b.session_date || "").localeCompare(a.session_date || "");
+                return (b.scheduled_date || "").localeCompare(a.scheduled_date || "");
               })[0]
             : null;
         var priorLine = credits
             ? " You have <strong>" + credits + "</strong> prior session" + (credits === 1 ? "" : "s") + " credited" +
-              (lastCredit ? " (most recent " + lastCredit.session_date + ")." : ".")
+              (lastCredit ? " (most recent " + lastCredit.scheduled_date + ")." : ".")
             : "";
         status.innerHTML =
             "<strong class='today-missed'>This session ended without credit.</strong> " +

--- a/pages/leaderboard.html
+++ b/pages/leaderboard.html
@@ -43,8 +43,8 @@
     <p class="muted" style="margin-top:1.5rem;font-size:0.85rem;">
         <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
         · <a href="/links.html">Show Links</a>
-        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a>
-        · <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
+        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a><br>
+        <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
     </p>
 </main>
 <script src="/leaderboard.js"></script>

--- a/pages/privacy.html
+++ b/pages/privacy.html
@@ -161,8 +161,8 @@
         <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
         · <a href="/leaderboard.html">Leaderboard</a>
         · <a href="/links.html">Show Links</a>
-        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a>
-        · <a href="/terms.html">Terms</a>
+        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a><br>
+        <a href="/terms.html">Terms</a>
     </p>
 </main>
 </body>

--- a/pages/recover.html
+++ b/pages/recover.html
@@ -37,8 +37,8 @@
         <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
         · <a href="/leaderboard.html">Leaderboard</a>
         · <a href="/links.html">Show Links</a>
-        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a>
-        · <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
+        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a><br>
+        <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
     </p>
 </main>
 <script src="/recover.js"></script>

--- a/pages/status.html
+++ b/pages/status.html
@@ -27,8 +27,8 @@
     <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
     · <a href="/leaderboard.html">Leaderboard</a>
     · <a href="/links.html">Show Links</a>
-    · <a href="/verify.html">Verify a cert</a>
-    · <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
+    · <a href="/verify.html">Verify a cert</a><br>
+    <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
   </p>
 </main>
 <script src="/status.js"></script>

--- a/pages/terms.html
+++ b/pages/terms.html
@@ -78,8 +78,8 @@
         <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
         · <a href="/leaderboard.html">Leaderboard</a>
         · <a href="/links.html">Show Links</a>
-        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a>
-        · <a href="/privacy.html">Privacy</a>
+        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a><br>
+        <a href="/privacy.html">Privacy</a>
     </p>
 </main>
 </body>

--- a/pages/verify.html
+++ b/pages/verify.html
@@ -55,7 +55,7 @@
         <a href="/">Home</a> · <a href="/faq.html">FAQ</a>
         · <a href="/leaderboard.html">Leaderboard</a>
         · <a href="/links.html">Show Links</a>
-        · <a href="/status.html">Status</a> · <a href="/verify.html">Verify a cert</a><br>
+        · <a href="/status.html">Status</a><br>
         <a href="/terms.html">Terms</a> &amp; <a href="/privacy.html">Privacy</a>
     </p>
 </main>


### PR DESCRIPTION
## Summary
- Adds `<br>` visual grouping (page links on line 1, legal links on line 2) to all 8 remaining page footers
- Removes verify.html self-link from its own footer
- Adds missing Terms & Privacy links to badge.html and dashboard.html
- Dashboard JS: load() race guard, event delegation refactor, rotate clears refresh timer, session_date → scheduled_date fix

## Test plan
- [ ] Visually check footer nav on all 11 public pages — each should have page links on row 1, Terms/Privacy on row 2
- [ ] No page should link to itself in its own footer
- [ ] Dashboard: rapid token navigation doesn't cause double-load
- [ ] Dashboard: token rotation stops auto-refresh timer
- [ ] Per-session cert request buttons still work after re-render

🤖 Generated with [Claude Code](https://claude.com/claude-code)