### PR TITLE
feat(links): archive v2 — empty days, copy, RSS, Discord backfill

### DIFF
--- a/pages/functions/api/coverage.test.mjs
+++ b/pages/functions/api/coverage.test.mjs
@@ -12,6 +12,7 @@ import { onRequestGet as annualSummaryGet } from "./me/[token]/annual-summary.js
 import { onRequestGet as leaderboardGet } from "./leaderboard.js";
 import { onRequestGet as linksGet } from "./links.js";
 import { onRequestGet as badgeGet } from "./badge/[token].js";
+import { onRequestGet as rssGet } from "./links/rss.js";
 
 // ── helpers ───────────────────────────────────────────────────────────────
 
@@ -556,6 +557,57 @@ test("links: viewer links excluded from response", async () => {
     });
     assert.ok(showLinksSql, "show_links query must have been executed");
     assert.ok(/author_type IN/.test(showLinksSql), "show_links query must filter by author_type");
+});
+
+// ── rss ──────────────────────────────────────────────────────────────────
+
+test("rss: returns valid XML with content-type application/rss+xml", async () => {
+    const db = mockDB([
+        { match: /LEFT JOIN show_links.*GROUP BY/s, handler: () => ({
+            all: [{ scheduled_date: "2026-04-10", cnt: 2 }],
+        })},
+        { match: /FROM streams\s+WHERE scheduled_date/s, handler: () => ({
+            first: { id: "s1", title: "DTB 2026-04-10", yt_video_id: "v1" },
+        })},
+        { match: /FROM show_links\s+WHERE stream_id/s, handler: () => ({
+            all: [
+                { url: "https://example.com", domain: "example.com", title: "Test Link",
+                  description: "A test", author_type: "owner", author_name: "SC", posted_at: "2026-04-10T10:00:00Z" },
+            ],
+        })},
+    ]);
+    const r = await rssGet({
+        env: { DB: db, RATE_KV: kvPermissive },
+        request: getReq("https://sc-cpe-web.pages.dev/api/links/rss"),
+    });
+    assert.equal(r.status, 200);
+    assert.ok(r.headers.get("Content-Type").includes("application/rss+xml"));
+    const body = await r.text();
+    assert.ok(body.includes("<rss"));
+    assert.ok(body.includes("Test Link"));
+    assert.ok(body.includes("2026-04-10"));
+});
+
+test("rss: rate limit trips → 429", async () => {
+    const r = await rssGet({
+        env: { DB: mockDB([]), RATE_KV: kvTripped },
+        request: getReq("https://sc-cpe-web.pages.dev/api/links/rss"),
+    });
+    assert.equal(r.status, 429);
+});
+
+test("rss: no data → valid XML with zero items", async () => {
+    const db = mockDB([
+        { match: /LEFT JOIN show_links.*GROUP BY/s, handler: () => ({ all: [] })},
+    ]);
+    const r = await rssGet({
+        env: { DB: db, RATE_KV: kvPermissive },
+        request: getReq("https://sc-cpe-web.pages.dev/api/links/rss"),
+    });
+    assert.equal(r.status, 200);
+    const body = await r.text();
+    assert.ok(body.includes("<rss"));
+    assert.ok(!body.includes("<item>"));
 });
 
 // ── badge ────────────────────────────────────────────────────────────────

