### PR TITLE
fix(hardening): 9 suggestion-tier audit improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,29 @@ ADMIN_TOKEN="$(tr -d '\n' < ~/.cloudflare/sc-cpe-admin-token)" \
   heartbeat now includes `auth_method` (`oauth`/`api_key`/`none`) in
   `detail_json`. `/api/health` surfaces detail per source.
   `/api/admin/ops-stats` warns when poller falls back to API key.
+- **Security audit fixes** — 2026-04-22. Migrations 006 (cert reissue
+  index) + 007 (badge_token). Key changes:
+    - `badge_token` column on `users` — badge/share URLs use this instead
+      of `dashboard_token`, preventing credential leak in shared links.
+      Badge endpoint looks up by `badge_token`. Rotate regenerates both.
+    - Cert reissue unique index: partial unique indexes now exclude
+      `state = 'regenerated'`; reissue endpoint sets old cert to
+      `regenerated` before INSERT to avoid constraint violation.
+    - XSS: admin.js `innerHTML` calls now use `escapeHtml()`;
+      generate.py uses `html.escape()` for recipient_name;
+      cert resend email escapes `sessionsCount`.
+    - enrichShowLinks always sets `enriched_at` (even on fetch failure)
+      to prevent infinite retry loop.
+    - `cert_nudge` added to `EXPECTED_CADENCE_S` in both `_heartbeat.js`
+      and purge worker mirror.
+    - `ip_hash` moved from `after` to `opts` param in 4 audit callers
+      (download, verify, register ×2) so it lands in the `ip_hash` column.
+    - generate.py email claim sets `sent_at` so the email-sender's
+      stuck-row rescue can reclaim it.
+    - Security alert cursor advances to `nowIso` on stale-only digests.
+    - resend-code "within 7 days" corrected to "before it expires".
+    - CRL endpoint sets `Cross-Origin-Resource-Policy: cross-origin`.
+    - admin.js reissue click listener moved to one-time registration.
 
 ## Where to look for more context
 

--- a/db/migrations/006_cert_reissue_index.sql
+++ b/db/migrations/006_cert_reissue_index.sql
@@ -1,0 +1,14 @@
+-- Allow cert reissue without unique-index conflict: exclude 'regenerated'
+-- from the partial unique indexes so the old cert can be marked regenerated
+-- before the new pending row is inserted.
+DROP INDEX IF EXISTS certs_user_period_bundled_unique;
+CREATE UNIQUE INDEX certs_user_period_bundled_unique
+    ON certs(user_id, period_yyyymm)
+    WHERE cert_kind = 'bundled' AND state NOT IN ('revoked', 'regenerated');
+
+DROP INDEX IF EXISTS certs_user_stream_unique;
+CREATE UNIQUE INDEX certs_user_stream_unique
+    ON certs(user_id, stream_id)
+    WHERE cert_kind = 'per_session'
+      AND stream_id IS NOT NULL
+      AND state NOT IN ('revoked', 'regenerated');

--- a/db/migrations/007_badge_token.sql
+++ b/db/migrations/007_badge_token.sql
@@ -1,0 +1,5 @@
+-- Separate badge_token for public badge/share URLs so the dashboard_token
+-- (sole credential) isn't exposed when users share their achievement.
+ALTER TABLE users ADD COLUMN badge_token TEXT;
+UPDATE users SET badge_token = lower(hex(randomblob(32))) WHERE badge_token IS NULL;
+CREATE UNIQUE INDEX users_badge_token_unique ON users(badge_token) WHERE badge_token IS NOT NULL;

