### PR TITLE
chore: backfill resume, Codex config, design docs

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,5 @@
+model = "gpt-5.4"
+approval_policy = "on-request"
+
+# Also read CLAUDE.md so Codex gets the full architecture context
+project_doc_fallback_filenames = ["CLAUDE.md"]

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules/
 *.key
 .DS_Store
 outputs/handoffs/
+scripts/.backfill_progress.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,92 @@
+# AGENTS.md -- SC-CPE guidance for Codex and other AI agents
+
+## System overview
+
+CPE certificate issuance for Simply Cyber Daily Threat Briefing attendees.
+Cloudflare Pages Functions (JS) + D1 (SQLite) + R2 + Workers. PAdES-T
+signed PDF certs. Hash-chained append-only audit log. See CLAUDE.md for
+full architecture and invariants.
+
+## Build & test
+
+```
+bash scripts/test.sh              # node --test suite
+bash scripts/smoke_hardening.sh   # read-only probes against deployed origin
+python scripts/verify_audit_chain.py  # audit chain integrity
+```
+
+## Security invariants -- DO NOT violate
+
+1. `audit_log` is append-only, hash-chained. Never UPDATE/DELETE rows.
+2. `canonicalAuditRow()` must be byte-identical across JS, Python, Workers.
+3. Admin endpoints use `Authorization: Bearer` -- no CSRF gates needed.
+4. `/api/me/[token]/*` endpoints ARE CSRF-sensitive -- must call `isSameOrigin()`.
+5. CSP: `script-src 'self'` -- no inline JS. External files only.
+6. `dashboard_token` and `badge_token` are separate credentials.
+7. Token expiry is 72h. Never extend.
+8. Cert reissue: never UPDATE a generated cert -- always supersede.
+9. Email sender cursor advances only on successful send.
+
+## Security audit checklist
+
+When reviewing for security, check ALL of these:
+
+### Injection (OWASP A03)
+- All D1 queries use parameterised `.bind()` -- no string concatenation
+- User input in SQL: email, codes, tokens, pagination params
+- No dynamic code execution of any kind (no string-to-code patterns)
+
+### XSS (OWASP A07)
+- All `innerHTML` uses `escapeHtml()` from `_lib.js`
+- CSP `script-src 'self'` enforced in `_middleware.js`
+- SVG badge endpoint sanitises all interpolated values
+
+### Authentication & authorisation (OWASP A01)
+- Admin endpoints: verify `isAdmin(request, env)` returns true
+- Dashboard endpoints: verify token lookup + `isSameOrigin(request)`
+- Token generation: `crypto.getRandomValues()` with 32 bytes
+- Rate limiting: `rateLimit()` called on auth-sensitive endpoints
+
+### CSRF
+- `/api/me/[token]/*` must check `isSameOrigin()` -- Origin/Referer match
+- Admin endpoints exempt (bearer token not auto-sent by browsers)
+
+### Error handling & info leakage
+- No stack traces in production responses
+- Error responses use generic messages, not internal details
+- 404 vs 403 -- avoid auth oracle
+
+### Rate limiting
+- Registration, login, recovery, resend-code, appeal endpoints
+- Public APIs (leaderboard, links, badge)
+
+### Audit log integrity
+- Every state change writes an audit row
+- `prev_hash` computed from `canonicalAuditRow(tip)`
+- `UNIQUE INDEX audit_prev_hash_unique` serialises concurrent writers
+- `ip_hash` lands in the `ip_hash` column (not `after_json`)
+
+### CSP & headers
+- Verify `_middleware.js` CSP covers all new resources
+- HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy
+
+## High-risk files for security review
+
+- `pages/functions/_middleware.js` -- CSP, security headers
+- `pages/functions/_lib.js` -- audit chain, crypto, rate limiting, auth
+- `pages/functions/api/register.js` -- user registration
+- `pages/functions/api/recover.js` -- account recovery
+- `pages/functions/api/me/[token]/*.js` -- CSRF-sensitive dashboard
+- `pages/functions/api/admin/*.js` -- bearer-token-gated admin ops
+- `workers/poller/src/index.js` -- YouTube API, OAuth
+- `workers/purge/src/index.js` -- cron: purge, digests, enrichment
+- `services/certs/generate.py` -- PDF cert generation, PAdES signing
+
+## Conventions
+
+- Do not add comments unless WHY is non-obvious
+- Do not create new files -- edit `_lib.js` for shared helpers
+- Input validation at API boundaries only
+- Commit style: `kind(scope): message`
+- No inline JS (CSP enforced)
+- No backwards-compat shims -- delete unused code

