### PR TITLE
fix(urls): derive SITE_BASE from request origin

### DIFF
--- a/pages/functions/api/admin/cert/[token]/resend.js
+++ b/pages/functions/api/admin/cert/[token]/resend.js
@@ -19,8 +19,6 @@ import {
 // retry a stuck send. Use sparingly; the email_outbox drainer also
 // auto-retries failed sends up to MAX_ATTEMPTS.
 
-const SITE_BASE = "https://sc-cpe-web.pages.dev";
-
 function buildBodies({ recipientName, periodDisplay, cpeTotal, sessionsCount, downloadUrl, verifyUrl, issuerName }) {
     const cpeStr = Number.isInteger(cpeTotal) ? `${cpeTotal}` : `${cpeTotal.toFixed(1)}`;
     const subject = `Your ${periodDisplay} Simply Cyber CPE certificate (re-issued link)`;
@@ -90,8 +88,9 @@ export async function onRequestPost({ params, request, env }) {
     const periodDisplay = new Date(Date.UTC(yyyy, mm - 1, 1))
         .toLocaleDateString("en-US", { month: "long", year: "numeric", timeZone: "UTC" });
 
-    const downloadUrl = `${SITE_BASE}/api/download/${cert.public_token}`;
-    const verifyUrl = `${SITE_BASE}/verify.html?t=${cert.public_token}`;
+    const siteBase = new URL(request.url).origin;
+    const downloadUrl = `${siteBase}/api/download/${cert.public_token}`;
+    const verifyUrl = `${siteBase}/verify.html?t=${cert.public_token}`;
 
     const bodies = buildBodies({
         recipientName: cert.recipient_name_snapshot || cert.legal_name,

--- a/pages/functions/api/me/[token]/resend-code.js
+++ b/pages/functions/api/me/[token]/resend-code.js
@@ -15,7 +15,6 @@ import {
 // re-send. Refuses on deleted users.
 
 const MAX_PER_HOUR = 3;
-const SITE_BASE = "https://sc-cpe-web.pages.dev";
 
 function bodies({ legalName, code, expiresAt, dashboardUrl }) {
     const display = formatCode(code);
@@ -89,7 +88,8 @@ export async function onRequestPost({ params, request, env }) {
         UPDATE users SET verification_code = ?1, code_expires_at = ?2 WHERE id = ?3
     `).bind(code, expiresAt, user.id).run();
 
-    const dashboardUrl = `${SITE_BASE}/dashboard.html?t=${user.dashboard_token}`;
+    const siteBase = new URL(request.url).origin;
+    const dashboardUrl = `${siteBase}/dashboard.html?t=${user.dashboard_token}`;
     const b = bodies({
         legalName: user.legal_name || "there",
         code, expiresAt, dashboardUrl,

--- a/pages/functions/api/me/[token]/rotate.js
+++ b/pages/functions/api/me/[token]/rotate.js
@@ -16,8 +16,6 @@ import {
 // build an account-recovery flow that needs another credential.
 
 const MAX_PER_HOUR = 3;
-const SITE_BASE = "https://sc-cpe-web.pages.dev";
-
 function bodies({ legalName, dashboardUrl }) {
     const subject = "Simply Cyber CPE — your dashboard link has been rotated";
     const text =
@@ -85,7 +83,8 @@ export async function onRequestPost({ params, request, env }) {
         "UPDATE users SET dashboard_token = ?1 WHERE id = ?2"
     ).bind(newToken, user.id).run();
 
-    const dashboardUrl = `${SITE_BASE}/dashboard.html?t=${newToken}`;
+    const siteBase = new URL(request.url).origin;
+    const dashboardUrl = `${siteBase}/dashboard.html?t=${newToken}`;
     const b = bodies({
         legalName: user.legal_name || "there",
         dashboardUrl,

--- a/pages/functions/api/recover.js
+++ b/pages/functions/api/recover.js
@@ -4,8 +4,6 @@ import {
     sha256Hex, killSwitched, killedResponse,
 } from "../_lib.js";
 
-const SITE_BASE = "https://sc-cpe-web.pages.dev";
-
 function recoveryEmailBodies({ legalName, dashboardUrl }) {
     const subject = "Your Simply Cyber CPE dashboard link";
     const text = (
@@ -106,7 +104,8 @@ export async function onRequestPost({ request, env }) {
 
     const emailId = ulid();
     const idempotencyKey = `recover:${user.id}:${hourBucket}`;
-    const dashboardUrl = `${SITE_BASE}/dashboard.html?t=${user.dashboard_token}`;
+    const siteBase = new URL(request.url).origin;
+    const dashboardUrl = `${siteBase}/dashboard.html?t=${user.dashboard_token}`;
     const bodies = recoveryEmailBodies({
         legalName: user.legal_name || "there",
         dashboardUrl,

--- a/pages/functions/api/register.js
+++ b/pages/functions/api/register.js
@@ -11,10 +11,8 @@ import {
 // expires after 72h; you rarely re-register more than once a day).
 const MAX_REGISTRATIONS_PER_HOUR = 10;
 
-const SITE_BASE = "https://sc-cpe-web.pages.dev";
-
-function welcomeEmailBodies({ legalName, code, dashboardToken, expiresAt }) {
-    const dashUrl = `${SITE_BASE}/dashboard.html?t=${dashboardToken}`;
+function welcomeEmailBodies({ legalName, code, dashboardToken, expiresAt, siteBase }) {
+    const dashUrl = `${siteBase}/dashboard.html?t=${dashboardToken}`;
     const display = formatCode(code);
     const subject = `Simply Cyber CPE — your verification code`;
     const text = (
@@ -118,8 +116,9 @@ export async function onRequestPost({ request, env }) {
         await audit(env, "user", existing.id, "registration_reissued", "user", existing.id,
             null, { email_sha256: await sha256Hex(email), ip_hash: await ipHash(clientIp(request)) });
 
+        const siteBase = new URL(request.url).origin;
         const bodies = welcomeEmailBodies({
-            legalName, code, dashboardToken: existing.dashboard_token, expiresAt,
+            legalName, code, dashboardToken: existing.dashboard_token, expiresAt, siteBase,
         });
         await queueEmail(env, {
             userId: existing.id,
@@ -152,7 +151,8 @@ export async function onRequestPost({ request, env }) {
         email_sha256: await sha256Hex(email), ip_hash: await ipHash(clientIp(request)),
     });
 
-    const bodies = welcomeEmailBodies({ legalName, code, dashboardToken, expiresAt });
+    const siteBase = new URL(request.url).origin;
+    const bodies = welcomeEmailBodies({ legalName, code, dashboardToken, expiresAt, siteBase });
     await queueEmail(env, {
         userId,
         template: "register",


### PR DESCRIPTION
## Summary
- Replaces hardcoded `const SITE_BASE = "https://sc-cpe-web.pages.dev"` in 5 API endpoint files with dynamic `new URL(request.url).origin`
- Emails (registration, recovery, token rotation, code resend, admin cert resend) will automatically use the correct domain when `cpe.simplycyber.io` is added as a custom domain
- No behavior change on current deployment — the origin resolves to the same value

## Files changed
- `pages/functions/api/register.js` — `siteBase` passed into `welcomeEmailBodies()`
- `pages/functions/api/recover.js` — dashboard URL built from request origin
- `pages/functions/api/me/[token]/rotate.js` — dashboard URL built from request origin
- `pages/functions/api/me/[token]/resend-code.js` — dashboard URL built from request origin
- `pages/functions/api/admin/cert/[token]/resend.js` — download + verify URLs built from request origin

## Test plan
- [x] All 164 unit tests pass
- [x] Zero remaining `SITE_BASE` constants in `pages/functions/`
- [ ] Post-deploy smoke test confirms email links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)