--- a/pages/functions/api/coverage.test.mjs
+++ b/pages/functions/api/coverage.test.mjs
@@ -413,7 +413,7 @@ test("leaderboard: rate limit trips → 429", async () => {
 
 test("links: no data → empty response", async () => {
     const db = mockDB([
-        { match: /FROM streams.*show_links.*ORDER BY.*DESC.*LIMIT 1/s, handler: () => ({ first: null })},
+        { match: /LEFT JOIN show_links/, handler: () => ({ all: [] })},
     ]);
     const r = await linksGet({
         env: { DB: db, RATE_KV: kvPermissive },
@@ -423,19 +423,24 @@ test("links: no data → empty response", async () => {
     const j = await r.json();
     assert.equal(j.date, null);
     assert.deepEqual(j.links, []);
+    assert.deepEqual(j.available_dates, []);
+    assert.deepEqual(j.date_link_counts, {});
 });
 
 test("links: with date param → returns links for that date", async () => {
     const db = mockDB([
+        { match: /LEFT JOIN show_links/, handler: () => ({
+            all: [
+                { scheduled_date: "2026-04-10", cnt: 3 },
+                { scheduled_date: "2026-04-09", cnt: 0 },
+            ],
+        })},
         { match: /FROM streams\s+WHERE scheduled_date/s, handler: () => ({
             first: { id: "s1", title: "DTB 2026-04-10", yt_video_id: "v1" },
         })},
-        { match: /FROM show_links/, handler: () => ({
+        { match: /FROM show_links\s+WHERE stream_id/s, handler: () => ({
             all: [{ url: "https://example.com", domain: "example.com", title: "Test",
-                     description: null, author_type: "host", author_name: "SC", posted_at: "2026-04-10T10:00:00Z" }],
-        })},
-        { match: /DISTINCT.*scheduled_date/, handler: () => ({
-            all: [{ scheduled_date: "2026-04-10" }, { scheduled_date: "2026-04-09" }],
+                     description: null, author_type: "owner", author_name: "SC", posted_at: "2026-04-10T10:00:00Z" }],
         })},
     ]);
     const r = await linksGet({
@@ -460,14 +465,16 @@ test("links: rate limit trips → 429", async () => {
 
 test("links: invalid date param falls back to latest", async () => {
     const db = mockDB([
-        { match: /FROM streams.*show_links.*ORDER BY.*DESC.*LIMIT 1/s, handler: () => ({
-            first: { scheduled_date: "2026-04-10" },
+        { match: /LEFT JOIN show_links/, handler: () => ({
+            all: [
+                { scheduled_date: "2026-04-10", cnt: 3 },
+                { scheduled_date: "2026-04-09", cnt: 0 },
+            ],
         })},
         { match: /FROM streams\s+WHERE scheduled_date/s, handler: () => ({
             first: { id: "s1", title: "DTB", yt_video_id: "v1" },
         })},
-        { match: /FROM show_links/, handler: () => ({ all: [] })},
-        { match: /DISTINCT.*scheduled_date/, handler: () => ({ all: [{ scheduled_date: "2026-04-10" }] })},
+        { match: /FROM show_links\s+WHERE stream_id/s, handler: () => ({ all: [] })},
     ]);
     const r = await linksGet({
         env: { DB: db, RATE_KV: kvPermissive },
@@ -476,6 +483,79 @@ test("links: invalid date param falls back to latest", async () => {
     assert.equal(r.status, 200);
     const j = await r.json();
     assert.equal(j.date, "2026-04-10");
+});
+
+test("links: response includes date_link_counts object", async () => {
+    const db = mockDB([
+        { match: /LEFT JOIN show_links/, handler: () => ({
+            all: [
+                { scheduled_date: "2026-04-10", cnt: 5 },
+                { scheduled_date: "2026-04-09", cnt: 2 },
+                { scheduled_date: "2026-04-08", cnt: 0 },
+            ],
+        })},
+        { match: /FROM streams\s+WHERE scheduled_date/s, handler: () => ({
+            first: { id: "s1", title: "DTB 2026-04-10", yt_video_id: "v1" },
+        })},
+        { match: /FROM show_links\s+WHERE stream_id/s, handler: () => ({ all: [] })},
+    ]);
+    const r = await linksGet({
+        env: { DB: db, RATE_KV: kvPermissive },
+        request: getReq("https://sc-cpe-web.pages.dev/api/links"),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(typeof j.date_link_counts, "object");
+    assert.equal(j.date_link_counts["2026-04-10"], 5);
+    assert.equal(j.date_link_counts["2026-04-09"], 2);
+    assert.equal(j.date_link_counts["2026-04-08"], 0);
+});
+
+test("links: empty show day — stream exists, no links", async () => {
+    const db = mockDB([
+        { match: /LEFT JOIN show_links/, handler: () => ({
+            all: [
+                { scheduled_date: "2026-04-10", cnt: 3 },
+                { scheduled_date: "2026-04-09", cnt: 0 },
+            ],
+        })},
+        { match: /FROM streams\s+WHERE scheduled_date/s, handler: () => ({
+            first: { id: "s2", title: "DTB 2026-04-09", yt_video_id: "v2" },
+        })},
+        { match: /FROM show_links\s+WHERE stream_id/s, handler: () => ({ all: [] })},
+    ]);
+    const r = await linksGet({
+        env: { DB: db, RATE_KV: kvPermissive },
+        request: getReq("https://sc-cpe-web.pages.dev/api/links?date=2026-04-09"),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.date, "2026-04-09");
+    assert.ok(j.stream, "stream info should be present");
+    assert.equal(j.stream.title, "DTB 2026-04-09");
+    assert.deepEqual(j.links, []);
+});
+
+test("links: viewer links excluded from response", async () => {
+    let showLinksSql = null;
+    const db = mockDB([
+        { match: /LEFT JOIN show_links/, handler: () => ({
+            all: [{ scheduled_date: "2026-04-10", cnt: 1 }],
+        })},
+        { match: /FROM streams\s+WHERE scheduled_date/s, handler: () => ({
+            first: { id: "s1", title: "DTB", yt_video_id: "v1" },
+        })},
+        { match: /FROM show_links\s+WHERE stream_id/s, handler: (sql) => {
+            showLinksSql = sql;
+            return { all: [] };
+        }},
+    ]);
+    await linksGet({
+        env: { DB: db, RATE_KV: kvPermissive },
+        request: getReq("https://sc-cpe-web.pages.dev/api/links?date=2026-04-10"),
+    });
+    assert.ok(showLinksSql, "show_links query must have been executed");
+    assert.ok(/author_type IN/.test(showLinksSql), "show_links query must filter by author_type");
 });
 
 // ── badge ────────────────────────────────────────────────────────────────

--- a/pages/functions/api/links.js
+++ b/pages/functions/api/links.js
@@ -10,28 +10,39 @@ export async function onRequestGet({ env, request }) {
     const limit = Math.min(Math.max(parseInt(url.searchParams.get("limit") || "30", 10) || 30, 1), 30);
     const offset = Math.max(parseInt(url.searchParams.get("offset") || "0", 10) || 0, 0);
 
+    const countsRs = await env.DB.prepare(`
+        SELECT s.scheduled_date,
+               COUNT(CASE WHEN sl.author_type IN ('owner','moderator') THEN 1 END) AS cnt
+          FROM streams s
+          LEFT JOIN show_links sl ON sl.stream_id = s.id
+         WHERE s.state IN ('live','complete','flagged','rescanned')
+      GROUP BY s.scheduled_date
+      ORDER BY s.scheduled_date DESC
+         LIMIT 90
+    `).all();
+    const countsRows = countsRs.results || [];
+
+    const available_dates = countsRows.map(r => r.scheduled_date);
+    const date_link_counts = {};
+    for (const r of countsRows) {
+        date_link_counts[r.scheduled_date] = r.cnt;
+    }
+
     let date = dateParam;
     if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-        const latest = await env.DB.prepare(`
-            SELECT s.scheduled_date
-              FROM streams s
-             WHERE s.id IN (SELECT stream_id FROM show_links)
-               AND s.state IN ('live','complete','flagged')
-          ORDER BY s.scheduled_date DESC
-             LIMIT 1
-        `).first();
-        date = latest?.scheduled_date || null;
+        const firstWithLinks = countsRows.find(r => r.cnt > 0);
+        date = firstWithLinks?.scheduled_date || null;
     }
 
     if (!date) {
-        return json({ date: null, stream: null, links: [], available_dates: [] });
+        return json({ date: null, stream: null, links: [], available_dates: [], date_link_counts: {} });
     }
 
     const stream = await env.DB.prepare(`
         SELECT id, title, yt_video_id
           FROM streams
          WHERE scheduled_date = ?1
-           AND state IN ('live','complete','flagged')
+           AND state IN ('live','complete','flagged','rescanned')
          LIMIT 1
     `).bind(date).first();
 
@@ -42,6 +53,7 @@ export async function onRequestGet({ env, request }) {
                    author_name, posted_at
               FROM show_links
              WHERE stream_id = ?1
+               AND author_type IN ('owner','moderator')
           ORDER BY posted_at ASC
              LIMIT ?2 OFFSET ?3
         `).bind(stream.id, limit, offset).all();
@@ -56,20 +68,11 @@ export async function onRequestGet({ env, request }) {
         }));
     }
 
-    const datesRs = await env.DB.prepare(`
-        SELECT DISTINCT s.scheduled_date
-          FROM streams s
-         WHERE s.id IN (SELECT stream_id FROM show_links)
-           AND s.state IN ('live','complete','flagged')
-      ORDER BY s.scheduled_date DESC
-         LIMIT 60
-    `).all();
-    const available_dates = (datesRs.results || []).map(r => r.scheduled_date);
-
     return json({
         date,
         stream: stream ? { title: stream.title, yt_video_id: stream.yt_video_id } : null,
         links,
         available_dates,
+        date_link_counts,
     });
 }

--- a/pages/functions/api/links/rss.js
+++ b/pages/functions/api/links/rss.js
@@ -1,0 +1,88 @@
+import { json, clientIp, ipHash, rateLimit, escapeHtml } from "../../_lib.js";
+
+function rfc2822(dateStr) {
+    return new Date(dateStr + "T12:00:00Z").toUTCString();
+}
+
+export async function onRequestGet({ env, request }) {
+    const ipH = await ipHash(clientIp(request));
+    const rl = await rateLimit(env, `rss:${ipH}`, 60);
+    if (!rl.ok) return json(rl.body, rl.status);
+
+    const origin = new URL(request.url).origin;
+
+    const countsRs = await env.DB.prepare(`
+        SELECT s.scheduled_date,
+               COUNT(CASE WHEN sl.author_type IN ('owner','moderator') THEN 1 END) AS cnt
+          FROM streams s
+          LEFT JOIN show_links sl ON sl.stream_id = s.id
+         WHERE s.state IN ('live','complete','flagged','rescanned')
+      GROUP BY s.scheduled_date
+      ORDER BY s.scheduled_date DESC
+         LIMIT 90
+    `).all();
+    const datesWithLinks = (countsRs.results || []).filter(r => r.cnt > 0).slice(0, 30);
+
+    let items = "";
+    for (const row of datesWithLinks) {
+        const stream = await env.DB.prepare(`
+            SELECT id, title, yt_video_id
+              FROM streams
+             WHERE scheduled_date = ?1
+               AND state IN ('live','complete','flagged','rescanned')
+             LIMIT 1
+        `).bind(row.scheduled_date).first();
+        if (!stream) continue;
+
+        const linksRs = await env.DB.prepare(`
+            SELECT url, domain, title, author_type, author_name
+              FROM show_links
+             WHERE stream_id = ?1
+               AND author_type IN ('owner','moderator')
+          ORDER BY posted_at ASC
+        `).bind(stream.id).all();
+        const links = linksRs.results || [];
+        if (!links.length) continue;
+
+        const pageUrl = `${origin}/links.html?date=${row.scheduled_date}`;
+        const titleDate = new Date(row.scheduled_date + "T12:00:00Z")
+            .toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric", timeZone: "UTC" });
+        const itemTitle = `Daily Threat Briefing Links — ${titleDate}`;
+
+        let desc = "<ul>";
+        for (const l of links) {
+            const label = l.title ? escapeHtml(l.title) : escapeHtml(l.url);
+            desc += `<li><a href="${escapeHtml(l.url)}">${label}</a> (${escapeHtml(l.domain)})</li>`;
+        }
+        desc += "</ul>";
+
+        items += `
+    <item>
+      <title>${escapeHtml(itemTitle)}</title>
+      <link>${escapeHtml(pageUrl)}</link>
+      <guid isPermaLink="true">${escapeHtml(pageUrl)}</guid>
+      <pubDate>${rfc2822(row.scheduled_date)}</pubDate>
+      <description><![CDATA[${desc}]]></description>
+    </item>`;
+    }
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Simply Cyber Daily Threat Briefing — Links</title>
+    <link>${origin}/links.html</link>
+    <description>Links shared during the Simply Cyber Daily Threat Briefing</description>
+    <language>en-us</language>
+    <atom:link href="${origin}/api/links/rss" rel="self" type="application/rss+xml"/>
+    ${items}
+  </channel>
+</rss>`;
+
+    return new Response(xml, {
+        status: 200,
+        headers: {
+            "Content-Type": "application/rss+xml; charset=utf-8",
+            "Cache-Control": "public, max-age=3600",
+        },
+    });
+}

--- a/pages/links.css
+++ b/pages/links.css
@@ -129,3 +129,17 @@
     color: var(--muted);
     padding: 3rem 1rem;
 }
+.copy-wrap {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+.copy-btn {
+    font-size: 0.85rem;
+    padding: 0.4rem 1rem;
+    background: var(--card);
+    color: var(--fg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    cursor: pointer;
+}
+.copy-btn:hover { background: var(--hover-bg); }

--- a/pages/links.html
+++ b/pages/links.html
@@ -25,6 +25,7 @@
     </div>
 
     <div id="stream-info" class="stream-info" hidden></div>
+    <div id="copy-wrap" hidden><button id="copy-all" class="copy-btn" type="button">Copy all links</button></div>
     <div id="err" class="err" hidden></div>
     <div id="links-list"></div>
     <p id="empty" class="links-empty" hidden>No links were shared during this show.</p>

--- a/pages/links.html
+++ b/pages/links.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="/links.css">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#0b3d5c">
+<link rel="alternate" type="application/rss+xml" href="/api/links/rss" title="Simply Cyber DTB Links">
 <meta property="og:title" content="SC-CPE Show Links Archive">
 <meta property="og:description" content="Links shared during Simply Cyber's Daily Threat Briefing, archived by date.">
 <meta property="og:type" content="website">

--- a/pages/links.js
+++ b/pages/links.js
@@ -16,6 +16,7 @@ async function load(date) {
     listEl.textContent = "";
     streamEl.hidden = true;
     streamEl.textContent = "";
+    document.getElementById("copy-wrap").hidden = true;
 
     try {
         const params = date ? `?date=${encodeURIComponent(date)}` : "";
@@ -76,6 +77,7 @@ async function load(date) {
         for (const link of links) {
             listEl.appendChild(renderCard(link));
         }
+        document.getElementById("copy-wrap").hidden = links.length === 0;
     } catch {
         errEl.textContent = "Failed to load links.";
         errEl.hidden = false;
@@ -189,6 +191,19 @@ document.getElementById("next-date").addEventListener("click", function() {
         currentIndex--;
         load(availableDates[currentIndex]);
     }
+});
+
+document.getElementById("copy-all").addEventListener("click", function() {
+    var cards = document.querySelectorAll(".link-title a[href]");
+    var urls = [];
+    for (var i = 0; i < cards.length; i++) urls.push(cards[i].href);
+    if (!urls.length) return;
+    navigator.clipboard.writeText(urls.join("\n")).then(function() {
+        var btn = document.getElementById("copy-all");
+        var orig = btn.textContent;
+        btn.textContent = "Copied!";
+        setTimeout(function() { btn.textContent = orig; }, 2000);
+    });
 });
 
 var params = new URLSearchParams(window.location.search);

--- a/pages/links.js
+++ b/pages/links.js
@@ -1,5 +1,6 @@
 let availableDates = [];
 let currentIndex = 0;
+let dateLinkCounts = {};
 
 async function load(date) {
     const errEl = document.getElementById("err");
@@ -32,6 +33,7 @@ async function load(date) {
         }
 
         availableDates = d.available_dates;
+        dateLinkCounts = d.date_link_counts || {};
         currentIndex = availableDates.indexOf(d.date);
         if (currentIndex === -1) currentIndex = 0;
 
@@ -56,6 +58,17 @@ async function load(date) {
 
         const links = d.links || [];
         if (links.length === 0) {
+            if (d.stream && d.stream.yt_video_id) {
+                emptyEl.textContent = "No links were shared during this show. ";
+                var watchLink = document.createElement("a");
+                watchLink.href = "https://www.youtube.com/watch?v=" + encodeURIComponent(d.stream.yt_video_id);
+                watchLink.target = "_blank";
+                watchLink.rel = "noopener";
+                watchLink.textContent = "Watch on YouTube";
+                watchLink.style.display = "inline-block";
+                watchLink.style.marginTop = "0.5rem";
+                emptyEl.appendChild(watchLink);
+            }
             emptyEl.hidden = false;
             return;
         }
@@ -137,7 +150,9 @@ function updateNav() {
     var next = document.getElementById("next-date");
 
     var d = availableDates[currentIndex];
-    label.textContent = formatDate(d);
+    var cnt = dateLinkCounts[d];
+    var countSuffix = (cnt !== undefined) ? " (" + cnt + ")" : "";
+    label.textContent = formatDate(d) + countSuffix;
     prev.disabled = currentIndex >= availableDates.length - 1;
     next.disabled = currentIndex <= 0;
 

--- a/scripts/backfill_discord_links.mjs
+++ b/scripts/backfill_discord_links.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+// Backfill show_links from Discord #live-chat channel history.
+// Uses Discord HTTP API with a user auth token, rate-limited to 1 req/2sec.
+// Writes to D1 via wrangler d1 execute (same pattern as seed_demo.mjs).
+//
+// Usage:
+//   source ~/.cloudflare/signalplane.env
+//   export DISCORD_TOKEN="$(cat ~/.discord-token)"
+//   export DISCORD_CHANNEL_ID="<channel-id>"
+//   node scripts/backfill_discord_links.mjs
+//
+// Options (env):
+//   BACKFILL_DAYS=100     How far back to go (default 100)
+//   DISCORD_DELAY_MS=2000 Pause between Discord API calls (default 2000)
+//   DRY_RUN=1             Log what would be inserted without writing to D1
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import https from "node:https";
+import { randomBytes } from "node:crypto";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// --- Config ---
+const token = process.env.DISCORD_TOKEN
+    || readFileSync(join(homedir(), ".discord-token"), "utf8").trim();
+const channelId = process.env.DISCORD_CHANNEL_ID;
+const backfillDays = parseInt(process.env.BACKFILL_DAYS || "100", 10);
+const delayMs = parseInt(process.env.DISCORD_DELAY_MS || "2000", 10);
+const dryRun = process.env.DRY_RUN === "1";
+
+if (!token) { console.error("DISCORD_TOKEN required (env or ~/.discord-token)"); process.exit(1); }
+if (!channelId) { console.error("DISCORD_CHANNEL_ID required"); process.exit(1); }
+
+const cutoff = new Date(Date.now() - backfillDays * 86400_000);
+const URL_RE = /https?:\/\/[^\s<>"')\]]+/gi;
+
+// --- ULID (same pattern as seed_demo.mjs) ---
+const A = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+function ulid() {
+    let ts = "", n = Date.now();
+    for (let i = 9; i >= 0; i--, n = Math.floor(n / 32)) ts = A[n % 32] + ts;
+    const rnd = randomBytes(16);
+    let r = "";
+    for (let i = 0; i < 16; i++) r += A[rnd[i] % 32];
+    return ts + r;
+}
+
+const sqlEsc = v => v === null ? "NULL" : `'${String(v).replace(/'/g, "''")}'`;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// --- Discord API ---
+function discordGet(path) {
+    return new Promise((resolve, reject) => {
+        const opts = {
+            hostname: "discord.com",
+            path,
+            method: "GET",
+            headers: { Authorization: token, "Content-Type": "application/json" },
+        };
+        const req = https.request(opts, res => {
+            let body = "";
+            res.on("data", c => body += c);
+            res.on("end", () => {
+                if (res.statusCode === 429) {
+                    let retryAfter;
+                    try { retryAfter = JSON.parse(body).retry_after; } catch { retryAfter = 5; }
+                    resolve({ rateLimited: true, retryAfter: retryAfter || 5 });
+                    return;
+                }
+                if (res.statusCode < 200 || res.statusCode >= 300) {
+                    reject(new Error(`Discord ${res.statusCode}: ${body}`));
+                    return;
+                }
+                try { resolve(JSON.parse(body)); } catch (e) { reject(e); }
+            });
+        });
+        req.on("error", reject);
+        req.end();
+    });
+}
+
+async function discordGetWithRetry(path) {
+    while (true) {
+        await sleep(delayMs);
+        const result = await discordGet(path);
+        if (result && result.rateLimited) {
+            const wait = Math.ceil(result.retryAfter * 1000) + 500;
+            console.log(`  [rate-limited] waiting ${wait}ms...`);
+            await sleep(wait);
+            continue;
+        }
+        return result;
+    }
+}
+
+// --- D1 helpers (same pattern as seed_demo.mjs) ---
+const spawnEnv = { ...process.env };
+
+function d1(cmd) {
+    const out = execFileSync("npx",
+        ["wrangler", "d1", "execute", "sc-cpe", "--remote", "--json", "--command", cmd],
+        { encoding: "utf8", cwd: "pages", timeout: 30_000, env: spawnEnv });
+    return JSON.parse(out);
+}
+
+function d1File(path) {
+    execFileSync("npx",
+        ["wrangler", "d1", "execute", "sc-cpe", "--remote", `--file=${path}`],
+        { stdio: "inherit", cwd: "pages", timeout: 60_000, env: spawnEnv });
+}
+
+// --- ET date conversion ---
+function toEtDate(isoTimestamp) {
+    return new Date(isoTimestamp).toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+}
+
+// --- Main ---
+async function main() {
+    console.log(`Backfilling Discord links from #live-chat`);
+    console.log(`  Channel: ${channelId}`);
+    console.log(`  Backfill: ${backfillDays} days (cutoff: ${cutoff.toISOString().slice(0, 10)})`);
+    console.log(`  Delay: ${delayMs}ms between API calls`);
+    console.log(`  Dry run: ${dryRun}\n`);
+
+    // 1. Fetch channel info to get guild_id
+    console.log("Fetching channel info...");
+    const channel = await discordGetWithRetry(`/api/v10/channels/${channelId}`);
+    const guildId = channel.guild_id;
+    if (!guildId) { console.error("Channel is not in a guild"); process.exit(1); }
+    console.log(`  Guild: ${guildId}\n`);
+
+    // 2. Fetch guild to get owner_id
+    console.log("Fetching guild info...");
+    const guild = await discordGetWithRetry(`/api/v10/guilds/${guildId}`);
+    const ownerId = guild.owner_id;
+    console.log(`  Owner: ${ownerId}\n`);
+
+    // 3. Fetch guild roles to identify admin/mod role IDs
+    console.log("Fetching guild roles...");
+    const roles = await discordGetWithRetry(`/api/v10/guilds/${guildId}/roles`);
+    const ADMINISTRATOR = 1n << 3n;
+    const MANAGE_GUILD = 1n << 5n;
+    const MODERATE_MEMBERS = 1n << 40n;
+    const adminModRoleIds = new Set();
+    for (const role of roles) {
+        const perms = BigInt(role.permissions);
+        if ((perms & ADMINISTRATOR) || (perms & MANAGE_GUILD) || (perms & MODERATE_MEMBERS)) {
+            adminModRoleIds.add(role.id);
+        }
+    }
+    console.log(`  Admin/mod roles: ${adminModRoleIds.size}\n`);
+
+    // 4. Prefetch streams from D1
+    console.log("Fetching streams from D1...");
+    const cutoffDate = cutoff.toISOString().slice(0, 10);
+    const streamsResult = d1(
+        `SELECT id, scheduled_date FROM streams WHERE scheduled_date >= '${cutoffDate}' ORDER BY scheduled_date`
+    );
+    const streamsByDate = new Map();
+    for (const row of streamsResult[0].results) {
+        streamsByDate.set(row.scheduled_date, row.id);
+    }
+    console.log(`  Found ${streamsByDate.size} streams in backfill window\n`);
+
+    // 5. Paginate messages
+    const memberCache = new Map(); // user_id -> "owner" | "moderator" | "viewer"
+    memberCache.set(ownerId, "owner");
+
+    async function classifyAuthor(userId, authorRoles) {
+        if (userId === ownerId) return "owner";
+
+        if (memberCache.has(userId)) return memberCache.get(userId);
+
+        // Check roles from message if available
+        if (authorRoles && authorRoles.length > 0) {
+            for (const roleId of authorRoles) {
+                if (adminModRoleIds.has(roleId)) {
+                    memberCache.set(userId, "moderator");
+                    return "moderator";
+                }
+            }
+        }
+
+        // Fetch member info for role check
+        try {
+            const member = await discordGetWithRetry(`/api/v10/guilds/${guildId}/members/${userId}`);
+            if (member && member.roles) {
+                for (const roleId of member.roles) {
+                    if (adminModRoleIds.has(roleId)) {
+                        memberCache.set(userId, "moderator");
+                        return "moderator";
+                    }
+                }
+            }
+        } catch {
+            // Member may have left the guild
+        }
+
+        memberCache.set(userId, "viewer");
+        return "viewer";
+    }
+
+    let page = 0;
+    let beforeId = undefined;
+    let totalScanned = 0;
+    let totalLinks = 0;
+    let counts = { owner: 0, moderator: 0, viewer: 0 };
+    let allStmts = [];
+    let done = false;
+
+    while (!done) {
+        page++;
+        let url = `/api/v10/channels/${channelId}/messages?limit=100`;
+        if (beforeId) url += `&before=${beforeId}`;
+
+        const messages = await discordGetWithRetry(url);
+        if (!messages || !Array.isArray(messages) || messages.length === 0) break;
+
+        totalScanned += messages.length;
+        beforeId = messages[messages.length - 1].id;
+        const oldestTs = messages[messages.length - 1].timestamp;
+        const oldestDate = new Date(oldestTs);
+
+        for (const msg of messages) {
+            const msgDate = new Date(msg.timestamp);
+            if (msgDate < cutoff) { done = true; continue; }
+
+            const text = msg.content || "";
+            URL_RE.lastIndex = 0;
+            const urlMatches = text.match(URL_RE);
+            if (!urlMatches) continue;
+
+            const etDate = toEtDate(msg.timestamp);
+            const streamId = streamsByDate.get(etDate);
+            if (!streamId) continue;
+
+            const authorType = await classifyAuthor(
+                msg.author.id,
+                msg.member?.roles
+            );
+
+            for (let raw of urlMatches) {
+                raw = raw.replace(/[.,;:!?]+$/, "");
+                let parsed;
+                try { parsed = new URL(raw); } catch { continue; }
+                if (parsed.protocol !== "https:" && parsed.protocol !== "http:") continue;
+
+                counts[authorType]++;
+                totalLinks++;
+
+                const authorName = msg.author.global_name
+                    || msg.author.username
+                    || "Unknown";
+
+                const stmt = `INSERT OR IGNORE INTO show_links (id, stream_id, url, domain, author_type, author_name, yt_channel_id, yt_message_id, posted_at, created_at) VALUES (${sqlEsc(ulid())}, ${sqlEsc(streamId)}, ${sqlEsc(raw)}, ${sqlEsc(parsed.hostname)}, ${sqlEsc(authorType)}, ${sqlEsc(authorName)}, ${sqlEsc("discord:" + msg.author.id)}, ${sqlEsc("discord:" + msg.id)}, ${sqlEsc(msg.timestamp)}, ${sqlEsc(new Date().toISOString())});`;
+                allStmts.push(stmt);
+            }
+        }
+
+        console.log(`[page ${page}] ${totalScanned} msgs scanned, ${totalLinks} links found (${counts.owner} owner, ${counts.moderator} mod, ${counts.viewer} viewer), oldest: ${oldestDate.toISOString().slice(0, 10)}`);
+
+        if (oldestDate < cutoff) break;
+    }
+
+    console.log(`\n=== Scan complete ===`);
+    console.log(`Pages: ${page}`);
+    console.log(`Messages scanned: ${totalScanned}`);
+    console.log(`Links found: ${totalLinks} (${counts.owner} owner, ${counts.moderator} mod, ${counts.viewer} viewer)`);
+    console.log(`Member cache entries: ${memberCache.size}`);
+
+    if (allStmts.length === 0) {
+        console.log("\nNo links to insert.");
+        return;
+    }
+
+    if (dryRun) {
+        console.log(`\n[DRY RUN] Would insert ${allStmts.length} rows. Sample:`);
+        for (const s of allStmts.slice(0, 5)) console.log(`  ${s.slice(0, 120)}...`);
+        return;
+    }
+
+    // Write to D1 via temp file (same pattern as seed_demo.mjs)
+    const sqlPath = "/tmp/backfill_discord_links.sql";
+    writeFileSync(sqlPath, allStmts.join("\n") + "\n");
+    console.log(`\nWriting ${allStmts.length} rows to D1...`);
+    d1File(sqlPath);
+    unlinkSync(sqlPath);
+    console.log("Done.");
+}
+
+main().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- **Empty show days**: API returns all stream dates (not just those with links) + per-date link counts. Frontend shows "No links were shared during this show" with YouTube link on empty days. Nav shows count badges like `(5)`.
- **Viewer link storage**: API filters to `owner`/`moderator` only. Backfill captures `viewer` links too (hidden from public page, stored for future intel feature).
- **Copy-all button**: One-click copies all URLs for the day to clipboard.
- **RSS feed**: `/api/links/rss` — one item per show day with HTML link list. Auto-discovery `<link>` tag in links.html. 1-hour cache, 60 req/hr rate limit.
- **Discord backfill script**: `scripts/backfill_discord_links.mjs` — paginates Discord `#live-chat` history, classifies author roles, writes to D1 via wrangler. Rate-limited (1 req/2sec), DRY_RUN mode, idempotent via INSERT OR IGNORE.
- **Bug fix**: Nav prev/next buttons — `prev.disabled` was set twice (never set `next.disabled`). Fixed.

## Test plan
- [x] All 170 node tests pass (6 new links/RSS tests)
- [ ] Smoke test after deploy
- [ ] Run backfill: `DRY_RUN=1 BACKFILL_DAYS=3 node scripts/backfill_discord_links.mjs`
- [ ] Verify empty-day display on a date with no links
- [ ] Verify copy button copies URLs correctly
- [ ] Verify RSS feed in a feed reader (`curl /api/links/rss`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)