--- a/docs/superpowers/plans/2026-04-22-analytics-dashboard.md
+++ b/docs/superpowers/plans/2026-04-22-analytics-dashboard.md
@@ -1,0 +1,744 @@
+# Analytics Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an admin analytics page with four panels (Growth, Engagement, Certs, System Health) powered by four API endpoints and rendered with Chart.js.
+
+**Architecture:** Four focused API endpoints under `pages/functions/api/admin/analytics/` each return JSON aggregates from D1. A new `analytics.html` page fetches all four in parallel, renders headline stat cards and Chart.js charts. Self-hosted Chart.js UMD bundle avoids CDN CSP changes. Auth via existing `isAdmin()` bearer token pattern.
+
+**Tech Stack:** Cloudflare Pages Functions (JS), D1 (SQLite), Chart.js 4.x (self-hosted UMD), vanilla JS frontend.
+
+**XSS note:** All dynamic text rendered via `escapeHtml()` helper (same pattern as `admin.js`). The `card()` helper escapes both key and value before inserting into the DOM. Error messages are escaped before display. Chart.js handles its own rendering safely via Canvas API.
+
+---
+
+### Task 1: Download and self-host Chart.js
+
+**Files:**
+- Create: `pages/lib/chart.umd.min.js`
+
+- [ ] **Step 1: Download Chart.js UMD bundle**
+
+```bash
+mkdir -p pages/lib
+curl -L "https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.min.js" -o pages/lib/chart.umd.min.js
+```
+
+- [ ] **Step 2: Verify the download**
+
+```bash
+head -c 100 pages/lib/chart.umd.min.js
+wc -c pages/lib/chart.umd.min.js
+```
+
+Expected: File starts with `/*!` or similar minified JS header, size ~200-210KB.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pages/lib/chart.umd.min.js
+git commit -m "chore: self-host Chart.js 4.4.9 UMD bundle for analytics"
+```
+
+---
+
+### Task 2: Shared analytics query helpers
+
+**Files:**
+- Create: `pages/functions/api/admin/analytics/_helpers.js`
+- Test: `pages/functions/api/admin/analytics/_helpers.test.mjs`
+
+The four analytics endpoints share range-parsing and date-grouping logic. Extract once here.
+
+- [ ] **Step 1: Write the helpers module**
+
+Create `pages/functions/api/admin/analytics/_helpers.js`:
+
+```js
+import { json, isAdmin } from "../../../_lib.js";
+
+export function parseRange(url) {
+    const range = url.searchParams.get("range") || "30d";
+    const validRanges = { "7d": 7, "30d": 30, "90d": 90 };
+    const days = validRanges[range];
+    if (range === "all") {
+        return { range: "all", since: null, granularity: url.searchParams.get("granularity") || "monthly" };
+    }
+    if (!days) {
+        return { range: "30d", since: new Date(Date.now() - 30 * 86400_000).toISOString().slice(0, 10), granularity: "daily" };
+    }
+    const since = new Date(Date.now() - days * 86400_000).toISOString().slice(0, 10);
+    const autoGran = days <= 30 ? "daily" : "weekly";
+    const granularity = url.searchParams.get("granularity") || autoGran;
+    return { range, since, granularity };
+}
+
+export function groupByKey(granularity) {
+    if (granularity === "weekly") return "strftime('%Y-W%W', {col})";
+    if (granularity === "monthly") return "strftime('%Y-%m', {col})";
+    return "date({col})";
+}
+
+export async function guardAdmin(env, request) {
+    if (!(await isAdmin(env, request))) {
+        return json({ error: "unauthorized" }, 401);
+    }
+    return null;
+}
+```
+
+- [ ] **Step 2: Write tests for parseRange**
+
+Create `pages/functions/api/admin/analytics/_helpers.test.mjs`:
+
+```js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseRange, groupByKey } from "./_helpers.js";
+
+test("parseRange: default is 30d daily", () => {
+    const url = new URL("https://example.com/api/admin/analytics/growth");
+    const r = parseRange(url);
+    assert.equal(r.range, "30d");
+    assert.equal(r.granularity, "daily");
+    assert.ok(r.since, "since should be set");
+});
+
+test("parseRange: 7d is daily", () => {
+    const url = new URL("https://example.com/?range=7d");
+    const r = parseRange(url);
+    assert.equal(r.range, "7d");
+    assert.equal(r.granularity, "daily");
+});
+
+test("parseRange: 90d defaults to weekly", () => {
+    const url = new URL("https://example.com/?range=90d");
+    const r = parseRange(url);
+    assert.equal(r.range, "90d");
+    assert.equal(r.granularity, "weekly");
+});
+
+test("parseRange: all has no since, defaults monthly", () => {
+    const url = new URL("https://example.com/?range=all");
+    const r = parseRange(url);
+    assert.equal(r.range, "all");
+    assert.equal(r.since, null);
+    assert.equal(r.granularity, "monthly");
+});
+
+test("parseRange: invalid range falls back to 30d", () => {
+    const url = new URL("https://example.com/?range=banana");
+    const r = parseRange(url);
+    assert.equal(r.range, "30d");
+});
+
+test("parseRange: explicit granularity override", () => {
+    const url = new URL("https://example.com/?range=90d&granularity=daily");
+    const r = parseRange(url);
+    assert.equal(r.granularity, "daily");
+});
+
+test("groupByKey: daily uses date()", () => {
+    assert.equal(groupByKey("daily"), "date({col})");
+});
+
+test("groupByKey: weekly uses strftime %W", () => {
+    assert.equal(groupByKey("weekly"), "strftime('%Y-W%W', {col})");
+});
+
+test("groupByKey: monthly uses strftime %Y-%m", () => {
+    assert.equal(groupByKey("monthly"), "strftime('%Y-%m', {col})");
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+node --test pages/functions/api/admin/analytics/_helpers.test.mjs
+```
+
+Expected: All 9 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pages/functions/api/admin/analytics/_helpers.js pages/functions/api/admin/analytics/_helpers.test.mjs
+git commit -m "feat(analytics): shared helpers — parseRange, groupByKey, guardAdmin"
+```
+
+---
+
+### Task 3: Growth API endpoint
+
+**Files:**
+- Create: `pages/functions/api/admin/analytics/growth.js`
+
+- [ ] **Step 1: Write the growth endpoint**
+
+Create `pages/functions/api/admin/analytics/growth.js`:
+
+```js
+import { json } from "../../../_lib.js";
+import { parseRange, groupByKey, guardAdmin } from "./_helpers.js";
+
+export async function onRequestGet({ request, env }) {
+    const denied = await guardAdmin(env, request);
+    if (denied) return denied;
+
+    const url = new URL(request.url);
+    const { since, granularity } = parseRange(url);
+
+    const grp = groupByKey(granularity).replace("{col}", "created_at");
+    const whereClause = since ? "WHERE created_at >= ?1" : "";
+    const binds = since ? [since] : [];
+
+    const [totalUsers, activeUsers, verifiedUsers, activeAttenders, newReg, timeSeries] = await Promise.all([
+        env.DB.prepare("SELECT COUNT(*) AS n FROM users WHERE deleted_at IS NULL").first(),
+        env.DB.prepare("SELECT COUNT(*) AS n FROM users WHERE state = 'active'").first(),
+        env.DB.prepare("SELECT COUNT(*) AS n FROM users WHERE verified_at IS NOT NULL").first(),
+        env.DB.prepare(
+            "SELECT COUNT(DISTINCT user_id) AS n FROM attendance WHERE created_at >= ?1"
+        ).bind(new Date(Date.now() - 30 * 86400_000).toISOString().slice(0, 10)).first(),
+        since
+            ? env.DB.prepare("SELECT COUNT(*) AS n FROM users WHERE created_at >= ?1").bind(since).first()
+            : env.DB.prepare("SELECT COUNT(*) AS n FROM users").first(),
+        since
+            ? env.DB.prepare(
+                `SELECT ${grp} AS period, COUNT(*) AS count FROM users ${whereClause} GROUP BY period ORDER BY period`
+              ).bind(...binds).all()
+            : env.DB.prepare(
+                `SELECT ${grp} AS period, COUNT(*) AS count FROM users GROUP BY period ORDER BY period`
+              ).all(),
+    ]);
+
+    return json({
+        ok: true,
+        headlines: {
+            total_users: totalUsers?.n ?? 0,
+            active_users: activeUsers?.n ?? 0,
+            verified_users: verifiedUsers?.n ?? 0,
+            active_attenders_30d: activeAttenders?.n ?? 0,
+            new_registrations: newReg?.n ?? 0,
+        },
+        series: (timeSeries?.results ?? []).map(r => ({ period: r.period, count: r.count })),
+    });
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add pages/functions/api/admin/analytics/growth.js
+git commit -m "feat(analytics): growth endpoint — user counts + registration time series"
+```
+
+---
+
+### Task 4: Engagement API endpoint
+
+**Files:**
+- Create: `pages/functions/api/admin/analytics/engagement.js`
+
+- [ ] **Step 1: Write the engagement endpoint**
+
+Create `pages/functions/api/admin/analytics/engagement.js`:
+
+```js
+import { json } from "../../../_lib.js";
+import { parseRange, groupByKey, guardAdmin } from "./_helpers.js";
+
+export async function onRequestGet({ request, env }) {
+    const denied = await guardAdmin(env, request);
+    if (denied) return denied;
+
+    const url = new URL(request.url);
+    const { since, granularity } = parseRange(url);
+
+    const grp = groupByKey(granularity).replace("{col}", "s.scheduled_date");
+    const whereClause = since ? "WHERE s.scheduled_date >= ?1" : "";
+    const binds = since ? [since] : [];
+
+    const streamWhere = since ? "WHERE scheduled_date >= ?1" : "";
+
+    const [avgPerStream, totalCpe, emptyStreams, timeSeries] = await Promise.all([
+        since
+            ? env.DB.prepare(
+                `SELECT AVG(cnt) AS avg_att FROM (
+                    SELECT COUNT(*) AS cnt FROM attendance a
+                    JOIN streams s ON a.stream_id = s.id
+                    WHERE s.scheduled_date >= ?1
+                    GROUP BY a.stream_id
+                )`
+              ).bind(since).first()
+            : env.DB.prepare(
+                "SELECT AVG(cnt) AS avg_att FROM (SELECT COUNT(*) AS cnt FROM attendance GROUP BY stream_id)"
+              ).first(),
+
+        since
+            ? env.DB.prepare(
+                "SELECT SUM(a.earned_cpe) AS total FROM attendance a JOIN streams s ON a.stream_id = s.id WHERE s.scheduled_date >= ?1"
+              ).bind(since).first()
+            : env.DB.prepare("SELECT SUM(earned_cpe) AS total FROM attendance").first(),
+
+        since
+            ? env.DB.prepare(
+                `SELECT COUNT(*) AS n FROM streams ${streamWhere}
+                 AND id NOT IN (SELECT DISTINCT stream_id FROM attendance)`
+              ).bind(since).first()
+            : env.DB.prepare(
+                "SELECT COUNT(*) AS n FROM streams WHERE id NOT IN (SELECT DISTINCT stream_id FROM attendance)"
+              ).first(),
+
+        since
+            ? env.DB.prepare(
+                `SELECT ${grp} AS period, COUNT(*) AS count
+                 FROM attendance a JOIN streams s ON a.stream_id = s.id
+                 ${whereClause} GROUP BY period ORDER BY period`
+              ).bind(...binds).all()
+            : env.DB.prepare(
+                `SELECT ${grp} AS period, COUNT(*) AS count
+                 FROM attendance a JOIN streams s ON a.stream_id = s.id
+                 GROUP BY period ORDER BY period`
+              ).all(),
+    ]);
+
+    return json({
+        ok: true,
+        headlines: {
+            avg_attendance_per_stream: Math.round((avgPerStream?.avg_att ?? 0) * 10) / 10,
+            total_cpe_awarded: totalCpe?.total ?? 0,
+            streams_with_zero_attendance: emptyStreams?.n ?? 0,
+        },
+        series: (timeSeries?.results ?? []).map(r => ({ period: r.period, count: r.count })),
+    });
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add pages/functions/api/admin/analytics/engagement.js
+git commit -m "feat(analytics): engagement endpoint — attendance trends + CPE stats"
+```
+
+---
+
+### Task 5: Certificates API endpoint
+
+**Files:**
+- Create: `pages/functions/api/admin/analytics/certs.js`
+
+- [ ] **Step 1: Write the certs endpoint**
+
+Create `pages/functions/api/admin/analytics/certs.js`:
+
+```js
+import { json } from "../../../_lib.js";
+import { parseRange, guardAdmin } from "./_helpers.js";
+
+export async function onRequestGet({ request, env }) {
+    const denied = await guardAdmin(env, request);
+    if (denied) return denied;
+
+    const url = new URL(request.url);
+    const { since } = parseRange(url);
+
+    const certStates = "('generated','delivered','viewed_by_auditor')";
+
+    const [issuedPeriod, pending, deliveryLatency, viewRate, timeSeries] = await Promise.all([
+        since
+            ? env.DB.prepare(
+                `SELECT COUNT(*) AS n FROM certs WHERE state IN ${certStates} AND created_at >= ?1`
+              ).bind(since).first()
+            : env.DB.prepare(
+                `SELECT COUNT(*) AS n FROM certs WHERE state IN ${certStates}`
+              ).first(),
+
+        env.DB.prepare("SELECT COUNT(*) AS n FROM certs WHERE state = 'pending'").first(),
+
+        since
+            ? env.DB.prepare(
+                `SELECT AVG(julianday(delivered_at) - julianday(created_at)) * 86400 AS avg_secs
+                 FROM certs WHERE delivered_at IS NOT NULL AND created_at >= ?1`
+              ).bind(since).first()
+            : env.DB.prepare(
+                "SELECT AVG(julianday(delivered_at) - julianday(created_at)) * 86400 AS avg_secs FROM certs WHERE delivered_at IS NOT NULL"
+              ).first(),
+
+        env.DB.prepare(
+            `SELECT COUNT(CASE WHEN first_viewed_at IS NOT NULL THEN 1 END) AS viewed,
+                    COUNT(*) AS total
+             FROM certs WHERE delivered_at IS NOT NULL`
+        ).first(),
+
+        env.DB.prepare(
+            `SELECT period_yyyymm AS period, COUNT(*) AS count
+             FROM certs WHERE state IN ${certStates}
+             GROUP BY period_yyyymm ORDER BY period_yyyymm`
+        ).all(),
+    ]);
+
+    var avgLatencySecs = deliveryLatency?.avg_secs ?? null;
+
+    return json({
+        ok: true,
+        headlines: {
+            issued_this_period: issuedPeriod?.n ?? 0,
+            pending_now: pending?.n ?? 0,
+            avg_delivery_seconds: avgLatencySecs != null ? Math.round(avgLatencySecs) : null,
+            view_rate_pct: (viewRate?.total ?? 0) > 0
+                ? Math.round((viewRate.viewed / viewRate.total) * 100)
+                : null,
+        },
+        series: (timeSeries?.results ?? []).map(r => ({ period: r.period, count: r.count })),
+    });
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add pages/functions/api/admin/analytics/certs.js
+git commit -m "feat(analytics): certs endpoint — issuance by month, delivery latency, view rate"
+```
+
+---
+
+### Task 6: System Health API endpoint
+
+**Files:**
+- Create: `pages/functions/api/admin/analytics/system.js`
+
+- [ ] **Step 1: Write the system endpoint**
+
+Create `pages/functions/api/admin/analytics/system.js`:
+
+```js
+import { json } from "../../../_lib.js";
+import { parseRange, groupByKey, guardAdmin } from "./_helpers.js";
+
+export async function onRequestGet({ request, env }) {
+    const denied = await guardAdmin(env, request);
+    if (denied) return denied;
+
+    const url = new URL(request.url);
+    const { since, granularity } = parseRange(url);
+
+    const grp = groupByKey(granularity).replace("{col}", "created_at");
+    const whereClause = since ? "WHERE created_at >= ?1" : "";
+    const binds = since ? [since] : [];
+
+    const [emailStats, emailSeries, appealsOpen, appealResTime] = await Promise.all([
+        since
+            ? env.DB.prepare(
+                `SELECT COUNT(CASE WHEN state = 'sent' THEN 1 END) AS sent,
+                        COUNT(CASE WHEN state = 'failed' THEN 1 END) AS failed,
+                        COUNT(*) AS total
+                 FROM email_outbox WHERE created_at >= ?1`
+              ).bind(since).first()
+            : env.DB.prepare(
+                `SELECT COUNT(CASE WHEN state = 'sent' THEN 1 END) AS sent,
+                        COUNT(CASE WHEN state = 'failed' THEN 1 END) AS failed,
+                        COUNT(*) AS total
+                 FROM email_outbox`
+              ).first(),
+
+        since
+            ? env.DB.prepare(
+                `SELECT ${grp} AS period,
+                        COUNT(CASE WHEN state = 'sent' THEN 1 END) AS sent,
+                        COUNT(CASE WHEN state = 'failed' THEN 1 END) AS failed
+                 FROM email_outbox ${whereClause}
+                 GROUP BY period ORDER BY period`
+              ).bind(...binds).all()
+            : env.DB.prepare(
+                `SELECT ${grp} AS period,
+                        COUNT(CASE WHEN state = 'sent' THEN 1 END) AS sent,
+                        COUNT(CASE WHEN state = 'failed' THEN 1 END) AS failed
+                 FROM email_outbox
+                 GROUP BY period ORDER BY period`
+              ).all(),
+
+        env.DB.prepare("SELECT COUNT(*) AS n FROM appeals WHERE state = 'open'").first(),
+
+        since
+            ? env.DB.prepare(
+                `SELECT AVG(julianday(resolved_at) - julianday(created_at)) * 86400 AS avg_secs
+                 FROM appeals WHERE resolved_at IS NOT NULL AND created_at >= ?1`
+              ).bind(since).first()
+            : env.DB.prepare(
+                "SELECT AVG(julianday(resolved_at) - julianday(created_at)) * 86400 AS avg_secs FROM appeals WHERE resolved_at IS NOT NULL"
+              ).first(),
+    ]);
+
+    var total = emailStats?.total ?? 0;
+    var sent = emailStats?.sent ?? 0;
+
+    return json({
+        ok: true,
+        headlines: {
+            email_success_rate_pct: total > 0 ? Math.round((sent / total) * 100) : null,
+            emails_sent: sent,
+            appeals_open: appealsOpen?.n ?? 0,
+            avg_appeal_resolution_seconds: appealResTime?.avg_secs != null
+                ? Math.round(appealResTime.avg_secs)
+                : null,
+        },
+        series: (emailSeries?.results ?? []).map(r => ({
+            period: r.period,
+            sent: r.sent,
+            failed: r.failed,
+        })),
+    });
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add pages/functions/api/admin/analytics/system.js
+git commit -m "feat(analytics): system health endpoint — email stats, appeal turnaround"
+```
+
+---
+
+### Task 7: Analytics HTML page + CSS
+
+**Files:**
+- Create: `pages/analytics.html`
+- Create: `pages/analytics.css`
+
+- [ ] **Step 1: Write analytics.html**
+
+Create `pages/analytics.html`:
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+<title>SC-CPE Analytics</title>
+<meta name="robots" content="noindex,nofollow">
+<link rel="stylesheet" href="/admin.css">
+<link rel="stylesheet" href="/analytics.css">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="theme-color" content="#0b3d5c">
+</head>
+<body>
+<div class="wrap">
+  <h1>SC-CPE Analytics</h1>
+  <div class="sub">
+    <a href="/admin.html">&larr; Back to Admin</a>
+    <span style="margin:0 8px">|</span>
+    Usage trends and program health over time.
+  </div>
+
+  <div id="login" class="login">
+    <input type="password" id="token" placeholder="ADMIN_TOKEN" autocomplete="off">
+    <button id="go">Load</button>
+  </div>
+
+  <div id="app" style="display:none;">
+    <div class="range-bar">
+      <button class="range-btn" data-range="7d">7d</button>
+      <button class="range-btn active" data-range="30d">30d</button>
+      <button class="range-btn" data-range="90d">90d</button>
+      <button class="range-btn" data-range="all">All</button>
+      <span class="muted" id="ts" style="margin-left:auto;font-size:12px;"></span>
+    </div>
+    <div id="err"></div>
+
+    <div class="panel" id="panel-growth">
+      <div class="section-h">Growth</div>
+      <div class="grid" id="growth-cards"></div>
+      <div class="chart-wrap"><canvas id="growth-chart"></canvas></div>
+    </div>
+
+    <div class="panel" id="panel-engagement">
+      <div class="section-h">Engagement</div>
+      <div class="grid" id="engagement-cards"></div>
+      <div class="chart-wrap"><canvas id="engagement-chart"></canvas></div>
+    </div>
+
+    <div class="panel" id="panel-certs">
+      <div class="section-h">Certificates</div>
+      <div class="grid" id="certs-cards"></div>
+      <div class="chart-wrap"><canvas id="certs-chart"></canvas></div>
+    </div>
+
+    <div class="panel" id="panel-system">
+      <div class="section-h">System Health</div>
+      <div class="grid" id="system-cards"></div>
+      <div class="chart-wrap"><canvas id="system-chart"></canvas></div>
+    </div>
+  </div>
+</div>
+
+<script src="/lib/chart.umd.min.js"></script>
+<script src="/analytics.js"></script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Write analytics.css**
+
+Create `pages/analytics.css`:
+
+```css
+.range-bar {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-bottom: 18px;
+}
+.range-btn {
+  background: #111820;
+  color: #95a4b3;
+  border: 1px solid #2a3644;
+  padding: 5px 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  min-height: 0;
+}
+.range-btn.active {
+  background: #0b3d5c;
+  color: #fff;
+  border-color: #0b3d5c;
+}
+.panel {
+  margin-bottom: 28px;
+}
+.chart-wrap {
+  background: #111820;
+  border: 1px solid #2a3644;
+  border-radius: 6px;
+  padding: 16px;
+  margin-bottom: 8px;
+}
+.chart-wrap canvas {
+  width: 100% !important;
+  max-height: 240px;
+}
+.panel .grid {
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pages/analytics.html pages/analytics.css
+git commit -m "feat(analytics): HTML page + CSS — four-panel layout with Chart.js"
+```
+
+---
+
+### Task 8: Analytics JS (fetch + render)
+
+**Files:**
+- Create: `pages/analytics.js`
+
+XSS prevention: All dynamic text is escaped via `escapeHtml()` before DOM insertion — same pattern as the existing `admin.js`. The `card()` helper escapes both the label and value. Error messages are also escaped. Chart.js renders via Canvas API (no DOM string injection).
+
+- [ ] **Step 1: Write analytics.js**
+
+Create `pages/analytics.js` — see the full implementation in the spec. Key points:
+- `escapeHtml(s)` used for all user-visible dynamic text
+- `card(k, v)` creates DOM elements with escaped content
+- `fetchJson()` uses bearer token auth (not cookies)
+- `makeChart()` wraps Chart.js with consistent dark-theme styling
+- Four `render*()` functions populate cards + charts per panel
+- Range buttons re-fetch all four endpoints on click
+- Token input supports Enter key
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add pages/analytics.js
+git commit -m "feat(analytics): JS — fetch four endpoints, render cards + Chart.js graphs"
+```
+
+---
+
+### Task 9: Link from admin dashboard
+
+**Files:**
+- Modify: `pages/admin.html:16` (the `.sub` div)
+
+- [ ] **Step 1: Add analytics link to admin.html**
+
+In `pages/admin.html`, modify line 16 (the `<div class="sub">` element) to append an analytics link.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add pages/admin.html
+git commit -m "feat(analytics): add analytics link to admin dashboard"
+```
+
+---
+
+### Task 10: Wire tests into test.sh
+
+**Files:**
+- Modify: `scripts/test.sh`
+
+- [ ] **Step 1: Add analytics helper tests to test.sh**
+
+Add `pages/functions/api/admin/analytics/_helpers.test.mjs` to the `node --test` list in `scripts/test.sh`.
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+bash scripts/test.sh
+```
+
+Expected: All tests pass including the new analytics helpers.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/test.sh
+git commit -m "test: wire analytics helper tests into test.sh"
+```
+
+---
+
+### Task 11: Smoke test against deployed site
+
+**Files:** None (manual verification)
+
+- [ ] **Step 1: Deploy and verify endpoints return valid JSON**
+
+After deploying (merge to main triggers auto-deploy), test each endpoint:
+
+```bash
+ADMIN_TOKEN="$(tr -d '\n' < ~/.cloudflare/sc-cpe-admin-token)"
+ORIGIN="https://sc-cpe-web.pages.dev"
+
+curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$ORIGIN/api/admin/analytics/growth?range=30d" | python3 -m json.tool | head -20
+curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$ORIGIN/api/admin/analytics/engagement?range=30d" | python3 -m json.tool | head -20
+curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$ORIGIN/api/admin/analytics/certs?range=all" | python3 -m json.tool | head -20
+curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$ORIGIN/api/admin/analytics/system?range=30d" | python3 -m json.tool | head -20
+```
+
+Expected: All four return `{"ok":true,...}` with headlines and series arrays.
+
+- [ ] **Step 2: Verify unauthorized access is blocked**
+
+```bash
+curl -s "$ORIGIN/api/admin/analytics/growth" | python3 -m json.tool
+```
+
+Expected: `{"error":"unauthorized"}` with HTTP 401.
+
+- [ ] **Step 3: Open analytics.html in browser**
+
+Navigate to `$ORIGIN/analytics.html`, paste admin token, verify:
+- Four panels load with stat cards
+- Charts render with Chart.js
+- Range selector (7d/30d/90d/All) re-fetches and re-renders
+- Back to Admin link works

--- a/docs/superpowers/specs/2026-04-22-analytics-dashboard-design.md
+++ b/docs/superpowers/specs/2026-04-22-analytics-dashboard-design.md
@@ -1,0 +1,212 @@
+# Analytics Dashboard Design
+
+## Overview
+
+A dedicated admin analytics page (`/analytics.html`) that surfaces growth,
+engagement, cert health, and system reliability trends. Separate from the
+existing ops dashboard (`/admin.html`) which focuses on real-time health.
+
+Auth: bearer token (ADMIN_TOKEN), same as all admin endpoints.
+
+## Architecture
+
+Four sectioned API endpoints, fetched in parallel by the page:
+
+```
+pages/functions/api/admin/analytics/
+  growth.js        — registrations, verifications, active users over time
+  engagement.js    — attendance rates, stream participation, streaks
+  certs.js         — issuance counts, delivery latency, view rates
+  system.js        — email delivery, heartbeat history, appeal turnaround
+```
+
+Each endpoint accepts query params:
+- `range` — `7d`, `30d`, `90d`, `all` (default: `30d`)
+- `granularity` — `daily`, `weekly`, `monthly` (default: auto based on range)
+
+Auto-granularity: 7d→daily, 30d→daily, 90d→weekly, all→monthly.
+
+### Frontend
+
+New files:
+- `pages/analytics.html` — admin analytics page
+- `pages/analytics.js` — fetch + render logic
+- `pages/analytics.css` — dashboard styling
+
+Chart library: Chart.js loaded from CDN (`https://cdn.jsdelivr.net/npm/chart.js`).
+CSP `script-src` already allows `'self'` — will need to add the CDN origin
+to the CSP in `_middleware.js`, or self-host the minified bundle. Self-hosting
+is preferred to avoid CDN dependency and keep the strict CSP.
+
+Link from admin.html → analytics.html in the nav.
+
+## Panel Designs
+
+### 1. Growth Panel (`/api/admin/analytics/growth`)
+
+**Headline cards:**
+- Total registered users
+- Verified users (completed email verification)
+- Active users (attended in last 30 days)
+- New registrations this period
+
+**Chart:** Line chart — daily registrations + cumulative users over time.
+
+**D1 queries:**
+```sql
+-- headline counts
+SELECT COUNT(*) FROM users WHERE state='active';
+SELECT COUNT(*) FROM users WHERE verified_at IS NOT NULL;
+SELECT COUNT(DISTINCT user_id) FROM attendance
+  WHERE created_at >= date('now', '-30 days');
+
+-- time series: registrations per day
+SELECT date(created_at) as day, COUNT(*) as count
+FROM users
+WHERE created_at >= ?1
+GROUP BY day ORDER BY day;
+```
+
+### 2. Engagement Panel (`/api/admin/analytics/engagement`)
+
+**Headline cards:**
+- Avg attendance per stream (this period)
+- Total CPE awarded (this period)
+- Median streak length
+- Streams with zero attendance
+
+**Chart:** Line chart — daily attendance count. Optional secondary axis
+for distinct_attendees from the streams table.
+
+**D1 queries:**
+```sql
+-- attendance per day
+SELECT s.scheduled_date as day, COUNT(*) as attended
+FROM attendance a JOIN streams s ON a.stream_id = s.id
+WHERE s.scheduled_date >= ?1
+GROUP BY day ORDER BY day;
+
+-- avg per stream
+SELECT AVG(cnt) FROM (
+  SELECT COUNT(*) as cnt FROM attendance
+  GROUP BY stream_id
+) WHERE stream_id IN (SELECT id FROM streams WHERE scheduled_date >= ?1);
+```
+
+### 3. Certificates Panel (`/api/admin/analytics/certs`)
+
+**Headline cards:**
+- Certs issued this period
+- Avg generation-to-delivery time
+- First-view rate (% of delivered certs that were viewed)
+- Pending certs now
+
+**Chart:** Bar chart — certs issued per month (natural grouping by
+`period_yyyymm`). Line overlay for avg delivery latency.
+
+**D1 queries:**
+```sql
+-- issued per month
+SELECT period_yyyymm, COUNT(*) as count
+FROM certs WHERE state IN ('generated','delivered','viewed')
+GROUP BY period_yyyymm ORDER BY period_yyyymm;
+
+-- delivery latency (seconds)
+SELECT AVG(julianday(delivered_at) - julianday(created_at)) * 86400 as avg_secs
+FROM certs WHERE delivered_at IS NOT NULL AND created_at >= ?1;
+
+-- view rate
+SELECT
+  COUNT(CASE WHEN first_viewed_at IS NOT NULL THEN 1 END) as viewed,
+  COUNT(*) as total
+FROM certs WHERE delivered_at IS NOT NULL;
+```
+
+### 4. System Health Panel (`/api/admin/analytics/system`)
+
+**Headline cards:**
+- Email success rate (sent / total)
+- Emails sent this period
+- Open appeals
+- Avg appeal resolution time
+
+**Chart:** Line chart — emails sent per day. Stacked with
+failures if any.
+
+**D1 queries:**
+```sql
+-- email stats
+SELECT date(created_at) as day,
+  COUNT(CASE WHEN state='sent' THEN 1 END) as sent,
+  COUNT(CASE WHEN state='failed' THEN 1 END) as failed
+FROM email_outbox WHERE created_at >= ?1
+GROUP BY day ORDER BY day;
+
+-- appeal resolution time
+SELECT AVG(julianday(resolved_at) - julianday(created_at)) * 86400 as avg_secs
+FROM appeals WHERE resolved_at IS NOT NULL AND created_at >= ?1;
+```
+
+## UI Layout
+
+```
+┌─────────────────────────────────────────────────┐
+│  SC-CPE Analytics          [7d] [30d] [90d] [All]│
+├─────────────────────────────────────────────────┤
+│  GROWTH                                          │
+│  ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐           │
+│  │ 142  │ │ 98   │ │ 34   │ │ +12  │           │
+│  │Users │ │Verified│Active │ │ New  │           │
+│  └──────┘ └──────┘ └──────┘ └──────┘           │
+│  [═══════ registration trend line ═══════════]   │
+├─────────────────────────────────────────────────┤
+│  ENGAGEMENT                                      │
+│  ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐           │
+│  │ 8.3  │ │ 204  │ │  5   │ │  0   │           │
+│  │Avg/  │ │CPE   │ │Med.  │ │Empty │           │
+│  │Stream│ │Earned│ │Streak│ │Shows │           │
+│  └──────┘ └──────┘ └──────┘ └──────┘           │
+│  [═══════ daily attendance line ═════════════]   │
+├─────────────────────────────────────────────────┤
+│  CERTIFICATES                                    │
+│  ... (same pattern) ...                          │
+├─────────────────────────────────────────────────┤
+│  SYSTEM HEALTH                                   │
+│  ... (same pattern) ...                          │
+└─────────────────────────────────────────────────┘
+```
+
+## File Changes Summary
+
+**New files (7):**
+- `pages/functions/api/admin/analytics/growth.js`
+- `pages/functions/api/admin/analytics/engagement.js`
+- `pages/functions/api/admin/analytics/certs.js`
+- `pages/functions/api/admin/analytics/system.js`
+- `pages/analytics.html`
+- `pages/analytics.js`
+- `pages/analytics.css`
+
+**Modified files (2):**
+- `pages/admin.html` — add nav link to analytics
+- `pages/_middleware.js` — add Chart.js CDN to CSP if not self-hosting
+
+**Chart.js strategy:** Self-host `chart.umd.min.js` in `pages/lib/` to
+avoid CDN CSP exception and keep `script-src 'self'` unchanged.
+Download from npm or CDN at build time.
+
+## Auth & Security
+
+- All analytics endpoints use `isAdmin(request, env)` from `_lib.js`
+- No PII in responses — aggregate counts only, no emails or names
+- Rate limiting via existing `rateLimit()` helper
+- No CSRF concern (bearer token auth, not cookie-based)
+
+## Constraints
+
+- D1 has no window functions — streak calculations use application logic
+  or self-joins
+- No pre-aggregation tables — all queries run on raw tables. D1 is fast
+  enough for the data volume (~150 users, ~250 streams, ~2000 attendance
+  rows). If it gets slow, add a materialized view later.
+- Granularity grouping uses SQLite `date()` / `strftime()` functions

--- a/scripts/backfill_discord_links.mjs
+++ b/scripts/backfill_discord_links.mjs
@@ -18,11 +18,12 @@
 //   DRY_RUN=1               Log what would be inserted without writing to D1
 //   HOST_USER_IDS=id1,id2   Discord user IDs to classify as "owner"
 
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, unlinkSync } from "node:fs";
 import https from "node:https";
 import { randomBytes } from "node:crypto";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
 // --- Config ---
 const token = process.env.DISCORD_TOKEN
@@ -41,6 +42,15 @@ if (!channelId) { console.error("DISCORD_CHANNEL_ID required"); process.exit(1);
 
 const cutoff = new Date(Date.now() - backfillDays * 86400_000);
 const URL_RE = /https?:\/\/[^\s<>"')\]]+/gi;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROGRESS_FILE = join(__dirname, ".backfill_progress.json");
+const resumeBeforeId = process.env.RESUME_BEFORE_ID
+    || (existsSync(PROGRESS_FILE) ? JSON.parse(readFileSync(PROGRESS_FILE, "utf8")).beforeId : undefined);
+
+function saveProgress(beforeId, page, totalLinks, totalWritten) {
+    writeFileSync(PROGRESS_FILE, JSON.stringify({ beforeId, page, totalLinks, totalWritten, savedAt: new Date().toISOString() }));
+}
 
 function isWeekday(dateStr) {
     const [y, m, d] = dateStr.split("-").map(Number);
@@ -197,6 +207,8 @@ async function main() {
     console.log(`  Backfill: ${backfillDays} days (cutoff: ${cutoff.toISOString().slice(0, 10)})`);
     console.log(`  Delay: ${delayMs}ms between API calls`);
     console.log(`  Host user IDs: ${hostUserIds.size ? [...hostUserIds].join(", ") : "(server owner only)"}`);
+    console.log(`  Resume from: ${resumeBeforeId || "(start)"}`);
+    console.log(`  Progress file: ${PROGRESS_FILE}`);
     console.log(`  Dry run: ${dryRun}\n`);
 
     // 1. Fetch channel info to get guild_id
@@ -281,7 +293,8 @@ async function main() {
     const FLUSH_EVERY = 25;
     const BATCH_SIZE = 50;
     let page = 0;
-    let beforeId = undefined;
+    let beforeId = resumeBeforeId || undefined;
+    if (beforeId) console.log(`Resuming from message ID: ${beforeId}\n`);
     let totalScanned = 0;
     let totalLinks = 0;
     let totalWritten = 0;
@@ -379,11 +392,15 @@ async function main() {
 
         console.log(`[page ${page}] ${totalScanned} msgs, ${totalLinks} links (${counts.owner}o/${counts.moderator}m/${counts.viewer}v), ${missingDates.size} new streams, oldest: ${oldestDate.toISOString().slice(0, 10)}`);
 
-        if (page % FLUSH_EVERY === 0) await flushToD1();
+        if (page % FLUSH_EVERY === 0) {
+            await flushToD1();
+            saveProgress(beforeId, page, totalLinks, totalWritten);
+        }
         if (oldestDate < cutoff) break;
     }
 
     await flushToD1();
+    try { if (existsSync(PROGRESS_FILE)) unlinkSync(PROGRESS_FILE); } catch {}
 
     console.log(`\n=== Scan complete ===`);
     console.log(`Pages: ${page}`);


### PR DESCRIPTION
## Summary
- **Backfill resume**: Discord backfill script now saves progress to `.backfill_progress.json` on every flush, allowing pickup after interruption. File auto-deleted on completion, added to `.gitignore`.
- **Codex config**: `.codex/config.toml` with correct `gpt-5.4` model (ChatGPT OAuth), plus `AGENTS.md` with security audit checklist for AI agents.
- **Design docs**: Analytics dashboard spec and implementation plan.

## Test plan
- [ ] `bash scripts/test.sh` passes (no functional code changed in endpoints)
- [ ] Backfill resume: interrupt script mid-run, verify `.backfill_progress.json` exists, re-run picks up where it left off

🤖 Generated with [Claude Code](https://claude.com/claude-code)