--- a/db/migrations/008_email_outbox_composite_index.sql
+++ b/db/migrations/008_email_outbox_composite_index.sql
@@ -1,0 +1,7 @@
+-- Composite index for the email-sender's ORDER BY created_at query.
+-- Replaces the state-only partial index with (state, created_at) so the
+-- drainer avoids a sort step on every tick.
+DROP INDEX IF EXISTS email_outbox_state_idx;
+CREATE INDEX email_outbox_state_created_idx
+    ON email_outbox(state, created_at)
+    WHERE state IN ('queued', 'sending');

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -26,6 +26,7 @@ CREATE TABLE users (
     deleted_at            TEXT,
     CHECK (state IN ('pending_verification','active','inactive','banned','deleted','expired')),
     show_on_leaderboard   INTEGER NOT NULL DEFAULT 0,
+    badge_token           TEXT,
     CHECK (legal_name_attested IN (0,1)),
     CHECK (age_attested_13plus IN (0,1)),
     CHECK (show_on_leaderboard IN (0,1))
@@ -34,6 +35,7 @@ CREATE UNIQUE INDEX users_email_unique ON users(lower(email)) WHERE deleted_at I
 CREATE UNIQUE INDEX users_channel_unique ON users(yt_channel_id) WHERE yt_channel_id IS NOT NULL AND state = 'active';
 CREATE UNIQUE INDEX users_code_unique ON users(verification_code) WHERE verification_code IS NOT NULL;
 CREATE UNIQUE INDEX users_dashboard_token_unique ON users(dashboard_token);
+CREATE UNIQUE INDEX users_badge_token_unique ON users(badge_token) WHERE badge_token IS NOT NULL;
 
 -- Livestream sessions. One row per YouTube video (not per calendar date).
 CREATE TABLE streams (
@@ -120,12 +122,12 @@ CREATE TABLE certs (
 -- can't ADD CONSTRAINT CHECK on ALTER so migration 003 leaves it off.
 CREATE UNIQUE INDEX certs_user_period_bundled_unique
     ON certs(user_id, period_yyyymm)
-    WHERE cert_kind = 'bundled' AND state != 'revoked';
+    WHERE cert_kind = 'bundled' AND state NOT IN ('revoked', 'regenerated');
 CREATE UNIQUE INDEX certs_user_stream_unique
     ON certs(user_id, stream_id)
     WHERE cert_kind = 'per_session'
       AND stream_id IS NOT NULL
-      AND state != 'revoked';
+      AND state NOT IN ('revoked', 'regenerated');
 CREATE INDEX certs_user_idx ON certs(user_id);
 CREATE INDEX certs_kind_idx ON certs(cert_kind);
 CREATE INDEX certs_pending_idx ON certs(state) WHERE state = 'pending';

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -172,7 +172,7 @@ CREATE TABLE email_outbox (
     FOREIGN KEY (user_id) REFERENCES users(id),
     CHECK (state IN ('queued','sending','sent','failed','bounced'))
 );
-CREATE INDEX email_outbox_state_idx ON email_outbox(state) WHERE state IN ('queued','sending');
+CREATE INDEX email_outbox_state_created_idx ON email_outbox(state, created_at) WHERE state IN ('queued','sending');
 
 -- Append-only audit trail. Every state transition writes here.
 -- NEVER UPDATE OR DELETE rows in this table.

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -42,7 +42,7 @@ async function load() {
     renderFeedback(fb);
     $("#ts").textContent = "updated " + new Date().toLocaleTimeString();
   } catch (e) {
-    $("#err").innerHTML = '<div class="err">' + e.message + '</div>';
+    $("#err").innerHTML = '<div class="err">' + escapeHtml(e.message) + '</div>';
     if (String(e.message).includes("unauthorized")) {
       $("#app").style.display = "none";
       $("#login").style.display = "";
@@ -60,7 +60,7 @@ function renderWarnings(s) {
       (isCritical
         ? "background:#3a1818;border-color:#6b2a2a;color:#ffb4b4;"
         : "background:#3a2f18;border-color:#6b5a2a;color:#ffe4a4;");
-    row.innerHTML = "<strong>" + (isCritical ? "CRITICAL" : "warn") + '</strong> \u00b7 <code style="font-size:11px;">' + w.code + "</code> \u2014 " + w.detail;
+    row.innerHTML = "<strong>" + (isCritical ? "CRITICAL" : "warn") + '</strong> \u00b7 <code style="font-size:11px;">' + escapeHtml(w.code) + "</code> \u2014 " + escapeHtml(w.detail);
     box.appendChild(row);
   }
 }
@@ -97,7 +97,7 @@ function renderToggles(d) {
           if (!r.ok) throw new Error("toggle \u2192 HTTP " + r.status);
           load();
         } catch (e) {
-          $("#err").innerHTML = '<div class="err">' + e.message + '</div>';
+          $("#err").innerHTML = '<div class="err">' + escapeHtml(e.message) + '</div>';
           btn.disabled = false;
         }
       });
@@ -187,27 +187,27 @@ function renderFeedback(fb) {
       "<td>" + action + "</td>";
     tb.appendChild(tr);
   }
-  tb.addEventListener("click", async function (e) {
-    var btn = e.target.closest(".reissue-btn");
-    if (!btn || btn.disabled) return;
-    var reason = prompt("Reason for re-issue? (required, max 500 chars)");
-    if (!reason) return;
-    btn.disabled = true; btn.textContent = "queueing\u2026";
-    try {
-      var r = await fetch("/api/admin/cert/" + encodeURIComponent(btn.dataset.cert) + "/reissue", {
-        method: "POST",
-        headers: { "Authorization": "Bearer " + TOKEN, "Content-Type": "application/json" },
-        body: JSON.stringify({ reason: reason }),
-      });
-      var j = await r.json().catch(function () { return {}; });
-      if (!r.ok) throw new Error(j.error || "HTTP " + r.status);
-      btn.outerHTML = '<span class="muted">reissue queued</span>';
-    } catch (err) {
-      btn.disabled = false; btn.textContent = "retry";
-      btn.title = String(err.message || err);
-    }
-  });
 }
+$("#fb tbody").addEventListener("click", async function (e) {
+  var btn = e.target.closest(".reissue-btn");
+  if (!btn || btn.disabled) return;
+  var reason = prompt("Reason for re-issue? (required, max 500 chars)");
+  if (!reason) return;
+  btn.disabled = true; btn.textContent = "queueing…";
+  try {
+    var r = await fetch("/api/admin/cert/" + encodeURIComponent(btn.dataset.cert) + "/reissue", {
+      method: "POST",
+      headers: { "Authorization": "Bearer " + TOKEN, "Content-Type": "application/json" },
+      body: JSON.stringify({ reason: reason }),
+    });
+    var j = await r.json().catch(function () { return {}; });
+    if (!r.ok) throw new Error(j.error || "HTTP " + r.status);
+    btn.outerHTML = '<span class="muted">reissue queued</span>';
+  } catch (err) {
+    btn.disabled = false; btn.textContent = "retry";
+    btn.title = String(err.message || err);
+  }
+});
 function escapeHtml(s) {
   return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) {
     return {"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c];

--- a/pages/badge.js
+++ b/pages/badge.js
@@ -1,13 +1,4 @@
-let token = new URLSearchParams(location.search).get("t");
-if (!token) {
-    try {
-        const raw = localStorage.getItem("sc_cpe_session");
-        if (raw) {
-            const s = JSON.parse(raw);
-            if (s.token && s.saved_at && Date.now() - s.saved_at < 30 * 24 * 60 * 60 * 1000) token = s.token;
-        }
-    } catch (e) {}
-}
+const token = new URLSearchParams(location.search).get("t");
 const errEl = document.getElementById("err");
 
 async function load() {

--- a/pages/badge.js
+++ b/pages/badge.js
@@ -17,7 +17,9 @@ async function load() {
     const svgText = await r.text();
     const blob = new Blob([svgText], { type: "image/svg+xml" });
     const blobUrl = URL.createObjectURL(blob);
-    document.getElementById("badge-img").src = blobUrl;
+    const badgeImg = document.getElementById("badge-img");
+    badgeImg.onload = function () { URL.revokeObjectURL(blobUrl); };
+    badgeImg.src = blobUrl;
 
     const ogImg = document.querySelector('meta[property="og:image"]');
     if (!ogImg) {

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -34,6 +34,7 @@ if (!token) {
 }
 var err = document.getElementById("err");
 var loadInProgress = false;
+var badgeToken = null;
 
 function showLogin() {
     document.getElementById("skel").hidden = true;
@@ -60,6 +61,7 @@ async function load() {
     document.getElementById("name").textContent = d.user.legal_name;
     document.getElementById("state").textContent = d.user.state;
     userState = d.user.state;
+    badgeToken = d.user.badge_token || null;
 
     var hasSaved = !!getSavedSession();
     var rememberCard = document.getElementById("remember-card");
@@ -950,8 +952,9 @@ function showAppealPopover(iso, anchorRect) {
 // --- Share achievement ---
 document.getElementById("share-btn").addEventListener("click", function () {
     var modal = document.getElementById("share-modal");
-    var badgeUrl = location.origin + "/api/badge/" + encodeURIComponent(token);
-    var pageUrl = location.origin + "/badge.html?t=" + encodeURIComponent(token);
+    var shareToken = badgeToken || token;
+    var badgeUrl = location.origin + "/api/badge/" + encodeURIComponent(shareToken);
+    var pageUrl = location.origin + "/badge.html?t=" + encodeURIComponent(shareToken);
     var cpe = document.getElementById("total").textContent;
     var shareText = "I've earned " + cpe + " CPE attending Simply Cyber's Daily Threat Briefing! Verified via cryptographic audit chain. #SimplyCyber #CPE";
 

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -650,18 +650,25 @@ document.getElementById("cal").addEventListener("click", function (e) {
 function renderCalendar() {
     var grid = document.getElementById("cal");
     grid.innerHTML = "";
+    grid.setAttribute("role", "grid");
     var y = calCursor.getFullYear();
     var m = calCursor.getMonth();
-    document.getElementById("cal-label").textContent =
-        calCursor.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+    var monthLabel = calCursor.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+    document.getElementById("cal-label").textContent = monthLabel;
+    grid.setAttribute("aria-label", monthLabel + " attendance calendar");
 
     var headers = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];
+    var headerRow = document.createElement("div");
+    headerRow.setAttribute("role", "row");
+    headerRow.style.display = "contents";
     for (var hi = 0; hi < headers.length; hi++) {
         var d = document.createElement("div");
         d.className = "cal-head";
+        d.setAttribute("role", "columnheader");
         d.textContent = headers[hi];
-        grid.appendChild(d);
+        headerRow.appendChild(d);
     }
+    grid.appendChild(headerRow);
 
     var credited = new Set();
     for (var ai = 0; ai < calData.attendance.length; ai++) {
@@ -681,12 +688,14 @@ function renderCalendar() {
     for (var i = 0; i < firstDow; i++) {
         var cell = document.createElement("div");
         cell.className = "cal-cell cal-empty";
+        cell.setAttribute("role", "gridcell");
         grid.appendChild(cell);
     }
     for (var day = 1; day <= daysInMonth; day++) {
         var iso = y + "-" + String(m + 1).padStart(2, "0") + "-" + String(day).padStart(2, "0");
         var cell = document.createElement("div");
         cell.className = "cal-cell";
+        cell.setAttribute("role", "gridcell");
         if (iso === todayIso) cell.classList.add("cal-today");
 
         var dots = [];

--- a/pages/functions/_heartbeat.js
+++ b/pages/functions/_heartbeat.js
@@ -17,6 +17,7 @@ export const EXPECTED_CADENCE_S = {
     canary: 3600,           // hourly synthetic smoke
     monthly_digest: 2678400, // ~31 days; fires 1st of month
     link_enrichment: 86400, // daily; piggybacks on purge
+    cert_nudge: 2678400,    // ~31 days; fires 1st of month via purge
 };
 
 // True when `now` falls inside the poller's ET weekday window. Vars come from

--- a/pages/functions/_lib.js
+++ b/pages/functions/_lib.js
@@ -98,7 +98,7 @@ export async function audit(env, actorType, actorId, action, entityType, entityI
         before_json: before == null ? null : JSON.stringify(before),
         after_json: after == null ? null : JSON.stringify(after),
         ip_hash: opts.ip_hash ?? null,
-        user_agent: opts.user_agent ?? null,
+        user_agent: opts.user_agent ? opts.user_agent.slice(0, 500) : null,
         ts: null,
         prev_hash: null,
     };

--- a/pages/functions/_middleware.js
+++ b/pages/functions/_middleware.js
@@ -16,7 +16,7 @@
 
 const CSP = [
     "default-src 'self'",
-    "script-src 'self' https://challenges.cloudflare.com https://cdnjs.cloudflare.com",
+    "script-src 'self' https://challenges.cloudflare.com https://cdnjs.cloudflare.com/ajax/libs/jszip/",
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob:",
     "font-src 'self'",

--- a/pages/functions/api/admin/cert/[id]/reissue.js
+++ b/pages/functions/api/admin/cert/[id]/reissue.js
@@ -50,6 +50,10 @@ export async function onRequestPost({ params, request, env }) {
     const publicToken = randomHex(32);
     const ts = now();
 
+    await env.DB.prepare(
+        "UPDATE certs SET state = 'regenerated' WHERE id = ?1 AND state != 'revoked'"
+    ).bind(certId).run();
+
     await env.DB.prepare(`
         INSERT INTO certs (
             id, public_token, user_id,

--- a/pages/functions/api/admin/cert/[token]/resend.js
+++ b/pages/functions/api/admin/cert/[token]/resend.js
@@ -1,6 +1,6 @@
 import {
     json, audit, clientIp, ipHash, isAdmin, queueEmail, now,
-    escapeHtml, emailShell,
+    escapeHtml, emailShell, rateLimit,
 } from "../../../../_lib.js";
 
 // POST /api/admin/cert/{public_token}/resend
@@ -81,6 +81,9 @@ export async function onRequestPost({ params, request, env }) {
     if (cert.state === "revoked") return json({ error: "cert_revoked" }, 409);
     if (!cert.pdf_r2_key) return json({ error: "cert_pdf_missing" }, 409);
     if (cert.deleted_at) return json({ error: "user_deleted" }, 409);
+
+    const rl = await rateLimit(env, `cert_resend:${cert.id}`, 5);
+    if (!rl.ok) return json(rl.body, rl.status);
 
     // period_yyyymm "202602" -> "February 2026"
     const yyyy = parseInt(cert.period_yyyymm.slice(0, 4), 10);

--- a/pages/functions/api/admin/cert/[token]/resend.js
+++ b/pages/functions/api/admin/cert/[token]/resend.js
@@ -36,7 +36,7 @@ function buildBodies({ recipientName, periodDisplay, cpeTotal, sessionsCount, do
 <p>Your <strong>${escapeHtml(periodDisplay)}</strong> Simply Cyber CPE certificate is ready.</p>
 <ul>
   <li>CPE credit hours: <strong>${escapeHtml(cpeStr)}</strong></li>
-  <li>Sessions attended: <strong>${sessionsCount}</strong></li>
+  <li>Sessions attended: <strong>${escapeHtml(String(sessionsCount))}</strong></li>
 </ul>
 <p>
   <a href="${downloadUrl}"

--- a/pages/functions/api/badge/[token].js
+++ b/pages/functions/api/badge/[token].js
@@ -14,7 +14,7 @@ export async function onRequestGet({ params, env, request }) {
 
     const user = await env.DB.prepare(`
         SELECT id, legal_name, state
-        FROM users WHERE dashboard_token = ?1 AND deleted_at IS NULL
+        FROM users WHERE badge_token = ?1 AND deleted_at IS NULL
     `).bind(token).first();
 
     if (!user) {

--- a/pages/functions/api/coverage.test.mjs
+++ b/pages/functions/api/coverage.test.mjs
@@ -491,7 +491,7 @@ test("badge: short token → 400", async () => {
 
 test("badge: unknown token → 404", async () => {
     const db = mockDB([
-        { match: /FROM users WHERE dashboard_token/, handler: () => ({ first: null })},
+        { match: /FROM users WHERE badge_token/, handler: () => ({ first: null })},
     ]);
     const r = await badgeGet({
         params: { token: "a".repeat(32) },
@@ -503,7 +503,7 @@ test("badge: unknown token → 404", async () => {
 
 test("badge: valid user → SVG with correct content type", async () => {
     const db = mockDB([
-        { match: /FROM users WHERE dashboard_token/, handler: () => ({
+        { match: /FROM users WHERE badge_token/, handler: () => ({
             first: { id: "u1", legal_name: "Alice Test", state: "active" },
         })},
         { match: /FROM attendance a JOIN streams/, handler: () => ({
@@ -528,7 +528,7 @@ test("badge: valid user → SVG with correct content type", async () => {
 
 test("badge: XSS in legal_name is escaped in SVG", async () => {
     const db = mockDB([
-        { match: /FROM users WHERE dashboard_token/, handler: () => ({
+        { match: /FROM users WHERE badge_token/, handler: () => ({
             first: { id: "u1", legal_name: '<script>alert("xss")</script>', state: "active" },
         })},
         { match: /FROM attendance a JOIN streams/, handler: () => ({ all: [] })},

--- a/pages/functions/api/crl.json.js
+++ b/pages/functions/api/crl.json.js
@@ -50,6 +50,7 @@ export async function onRequestGet({ env }) {
             "Content-Type": "application/json",
             "Cache-Control": "public, max-age=300",
             "Access-Control-Allow-Origin": "*",
+            "Cross-Origin-Resource-Policy": "cross-origin",
         },
     });
 }

--- a/pages/functions/api/download/[token].js
+++ b/pages/functions/api/download/[token].js
@@ -23,7 +23,7 @@ export async function onRequestGet({ params, env, request }) {
     if (!row) {
         return new Response("not found", { status: 404 });
     }
-    if (row.state === "revoked") {
+    if (row.state === "revoked" || row.state === "regenerated") {
         return new Response("certificate revoked", { status: 410 });
     }
     if (!row.pdf_r2_key) {

--- a/pages/functions/api/download/[token].js
+++ b/pages/functions/api/download/[token].js
@@ -58,7 +58,7 @@ export async function onRequestGet({ params, env, request }) {
         }
     }
 
-    await audit(env, "api", null, "cert_downloaded", "cert", row.id, null, {
+    await audit(env, "api", null, "cert_downloaded", "cert", row.id, null, null, {
         ip_hash: await ipHash(clientIp(request)),
     });
 

--- a/pages/functions/api/me/[token].js
+++ b/pages/functions/api/me/[token].js
@@ -16,7 +16,7 @@ export async function onRequestGet({ params, env, request }) {
     const user = await env.DB.prepare(`
         SELECT id, email, legal_name, yt_channel_id, yt_display_name_seen,
                verification_code, code_expires_at, state, email_prefs,
-               show_on_leaderboard, created_at, verified_at
+               show_on_leaderboard, badge_token, created_at, verified_at
         FROM users WHERE dashboard_token = ?1 AND deleted_at IS NULL
     `).bind(token).first();
 
@@ -141,6 +141,7 @@ export async function onRequestGet({ params, env, request }) {
             code_expires_at: user.code_expires_at,
             email_prefs: emailPrefs,
             show_on_leaderboard: !!user.show_on_leaderboard,
+            badge_token: user.badge_token,
             created_at: user.created_at,
             verified_at: user.verified_at,
         },

--- a/pages/functions/api/me/[token]/resend-code.js
+++ b/pages/functions/api/me/[token]/resend-code.js
@@ -22,7 +22,7 @@ function bodies({ legalName, code, expiresAt, dashboardUrl }) {
     const text =
         `Hi ${legalName},\n\n` +
         `You requested a fresh verification code. Paste this into a live chat\n` +
-        `message during the Daily Threat Briefing on YouTube within 7 days:\n\n` +
+        `message during the Daily Threat Briefing on YouTube before it expires:\n\n` +
         `    ${display}\n\n` +
         `The code expires ${expiresAt}.\n\n` +
         `Your dashboard:\n  ${dashboardUrl}\n\n` +
@@ -31,7 +31,7 @@ function bodies({ legalName, code, expiresAt, dashboardUrl }) {
     const bodyHtml = `
 <p>Hi ${escapeHtml(legalName)},</p>
 <p>You requested a fresh verification code. Paste this into a live chat
-message during the Daily Threat Briefing on YouTube within 7 days:</p>
+message during the Daily Threat Briefing on YouTube before it expires:</p>
 <p style="font-family:Menlo,monospace;font-size:20pt;text-align:center;
    background:#f4f6f8;padding:14px;border-radius:6px;letter-spacing:0.04em;">
    ${escapeHtml(display)}

--- a/pages/functions/api/me/[token]/rotate.js
+++ b/pages/functions/api/me/[token]/rotate.js
@@ -79,9 +79,10 @@ export async function onRequestPost({ params, request, env }) {
     if (!rl.ok) return json(rl.body, rl.status);
 
     const newToken = randomToken();
+    const newBadgeToken = randomToken();
     await env.DB.prepare(
-        "UPDATE users SET dashboard_token = ?1 WHERE id = ?2"
-    ).bind(newToken, user.id).run();
+        "UPDATE users SET dashboard_token = ?1, badge_token = ?2 WHERE id = ?3"
+    ).bind(newToken, newBadgeToken, user.id).run();
 
     const siteBase = new URL(request.url).origin;
     const dashboardUrl = `${siteBase}/dashboard.html?t=${newToken}`;

--- a/pages/functions/api/onboarding.test.mjs
+++ b/pages/functions/api/onboarding.test.mjs
@@ -616,7 +616,7 @@ test("rotate: updates dashboard_token, queues email, returns no new token", asyn
             handler: () => ({ first: { id: FAKE_ULID, email: "alice@example.com", legal_name: "Alice Smith" } }),
         },
         {
-            match: /UPDATE users SET dashboard_token = \?1 WHERE id = \?2/,
+            match: /UPDATE users SET dashboard_token = \?1, badge_token = \?2 WHERE id = \?3/,
             handler: (_sql, binds) => { updatedToken = binds[0]; return { run: { meta: {} } }; },
         },
         {

--- a/pages/functions/api/register.js
+++ b/pages/functions/api/register.js
@@ -114,7 +114,7 @@ export async function onRequestPost({ request, env }) {
         `).bind(legalName, code, expiresAt, tosVersion, existing.id).run();
 
         await audit(env, "user", existing.id, "registration_reissued", "user", existing.id,
-            null, { email_sha256: await sha256Hex(email), ip_hash: await ipHash(clientIp(request)) });
+            null, { email_sha256: await sha256Hex(email) }, { ip_hash: await ipHash(clientIp(request)) });
 
         const siteBase = new URL(request.url).origin;
         const bodies = welcomeEmailBodies({
@@ -139,17 +139,18 @@ export async function onRequestPost({ request, env }) {
 
     const userId = ulid();
     const dashboardToken = randomToken();
+    const badgeToken = randomToken();
 
     await env.DB.prepare(`
         INSERT INTO users (id, email, legal_name, verification_code, code_expires_at,
-                           dashboard_token, state, legal_name_attested, age_attested_13plus,
-                           tos_version_accepted, created_at)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'pending_verification', 1, 1, ?7, ?8)
-    `).bind(userId, email, legalName, code, expiresAt, dashboardToken, tosVersion, nowIso).run();
+                           dashboard_token, badge_token, state, legal_name_attested,
+                           age_attested_13plus, tos_version_accepted, created_at)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'pending_verification', 1, 1, ?8, ?9)
+    `).bind(userId, email, legalName, code, expiresAt, dashboardToken, badgeToken, tosVersion, nowIso).run();
 
-    await audit(env, "user", userId, "registration_created", "user", userId, null, {
-        email_sha256: await sha256Hex(email), ip_hash: await ipHash(clientIp(request)),
-    });
+    await audit(env, "user", userId, "registration_created", "user", userId, null,
+        { email_sha256: await sha256Hex(email) },
+        { ip_hash: await ipHash(clientIp(request)) });
 
     const siteBase = new URL(request.url).origin;
     const bodies = welcomeEmailBodies({ legalName, code, dashboardToken, expiresAt, siteBase });

--- a/pages/functions/api/register.js
+++ b/pages/functions/api/register.js
@@ -62,7 +62,7 @@ export async function onRequestPost({ request, env }) {
     const legalName = (body.legal_name || "").trim();
     const legalAttested = !!body.legal_name_attested;
     const ageAttested = !!body.age_attested_13plus;
-    const tosVersion = body.tos_version || "v1";
+    const tosVersion = (body.tos_version || "v1").slice(0, 20);
     const turnstileToken = body.turnstile_token;
 
     if (!isValidEmail(email)) return json({ error: "invalid_email" }, 400);

--- a/pages/functions/api/verify/[token].js
+++ b/pages/functions/api/verify/[token].js
@@ -33,7 +33,7 @@ export async function onRequestGet({ params, env, request }) {
         WHERE id = ?2 AND first_viewed_at IS NULL
     `).bind(new Date().toISOString(), row.id).run();
 
-    await audit(env, "api", null, "cert_verified", "cert", row.id, null, {
+    await audit(env, "api", null, "cert_verified", "cert", row.id, null, null, {
         ip_hash: await ipHash(clientIp(request)),
     });
 

--- a/services/certs/generate.py
+++ b/services/certs/generate.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import base64
 import datetime as dt
 import hashlib
+import html as html_mod
 import io
 import json
 import os
@@ -718,7 +719,7 @@ def build_email_bodies(
     )
     html = f"""<!doctype html>
 <html><body style="font-family:Helvetica,Arial,sans-serif;color:#111;line-height:1.45;">
-<p>Hi {recipient_name},</p>
+<p>Hi {html_mod.escape(recipient_name)},</p>
 <p>Your <strong>{period_display}</strong> Simply Cyber CPE certificate is ready.
 {attended_sentence}</p>
 <ul>
@@ -1009,9 +1010,10 @@ def issue_for_user(
 
     # 12. Send via Resend; tolerate send failure (outbox still queued).
     try:
+        claimed_at = now_iso_utc()
         d1.execute(
-            "UPDATE email_outbox SET state = 'sending', attempts = attempts + 1 WHERE id = ?",
-            [email_id],
+            "UPDATE email_outbox SET state = 'sending', attempts = attempts + 1, sent_at = ? WHERE id = ?",
+            [claimed_at, email_id],
         )
         msg_id = send_resend_email(
             api_key=cfg.resend_api_key,

--- a/workers/purge/src/heartbeat-staleness.test.mjs
+++ b/workers/purge/src/heartbeat-staleness.test.mjs
@@ -17,7 +17,7 @@ function ago(s) { return new Date(NOW_MS - s * 1000).toISOString(); }
 test("staleHeartbeats: empty table → every known non-poller source stale", () => {
     const out = staleHeartbeats([], NOW_MS);
     const sources = out.map(r => r.source).sort();
-    assert.deepEqual(sources, ["canary", "email_sender", "link_enrichment", "monthly_digest", "purge", "security_alerts"]);
+    assert.deepEqual(sources, ["canary", "cert_nudge", "email_sender", "link_enrichment", "monthly_digest", "purge", "security_alerts"]);
     assert.ok(out.every(r => r.reason === "never_beat"));
 });
 
@@ -29,6 +29,7 @@ test("staleHeartbeats: fresh beats → none stale", () => {
         { source: "canary", last_beat_at: ago(600), last_status: "ok" },
         { source: "monthly_digest", last_beat_at: ago(86400), last_status: "ok" },
         { source: "link_enrichment", last_beat_at: ago(3600), last_status: "ok" },
+        { source: "cert_nudge", last_beat_at: ago(86400), last_status: "ok" },
     ];
     assert.deepEqual(staleHeartbeats(rows, NOW_MS), []);
 });
@@ -41,6 +42,7 @@ test("staleHeartbeats: email_sender 11 min old → stale", () => {
         { source: "canary", last_beat_at: ago(600), last_status: "ok" },
         { source: "monthly_digest", last_beat_at: ago(86400), last_status: "ok" },
         { source: "link_enrichment", last_beat_at: ago(3600), last_status: "ok" },
+        { source: "cert_nudge", last_beat_at: ago(86400), last_status: "ok" },
     ];
     const out = staleHeartbeats(rows, NOW_MS);
     assert.equal(out.length, 1);
@@ -58,6 +60,7 @@ test("staleHeartbeats: poller excluded regardless of staleness", () => {
         { source: "canary", last_beat_at: ago(600), last_status: "ok" },
         { source: "monthly_digest", last_beat_at: ago(86400), last_status: "ok" },
         { source: "link_enrichment", last_beat_at: ago(3600), last_status: "ok" },
+        { source: "cert_nudge", last_beat_at: ago(86400), last_status: "ok" },
     ];
     assert.deepEqual(staleHeartbeats(rows, NOW_MS), []);
 });
@@ -70,6 +73,7 @@ test("staleHeartbeats: unknown source ignored", () => {
         { source: "canary", last_beat_at: ago(600), last_status: "ok" },
         { source: "monthly_digest", last_beat_at: ago(86400), last_status: "ok" },
         { source: "link_enrichment", last_beat_at: ago(3600), last_status: "ok" },
+        { source: "cert_nudge", last_beat_at: ago(86400), last_status: "ok" },
         { source: "mystery_cron", last_beat_at: ago(7 * 86400), last_status: "ok" },
     ];
     assert.deepEqual(staleHeartbeats(rows, NOW_MS), []);

--- a/workers/purge/src/index.js
+++ b/workers/purge/src/index.js
@@ -457,6 +457,7 @@ const EXPECTED_CADENCE_S = {
     canary: 3600,
     monthly_digest: 2678400,
     link_enrichment: 86400,
+    cert_nudge: 2678400,
 };
 
 function staleHeartbeats(rows, nowMs) {
@@ -564,15 +565,14 @@ async function runSecurityAlerts(env, nowIso) {
         throw new Error(`resend_${resp.status}: ${body}`);
     }
 
-    // Advance cursor only after a successful send so a failed email gets
-    // retried on the next run instead of being silently lost. If there were
-    // no audit events (digest was purely a staleness alarm), keep the cursor
-    // where it was so the next run still scans from the same point.
+    // Advance cursor past the newest audit event we included, or to now if
+    // the digest was purely a staleness alarm (so we don't re-send the same
+    // stale-heartbeat digest every run).
     return {
         scanned_since: since,
         events: rows.length,
         stale_heartbeats: stale.length,
-        cursor_ts: rows.length ? rows[rows.length - 1].ts : since,
+        cursor_ts: rows.length ? rows[rows.length - 1].ts : nowIso,
     };
 }
 
@@ -620,11 +620,9 @@ async function enrichShowLinks(env, nowIso) {
         } catch {
             failed++;
         }
-        if (fetchOk || title) {
-            await env.DB.prepare(
-                "UPDATE show_links SET title = ?1, description = ?2, enriched_at = ?3 WHERE id = ?4"
-            ).bind(title, description, nowIso, row.id).run();
-        }
+        await env.DB.prepare(
+            "UPDATE show_links SET title = ?1, description = ?2, enriched_at = ?3 WHERE id = ?4"
+        ).bind(title, description, nowIso, row.id).run();
     }
     return { candidates: rows.length, enriched, failed };
 }


### PR DESCRIPTION
## Summary
- **S2**: Pin CSP `script-src` to exact cdnjs library path (`/ajax/libs/jszip/`) instead of full CDN domain
- **S3**: Cap `tos_version` to 20 chars at registration to prevent oversized values
- **S4**: Truncate `user_agent` to 500 chars in audit log helper
- **S5**: Block download of regenerated (superseded) certs — returns 410 alongside revoked
- **S6**: Add `(state, created_at)` composite index on `email_outbox` (migration 008) so the drainer avoids a sort step
- **S7**: Add per-cert rate limit (5/hr) to admin cert resend endpoint
- **S8**: Add ARIA `role="grid"`, `role="row"`, `role="columnheader"`, `role="gridcell"` to attendance calendar
- **S9**: No code change needed — poller finalization already handles missing `nextPageToken` correctly
- **S10**: Fix blob URL memory leak in badge page (revoke on image load)

## Test plan
- [x] All 164 node tests pass
- [ ] Smoke test after deploy: `scripts/smoke_hardening.sh`
- [ ] Verify calendar screen reader behavior with NVDA/VoiceOver
- [ ] Confirm cert download returns 410 for regenerated certs
- [ ] Verify admin cert resend rate limit triggers after 5 resends

🤖 Generated with [Claude Code](https://claude.com/claude-code)