### PR TITLE
feat: ops polish — analytics UI, streams, email prefs, cron triggers, tests, docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,6 +397,15 @@ ADMIN_TOKEN="$(tr -d '\n' < ~/.cloudflare/sc-cpe-admin-token)" \
 - **RUNBOOK incident response SLA** — added 2026-04-24. Severity levels
   P1 (4h), P2 (24h), P3 (1 week) with escalation path and post-incident
   template.
+- **Ops-polish feature bundle** — added 2026-04-24 (PR #67). Admin
+  analytics dashboard with 4 sub-endpoints (growth, engagement, certs,
+  system) rendered as stat-card grids + time-series tables.
+  `GET /api/admin/streams` returns recent streams with attendance counts.
+  Admin dashboard has manual cron trigger buttons for each purge worker
+  block. User detail expansion in admin user search. Dashboard email
+  prefs UI with 4-category unsubscribe checkboxes. Test coverage: 22 new
+  unit tests across 3 test files. Docs: `docs/DEV_SETUP.md` (developer
+  setup) and `docs/ADMIN_ONBOARDING.md` (admin guide).
 
 ## Where to look for more context
 
@@ -404,5 +413,7 @@ ADMIN_TOKEN="$(tr -d '\n' < ~/.cloudflare/sc-cpe-admin-token)" \
 - `docs/LTV.md` — legal/compliance reasoning (GDPR Art. 17(3)(e) carve-out)
 - `docs/DESIGN.md` — architecture decisions
 - `docs/PITCH.md` — Simply Cyber team pitch
+- `docs/DEV_SETUP.md` — developer environment setup
+- `docs/ADMIN_ONBOARDING.md` — admin dashboard guide + common tasks
 - `outputs/handoffs/` — session-end briefs; the most recent one is always
   the fastest way to understand "where we are right now"

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ D1 migrations in `db/migrations/` are applied automatically during deploy — th
 ---
 
 <details>
-<summary><strong>API Surface (46 endpoints)</strong></summary>
+<summary><strong>API Surface (49 endpoints)</strong></summary>
 
 ### Public
 
@@ -297,6 +297,9 @@ D1 migrations in `db/migrations/` are applied automatically during deploy — th
 | `POST /api/admin/revoke` | bearer | Revoke a certificate |
 | `GET /api/admin/export` | bearer | CSV export (users, attendance, certs) |
 | `GET /api/admin/security-events` | bearer | Security event log |
+| `GET /api/admin/streams` | bearer | Recent streams with attendance counts |
+| `POST /api/admin/suspend` | bearer | Suspend / unsuspend a user |
+| `GET/DELETE /api/admin/email-suppression` | bearer | Email suppression list management |
 | `GET /api/admin/analytics/growth` | bearer | User growth time series |
 | `GET /api/admin/analytics/engagement` | bearer | Attendance engagement metrics |
 | `GET /api/admin/analytics/certs` | bearer | Certificate issuance stats |

--- a/docs/ADMIN_ONBOARDING.md
+++ b/docs/ADMIN_ONBOARDING.md
@@ -1,0 +1,90 @@
+# Admin Onboarding Guide
+
+## How admin auth works
+
+Admins authenticate via magic link email. The flow:
+
+1. Admin visits `/admin.html` and enters their email
+2. System sends a time-limited login link (15 min expiry)
+3. Clicking the link sets a session cookie
+4. All subsequent API calls use the cookie (or bearer token fallback)
+
+Admin emails are configured in the `ADMIN_EMAILS` environment variable
+on Cloudflare Pages (comma-separated list).
+
+## Adding a new admin
+
+1. Go to Cloudflare Pages > sc-cpe-web > Settings > Environment variables
+2. Edit `ADMIN_EMAILS` (Production) to add the new email
+3. Trigger a redeploy (merge any PR, or manual `wrangler pages deploy`)
+4. The new admin can now log in at `/admin.html`
+
+## Dashboard sections
+
+| Section | What it shows |
+|---------|---------------|
+| **Overview** | Users, certs, attendance, email queue stats (last 24h) |
+| **Analytics** | Growth, engagement, cert, and system metrics with date range |
+| **War Room** | Rate limit trips and auth failures (24h sparklines) |
+| **Kill switches** | Emergency toggles to disable public endpoints |
+| **Manual triggers** | On-demand execution of purge worker cron blocks |
+| **Email Suppression** | Bounced/complained addresses blocked from sending |
+| **Heartbeats** | Worker health — each cron writes a heartbeat row |
+| **Audit chain** | Hash-chain integrity verification |
+| **Streams** | Recent livestream sessions with attendance counts |
+| **Users** | Search by name, email, channel ID, or user ID |
+| **Appeals** | Attendance dispute queue with grant/deny actions |
+| **Cert feedback** | User-reported typos/errors with re-issue button |
+
+## Common admin tasks
+
+**Search a user**: Type 2+ characters in the Users search box. Results
+show name, email, state, and counts. Click "Details" for full metadata.
+
+**Suspend/unsuspend**: Find the user, click Suspend/Unsuspend. Requires
+a reason (logged in audit trail). Suspended users cannot earn attendance
+or receive certs.
+
+**Revoke a certificate**: Use the Revoke Certificate form with the cert's
+64-char public token, or click Revoke on a cert row in user search results.
+
+**Grant manual attendance**: Click "Grant attendance" on a user row to
+pre-fill the user ID, then fill in stream ID and reason. The stream must
+exist in the database.
+
+**Resolve an appeal**: Load appeals (Open tab), review evidence, click
+Grant or Deny. Grant auto-inserts an attendance row.
+
+**Re-issue a cert**: From cert feedback or user cert list, click Re-issue.
+Creates a new pending cert that supersedes the old one.
+
+## Emergency procedures
+
+**Kill switches**: Toggle any endpoint to return 503. Use when an
+endpoint is being abused or a downstream dependency is failing. The
+toggle is instant — no redeploy needed.
+
+**Manual cron triggers**: Click "Run" on any block to execute it
+immediately via the purge worker. Useful for testing or forcing a
+digest/purge outside its normal schedule.
+
+**Self-healing watchdog**: Runs every 15 minutes via GitHub Actions.
+If a worker goes stale, it auto-triggers the purge worker's on-demand
+endpoint. Failures create GitHub issues with the `auto-heal-escalation`
+label. Manual dispatch: `gh workflow run heal.yml -f sources="purge"`.
+
+## Where to find logs and alerts
+
+- **GitHub Actions**: CI runs, watchdog alerts, monthly cert sweep
+- **Watchdog issues**: Auto-created with `auto-heal-escalation` label
+- **Secret rotation**: Monthly check via `secret-rotation.yml` workflow
+- **Schema drift**: Daily check via `schema-drift.yml` workflow
+- **Ops-stats warnings**: Shown at the top of the admin dashboard
+
+## Escalation path
+
+| Severity | Response time | Examples |
+|----------|--------------|---------|
+| P1 | 4 hours | Audit chain broken, all crons stale |
+| P2 | 24 hours | Single cron stale, email delivery failing |
+| P3 | 1 week | Schema drift, non-critical warning |

--- a/docs/API.md
+++ b/docs/API.md
@@ -1079,6 +1079,107 @@ Email delivery and appeals system metrics.
 }
 ```
 
+### `GET /api/admin/streams`
+
+Recent livestream sessions with attendance counts.
+
+**Auth:** bearer  
+**Rate limit:** 60 req/hr per IP
+
+**Query parameters**
+
+| Param | Type | Default | Notes |
+|-------|------|---------|-------|
+| `days` | int | `30` | 1–365, clamped |
+
+**Response**
+
+```json
+{
+  "ok": true,
+  "streams": [
+    {
+      "id": "ULID",
+      "yt_video_id": "dQw4w9WgXcQ",
+      "title": "Daily Threat Briefing — 2026-04-24",
+      "scheduled_date": "2026-04-24",
+      "state": "ended",
+      "actual_start_at": "2026-04-24T12:00:00Z",
+      "actual_end_at": "2026-04-24T13:00:00Z",
+      "attendance_count": 42
+    }
+  ]
+}
+```
+
+### `POST /api/admin/suspend`
+
+Suspend or unsuspend a user. Suspended users cannot earn attendance or receive certs. Writes an audit trail entry.
+
+**Auth:** bearer  
+**Rate limit:** 30 req/hr per IP
+
+**Body**
+
+```json
+{
+  "user_id": "ULID",
+  "suspended": true,
+  "reason": "Policy violation"
+}
+```
+
+**Response**
+
+```json
+{ "ok": true, "user_id": "ULID", "suspended_at": "2026-04-24T18:00:00Z" }
+```
+
+Set `suspended: false` to unsuspend; response has `"suspended_at": null`.
+
+**Audit:** `user_suspended` / `user_unsuspended`
+
+### `GET /api/admin/email-suppression`
+
+List email addresses blocked from sending (bounced/complained).
+
+**Auth:** bearer  
+**Rate limit:** 60 req/hr per IP
+
+**Response**
+
+```json
+{
+  "ok": true,
+  "suppressions": [
+    {
+      "email_masked": "use***@example.com",
+      "reason": "hard_bounce",
+      "event_id": "evt_abc123",
+      "created_at": "2026-04-24T10:00:00Z"
+    }
+  ]
+}
+```
+
+### `DELETE /api/admin/email-suppression`
+
+Remove an address from the suppression list. Requires the full (unmasked) email.
+
+**Auth:** bearer
+
+**Body**
+
+```json
+{ "email": "user@example.com" }
+```
+
+**Response:** `{ "ok": true }`
+
+**Errors:** `not_found` (404) if the email is not suppressed.
+
+**Audit:** `suppression_removed`
+
 ---
 
 ## 6. Admin auth

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -1,0 +1,134 @@
+# Developer Environment Setup
+
+## Prerequisites
+
+- **Node.js 18+** — test suite uses `node --test` (built-in runner)
+- **Python 3.10+** — cert generator (`services/certs/generate.py`)
+- **wrangler CLI** — `npm i -g wrangler` for local Pages/Workers dev
+- **git** — repo uses `.githooks/pre-push` (runs test suite)
+
+## Clone and install
+
+```bash
+git clone https://github.com/<org>/sc-cpe.git
+cd sc-cpe
+```
+
+No `npm install` needed — the project has zero Node dependencies. All
+tests use `node:test` and `node:assert` (stdlib). The Python cert
+generator has its own requirements in `services/certs/requirements.txt`.
+
+## Running tests
+
+```bash
+bash scripts/test.sh
+```
+
+This runs every `*.test.mjs` file listed in `scripts/test.sh`. New test
+files must be added to that script manually (no auto-discovery). The
+`.githooks/pre-push` hook runs the same suite before every push.
+
+## Smoke tests (deployed origin)
+
+```bash
+ADMIN_TOKEN="$(tr -d '\n' < ~/.cloudflare/sc-cpe-admin-token)" \
+  ORIGIN="https://sc-cpe-web.pages.dev" scripts/smoke_hardening.sh
+```
+
+Read-only probes against the deployed site. Safe to run anytime.
+
+## Schema drift check
+
+```bash
+bash scripts/check_schema.sh
+```
+
+Compares live D1 schema against `db/schema.sql`. Requires
+`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` env vars.
+
+## Preview environment
+
+The repo has a full preview environment configured in `wrangler.toml`
+under `[env.preview]`:
+
+| Resource | Preview binding |
+|----------|----------------|
+| D1 | `sc-cpe-preview` (`8aa974e0-...`) |
+| KV | `sc-cpe-rate-preview` (`3eecd067...`) |
+| R2 | `sc-cpe-certs-preview` |
+
+PR deployments use these bindings via `.github/workflows/deploy-preview.yml`.
+Preview D1 is independent of production — safe for schema experiments.
+
+## Local development with wrangler
+
+```bash
+cd pages
+wrangler pages dev .
+```
+
+For local secrets, create `pages/.dev.vars`:
+
+```
+ADMIN_TOKEN=your-local-dev-token
+YOUTUBE_API_KEY=your-api-key
+RESEND_API_KEY=re_test_...
+```
+
+Workers run independently:
+
+```bash
+cd workers/poller && wrangler dev
+cd workers/purge && wrangler dev
+cd workers/email-sender && wrangler dev
+```
+
+## Python cert generator
+
+```bash
+cd services/certs
+python3 -m venv .venv
+source .venv/bin/activate   # or .venv\Scripts\activate on Windows
+pip install -r requirements.txt
+```
+
+Run locally (requires D1 API access + signing key):
+
+```bash
+python generate.py --pending-only  # drain pending certs
+python generate.py                 # full monthly sweep
+```
+
+## Audit chain verification
+
+```bash
+python scripts/verify_audit_chain.py
+```
+
+Checks hash-chain integrity via D1 HTTP API. Requires CF API token.
+
+## Common issues
+
+**CRLF warnings on Windows**: Git may warn about LF→CRLF conversion.
+This is cosmetic — the CI runs on Linux. To silence:
+
+```bash
+git config core.autocrlf input
+```
+
+**Python venv on Windows**: Use `.venv\Scripts\activate` instead of
+`source .venv/bin/activate`. If `pip install` fails for `cryptography`,
+install the Rust toolchain or use `pip install --only-binary=:all:`.
+
+**Pre-push hook not firing**: Ensure the hook is executable and git is
+configured to use the repo's hooks directory:
+
+```bash
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-push
+```
+
+## Architecture context
+
+See `CLAUDE.md` for invariants, deployment details, and known gaps.
+See `docs/DESIGN.md` for architecture decisions.

--- a/outputs/next-session-prompt.md
+++ b/outputs/next-session-prompt.md
@@ -1,0 +1,116 @@
+# Next Session Prompt — QA & Hardening
+
+Paste this into a new Claude Code session:
+
+---
+
+QA/hardening session for the `feat/ops-polish` bundle (PR #67). Goal: find bugs, edge cases, and integration gaps across all 8 shipped features before merge. Read CLAUDE.md first.
+
+Work on `main` (or the merge result). Commit fixes as you go. Run `bash scripts/test.sh` after each fix to confirm green. Push when done.
+
+## Phase 1: Smoke test the new probes
+
+Run the updated smoke suite against the deployed preview (or prod):
+
+```bash
+ADMIN_TOKEN="$(tr -d '\n' < ~/.cloudflare/sc-cpe-admin-token)" \
+  ORIGIN="https://sc-cpe-web.pages.dev" bash scripts/smoke_hardening.sh
+```
+
+Verify all new probes pass: `admin/streams`, `admin/analytics/*` (4 endpoints), `admin/suspend`, `admin/email-suppression`. If any fail, triage and fix the endpoint before continuing.
+
+## Phase 2: Analytics dashboard edge cases
+
+Test each analytics endpoint with boundary inputs:
+
+1. **Empty database**: What happens when there are zero users, zero attendance, zero certs? Each of the 4 analytics endpoints should return valid JSON with empty arrays / zero counts — not 500.
+2. **Range boundaries**: Call each with `?range=7d`, `?range=90d`, `?range=all`, `?range=invalid`, `?range=` (empty). Invalid/missing should fall back to 30d, not error.
+3. **Growth time-series ordering**: Verify `GET /api/admin/analytics/growth` returns `registrations_by_period` sorted ascending by period. Check that the period labels match the range (daily for 7d/30d, weekly for 90d, monthly for all).
+4. **Admin.js rendering**: Open admin.html in a browser. Click "Load" on the Analytics section with each range. Verify:
+   - Stat cards render with correct labels (no `undefined` or `NaN`)
+   - Time-series table has correct column headers
+   - Empty states show "No data" rather than a blank or broken table
+   - No console errors
+
+## Phase 3: Streams endpoint + UI
+
+1. **Streams with no data**: Call `GET /api/admin/streams?days=7` when no streams exist in the range. Should return `{ ok: true, streams: [] }`, not error.
+2. **Days parameter validation**: Test `?days=0`, `?days=-1`, `?days=999`, `?days=abc`, no param. Should clamp to 1-365 range or default to 30.
+3. **Attendance count accuracy**: For a stream with known attendance, verify the `attendance_count` subquery returns the correct number. Cross-check against `GET /api/admin/attendance`.
+4. **YouTube link generation**: In admin.js, verify that the YouTube link for each stream row correctly links to `https://youtube.com/watch?v={yt_video_id}`. Streams with null `yt_video_id` should not show a broken link.
+5. **Table rendering**: Open admin.html, load streams with different day ranges. Verify the "No streams found" empty state appears when appropriate.
+
+## Phase 4: Email preferences UI
+
+1. **Initial state**: Register a test user. Open their dashboard. Verify the email preferences card shows all 4 categories checked (subscribed by default).
+2. **Toggle persistence**: Uncheck "Monthly digest", wait for the POST to complete, refresh the page. Verify the checkbox stays unchecked.
+3. **Multiple toggles**: Uncheck all 4 categories, refresh. Re-check 2 of them, refresh. Verify state persists correctly each time.
+4. **Race condition**: Rapidly toggle checkboxes. Verify no duplicate POST requests pile up and the final state is correct.
+5. **Error handling**: What happens if the prefs POST fails (e.g., network error)? Does the checkbox revert? Is there user feedback?
+6. **Interaction with unsubscribe endpoint**: If a user has unsubscribed via email footer link (setting `email_prefs.unsubscribed = ["monthly_digest"]`), does the dashboard correctly show that category unchecked?
+
+## Phase 5: User detail expansion
+
+1. **Field completeness**: Search for a user. Click the detail expand button. Verify all 8 metadata fields render (id, email, legal_name, state, yt_channel_id, yt_display_name_seen, created_at, verified_at). Null fields should show "—" or similar, not "null" or "undefined".
+2. **Suspended user**: Find a suspended user (or suspend one via API). Verify the SUSPENDED pill appears and the detail panel shows `suspended_at` with a timestamp.
+3. **Deleted user**: Check that deleted users (if any) show `deleted_at` and a visual indicator.
+4. **Pre-fill links**: Click "Grant attendance" link on a user row. Verify the attendance form's user ID field is pre-filled with the correct ULID. Same for "Revoke certificate" link.
+5. **Cert summary**: Verify the cert count breakdown (pending/generated/delivered/revoked) matches what `/api/admin/user/{id}/certs` returns.
+6. **XSS safety**: Create a user with `legal_name` containing `<script>alert(1)</script>`. Verify it renders as escaped text, not executable HTML.
+
+## Phase 6: Cron trigger buttons
+
+1. **Button rendering**: Open admin.html. Verify 6 buttons appear in the Manual Triggers section: purge, security_alerts, weekly_digest, cert_nudge, link_enrichment, all.
+2. **Confirmation prompt**: Click a trigger button. Verify a confirmation dialog appears before the POST fires.
+3. **Auth forwarding**: Verify the POST to the purge worker URL includes the correct `Authorization: Bearer` header. Check browser DevTools Network tab.
+4. **Success/failure feedback**: After triggering, verify the UI shows a success or error message inline. Test with an intentionally wrong token to see the error path.
+5. **"All" button**: Trigger "all" and verify it executes without error. Check that it doesn't cause a rate-limit trip on subsequent button presses.
+6. **URL correctness**: Verify the hardcoded purge worker URL `https://sc-cpe-purge.ericrihm.workers.dev/` is correct and reachable.
+
+## Phase 7: Test suite integrity
+
+1. **Run full suite**: `bash scripts/test.sh` — all tests must pass (expect 318+ tests, 0 failures).
+2. **New test file coverage**: Verify these 3 files are listed in `scripts/test.sh`:
+   - `pages/functions/api/admin/analytics/analytics.test.mjs`
+   - `pages/functions/api/admin/new-admin-features.test.mjs`
+   - `pages/functions/api/me/user-features.test.mjs`
+3. **Parity tests**: Run `node scripts/test_chain_parity.mjs` and `node scripts/test_source_parity.mjs` to confirm audit chain canonical form and heartbeat source parity still hold.
+4. **E2E test**: Run `node scripts/test_e2e.mjs` — the register-attend-cert-verify pipeline should still pass.
+
+## Phase 8: Cross-cutting integration checks
+
+1. **Heartbeat parity**: Confirm `pages/functions/_heartbeat.js` and `workers/purge/src/index.js` have identical `EXPECTED_CADENCE_S` entries. No new crons were added, but verify nothing was accidentally modified.
+2. **CSP compliance**: Verify no inline `<script>` was introduced in admin.html or dashboard.html. All JS must be in external files (`admin.js`, `dashboard.js`). Check `_middleware.js` CSP header still has `script-src 'self'`.
+3. **Rate limiting**: Each new admin endpoint should have rate limiting. Verify:
+   - `/api/admin/streams` has rate limit (60/hr per admin)
+   - `/api/admin/analytics/*` endpoints have rate limits
+   - `/api/admin/suspend` has rate limit
+   - `/api/admin/email-suppression` has rate limit
+4. **Audit trail**: Verify these admin actions write audit log entries:
+   - Suspend/unsuspend a user
+   - Delete an email suppression entry
+   - Cert resend (user-initiated)
+5. **Dashboard token isolation**: Verify badge URLs use `badge_token` (not `dashboard_token`). Check that the dashboard email prefs POST uses the CSRF same-origin check.
+6. **Kill switch interaction**: Toggle a kill switch (e.g., disable `/api/register`). Verify the analytics endpoints still work — they should not be affected by public endpoint kill switches.
+7. **Schema alignment**: Run `bash scripts/check_schema.sh` to confirm `db/schema.sql` matches live D1. The ops-polish bundle added no migrations, but verify no drift exists.
+
+## Phase 9: Documentation review
+
+1. **`docs/DEV_SETUP.md`**: Follow the setup instructions on a clean checkout. Verify every command works. Check that the preview environment table matches `wrangler.toml` `[env.preview]` bindings.
+2. **`docs/ADMIN_ONBOARDING.md`**: Walk through each "Common admin tasks" section against the actual admin.html UI. Verify the dashboard section table matches what's actually rendered. Confirm emergency procedures match the actual kill switch and cron trigger UX.
+3. **`CLAUDE.md`**: Verify the ops-polish entry accurately describes what was shipped. Verify the "Where to look" section includes DEV_SETUP.md and ADMIN_ONBOARDING.md.
+4. **`README.md`**: Verify the API surface table includes `/api/admin/streams`, `/api/admin/suspend`, and `/api/admin/email-suppression`. Verify the endpoint count in the `<summary>` tag is correct (49).
+
+## Phase 10: Security spot-check
+
+1. **XSS in admin.js**: Grep for any remaining `innerHTML` assignments that don't use `escapeHtml()`. All dynamic content in admin.js must be escaped or use `textContent`/DOM methods.
+2. **CSRF on new endpoints**: Verify `/api/me/{token}/cert-resend/{cert_id}` calls `isSameOrigin()`. Verify prefs POST calls `isSameOrigin()`.
+3. **Auth on admin endpoints**: Verify every admin endpoint calls `isAdmin()` and returns 401 on failure. Check streams, analytics/*, suspend, email-suppression.
+4. **Input validation**: Verify the streams `?days=` param is parseInt'd and clamped. Verify the suspend endpoint validates `user_id` and `reason` fields.
+5. **Error message leakage**: Verify admin endpoint error responses don't leak stack traces, SQL, or internal paths. Check that 500 errors return a generic message.
+
+---
+
+**Priority**: Phases 1-3 are critical (new endpoints and rendering). Phase 8 (integration) is high priority. Phases 4-7 and 9-10 are important but lower blast radius.
+
+Fix any bugs found. Commit each fix separately with descriptive messages. Run `bash scripts/test.sh` after each fix. When all phases pass, push and report a summary of findings and fixes.

--- a/pages/admin.html
+++ b/pages/admin.html
@@ -41,6 +41,21 @@
     <div class="section-h">Overview (last 24h)</div>
     <div class="grid" id="stats"></div>
 
+    <div class="section-h">Analytics <span class="muted" style="font-size:11px;text-transform:none;letter-spacing:0;">— registration, engagement, certs, system health</span></div>
+    <div style="margin-bottom:12px;display:flex;gap:6px;align-items:center;">
+      <select id="analytics-range" style="background:var(--adm-card);color:var(--adm-fg);border:1px solid var(--adm-border);padding:4px 8px;border-radius:4px;font-size:12px;">
+        <option value="7d">Last 7 days</option>
+        <option value="30d" selected>Last 30 days</option>
+        <option value="90d">Last 90 days</option>
+        <option value="all">All time</option>
+      </select>
+      <button class="refresh" id="analytics-load" style="font-size:11px;padding:3px 10px;">Load</button>
+    </div>
+    <div id="analytics-growth"></div>
+    <div id="analytics-engagement"></div>
+    <div id="analytics-certs"></div>
+    <div id="analytics-system"></div>
+
     <div class="section-h" style="color:var(--bad);">War Room <span class="muted" style="font-size:11px;text-transform:none;letter-spacing:0;">— live attack monitoring (rate limit trips, auth failures)</span></div>
     <div id="sec-events"></div>
 

--- a/pages/admin.html
+++ b/pages/admin.html
@@ -62,6 +62,9 @@
     <div class="section-h">Kill switches <span class="muted" style="font-size:11px;text-transform:none;letter-spacing:0;">— emergency containment for public endpoints</span></div>
     <div id="toggles" style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:20px;"></div>
 
+    <div class="section-h">Manual triggers <span class="muted" style="font-size:11px;text-transform:none;letter-spacing:0;">— on-demand cron block execution via purge worker</span></div>
+    <div id="cron-triggers" style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:20px;"></div>
+
     <div class="section-h">Email Suppression <span class="muted" style="font-size:11px;text-transform:none;letter-spacing:0;">— bounced/complained addresses blocked from sending</span></div>
     <div id="suppression-rows"></div>
     <p id="suppression-empty" class="muted" style="font-size:12px;" hidden>No suppressed addresses.</p>

--- a/pages/admin.html
+++ b/pages/admin.html
@@ -74,6 +74,23 @@
     <div class="section-h">Audit chain</div>
     <div class="grid" id="chain"></div>
 
+    <div class="section-h">Streams <span class="muted" style="font-size:11px;text-transform:none;letter-spacing:0;">— recent livestream sessions</span></div>
+    <div style="margin-bottom:8px;display:flex;gap:6px;align-items:center;">
+      <select id="streams-days" style="background:var(--adm-card);color:var(--adm-fg);border:1px solid var(--adm-border);padding:4px 8px;border-radius:4px;font-size:12px;">
+        <option value="7">Last 7 days</option>
+        <option value="14">Last 14 days</option>
+        <option value="30" selected>Last 30 days</option>
+        <option value="90">Last 90 days</option>
+      </select>
+      <button class="refresh" id="streams-load" style="font-size:11px;padding:3px 10px;">Load</button>
+    </div>
+    <div class="stats-scroll">
+    <table id="streams-table"><thead>
+      <tr><th>Date</th><th>Title</th><th>State</th><th>Attendance</th><th>Start</th><th>End</th></tr>
+    </thead><tbody></tbody></table>
+    </div>
+    <p id="streams-empty" class="muted" style="font-size:12px;" hidden>No streams found.</p>
+
     <div class="section-h">Users</div>
     <div class="admin-search" id="user-search-wrap">
       <form id="user-search-form" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -58,6 +58,7 @@ async function load() {
     renderWarnings(stats);
     renderStats(stats);
     renderToggles(toggles);
+    renderCronTriggers();
     if (supp) renderSuppression(supp);
     renderHeartbeats(hb);
     renderChain(chain, stats);
@@ -128,6 +129,50 @@ function renderToggles(d) {
     })(t, btn);
     wrap.append(label, btn);
     box.appendChild(wrap);
+  }
+}
+function renderCronTriggers() {
+  var box = $("#cron-triggers");
+  if (!box || box.childNodes.length > 0) return;
+  var blocks = ["purge", "security_alerts", "weekly_digest", "cert_nudge", "link_enrichment", "all"];
+  var PURGE_URL = "https://sc-cpe-purge.ericrihm.workers.dev/";
+  for (var i = 0; i < blocks.length; i++) {
+    (function (block) {
+      var wrap = document.createElement("div");
+      wrap.className = "card";
+      wrap.style.cssText = "padding:10px 14px;display:flex;align-items:center;gap:10px;min-width:180px;";
+      var label = document.createElement("div");
+      var labelK = document.createElement("div");
+      labelK.className = "k";
+      labelK.textContent = block;
+      label.appendChild(labelK);
+      var btn = document.createElement("button");
+      btn.className = "refresh";
+      btn.style.cssText = "margin-left:auto;font-size:11px;padding:3px 10px;";
+      btn.textContent = "Run";
+      btn.addEventListener("click", async function () {
+        if (!confirm("Run " + block + " now?")) return;
+        btn.disabled = true;
+        btn.textContent = "running…";
+        try {
+          var r = await fetch(PURGE_URL + "?only=" + encodeURIComponent(block), {
+            method: "POST",
+            headers: { "Authorization": "Bearer " + TOKEN },
+          });
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          btn.textContent = "done";
+          btn.style.color = "var(--adm-ok)";
+          setTimeout(function () { btn.textContent = "Run"; btn.style.color = ""; btn.disabled = false; }, 3000);
+        } catch (e) {
+          btn.textContent = "failed";
+          btn.title = e.message;
+          btn.style.color = "var(--adm-bad)";
+          setTimeout(function () { btn.textContent = "Run"; btn.style.color = ""; btn.disabled = false; }, 3000);
+        }
+      });
+      wrap.append(label, btn);
+      box.appendChild(wrap);
+    })(blocks[i]);
   }
 }
 function renderSuppression(d) {

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -547,6 +547,37 @@ function buildUserRow(u) {
         meta.appendChild(appSpan);
     }
 
+    var detail = document.createElement("div");
+    detail.className = "user-detail";
+    detail.style.cssText = "display:none;margin-top:8px;padding-top:8px;border-top:1px solid var(--adm-border);font-size:12px;";
+    var detailGrid = document.createElement("div");
+    detailGrid.style.cssText = "display:grid;grid-template-columns:1fr 1fr 1fr;gap:4px 16px;";
+    var fields = [
+        ["Created", u.created_at], ["Verified", u.verified_at],
+        ["Email", u.email], ["Legal name", u.legal_name],
+        ["YT Channel", u.yt_channel_id], ["YT Display Name", u.yt_display_name_seen],
+        ["Suspended", u.suspended_at], ["Deleted", u.deleted_at],
+    ];
+    for (var fi = 0; fi < fields.length; fi++) {
+        var fd = document.createElement("div");
+        var fl = document.createElement("div");
+        fl.style.cssText = "color:var(--adm-muted-dim);font-size:10px;text-transform:uppercase;letter-spacing:0.06em;";
+        fl.textContent = fields[fi][0];
+        var fv = document.createElement("div");
+        fv.style.fontFamily = "monospace";
+        fv.style.wordBreak = "break-all";
+        fv.textContent = fields[fi][1] || "—";
+        fd.append(fl, fv);
+        detailGrid.appendChild(fd);
+    }
+    detail.appendChild(detailGrid);
+
+    var detailToggle = document.createElement("button");
+    detailToggle.className = "refresh detail-toggle-btn";
+    detailToggle.dataset.uid = u.id;
+    detailToggle.style.cssText = "font-size:11px;padding:3px 10px;background:transparent;border:1px solid var(--adm-border);color:var(--adm-muted);";
+    detailToggle.textContent = "Details";
+
     var actions = document.createElement("div");
     actions.className = "user-actions";
     var certsBtn = document.createElement("button");
@@ -565,13 +596,13 @@ function buildUserRow(u) {
     suspendBtn.dataset.suspended = u.suspended_at ? "1" : "";
     suspendBtn.style.cssText = "font-size:11px;padding:3px 10px;" + (u.suspended_at ? "" : "background:#5c1515;");
     suspendBtn.textContent = u.suspended_at ? "Unsuspend" : "Suspend";
-    actions.append(certsBtn, grantBtn, suspendBtn);
+    actions.append(certsBtn, grantBtn, suspendBtn, detailToggle);
 
     var expand = document.createElement("div");
     expand.className = "cert-expand";
     expand.id = "certs-" + u.id;
 
-    row.append(header, meta, actions, expand);
+    row.append(header, meta, actions, detail, expand);
     return row;
 }
 
@@ -647,6 +678,16 @@ function renderCertSubTable(container, certs) {
 var userResultsBox = $("#user-results");
 if (userResultsBox) {
     userResultsBox.addEventListener("click", async function (e) {
+        var detailBtn = e.target.closest(".detail-toggle-btn");
+        if (detailBtn) {
+            var detailEl = detailBtn.closest(".user-row").querySelector(".user-detail");
+            if (detailEl) {
+                var showing = detailEl.style.display !== "none";
+                detailEl.style.display = showing ? "none" : "";
+                detailBtn.textContent = showing ? "Details" : "Hide details";
+            }
+            return;
+        }
         var certsBtn = e.target.closest(".view-certs-btn");
         if (certsBtn && !certsBtn.disabled) {
             var uid = certsBtn.dataset.uid;

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -102,7 +102,7 @@ function renderToggles(d) {
     wrap.style.gap = "10px";
     wrap.style.minWidth = "240px";
     var label = document.createElement("div");
-    label.innerHTML = '<span class="k">/api/' + t.name + '</span><div class="v ' + (t.killed ? "stale" : "ok") + '" style="font-size:14px;">' + (t.killed ? "KILLED (503)" : "live") + '</div>';
+    label.innerHTML = '<span class="k">/api/' + escapeHtml(t.name) + '</span><div class="v ' + (t.killed ? "stale" : "ok") + '" style="font-size:14px;">' + (t.killed ? "KILLED (503)" : "live") + '</div>';
     var btn = document.createElement("button");
     btn.className = "refresh";
     btn.style.marginLeft = "auto";

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -1040,6 +1040,89 @@ if (attendanceForm) {
         }
     });
 }
+async function loadAnalytics() {
+  var range = ($("#analytics-range") || {}).value || "30d";
+  var qs = "?range=" + range;
+  var sections = ["growth", "engagement", "certs", "system"];
+  for (var i = 0; i < sections.length; i++) {
+    var el = $("#analytics-" + sections[i]);
+    if (el) { el.textContent = ""; var p = document.createElement("p"); p.className = "muted"; p.style.fontSize = "12px"; p.textContent = "Loading…"; el.appendChild(p); }
+  }
+  try {
+    var results = await Promise.all([
+      fetchJson("/api/admin/analytics/growth" + qs),
+      fetchJson("/api/admin/analytics/engagement" + qs),
+      fetchJson("/api/admin/analytics/certs" + qs),
+      fetchJson("/api/admin/analytics/system" + qs),
+    ]);
+    renderAnalyticsSection("analytics-growth", "Growth", results[0].headlines, {
+      total_users: "Total users", active_users: "Active", verified_users: "Verified",
+      active_attenders_30d: "Active attenders (30d)", new_registrations: "New registrations",
+    }, results[0].series);
+    renderAnalyticsSection("analytics-engagement", "Engagement", results[1].headlines, {
+      avg_attendance_per_stream: "Avg attendance / stream",
+      total_cpe_awarded: "Total CPE awarded",
+      streams_with_zero_attendance: "Streams (0 attendance)",
+    }, results[1].series);
+    renderAnalyticsSection("analytics-certs", "Certificates", results[2].headlines, {
+      issued_this_period: "Issued (period)",
+      pending_now: "Pending now",
+      avg_delivery_seconds: "Avg delivery (s)",
+      view_rate_pct: "View rate %",
+    }, results[2].series);
+    renderAnalyticsSection("analytics-system", "System", results[3].headlines, {
+      email_success_rate_pct: "Email success %",
+      emails_sent: "Emails sent",
+      appeals_open: "Open appeals",
+      avg_appeal_resolution_seconds: "Avg appeal resolution (s)",
+    }, results[3].series);
+  } catch (e) {
+    var el = $("#analytics-growth");
+    if (el) { el.textContent = ""; var d = document.createElement("div"); d.className = "err"; d.textContent = e.message; el.appendChild(d); }
+  }
+}
+function renderAnalyticsSection(containerId, title, headlines, labels, series) {
+  var el = $("#" + containerId);
+  if (!el) return;
+  el.textContent = "";
+  var hdr = document.createElement("div");
+  hdr.style.cssText = "font-size:12px;font-weight:600;color:var(--adm-muted);margin-bottom:6px;";
+  hdr.textContent = title;
+  el.appendChild(hdr);
+  var grid = document.createElement("div");
+  grid.className = "grid";
+  var keys = Object.keys(labels);
+  for (var i = 0; i < keys.length; i++) {
+    var val = headlines[keys[i]];
+    grid.appendChild(card(labels[keys[i]], val != null ? escapeHtml(String(val)) : "—"));
+  }
+  el.appendChild(grid);
+  if (series && series.length > 0) {
+    var tbl = document.createElement("table");
+    tbl.style.fontSize = "12px";
+    var cols = Object.keys(series[0]);
+    var thead = document.createElement("thead");
+    var headTr = document.createElement("tr");
+    for (var c = 0; c < cols.length; c++) {
+      var th = document.createElement("th"); th.textContent = cols[c]; headTr.appendChild(th);
+    }
+    thead.appendChild(headTr);
+    tbl.appendChild(thead);
+    var tbody = document.createElement("tbody");
+    var limit = Math.min(series.length, 30);
+    for (var r = 0; r < limit; r++) {
+      var tr = document.createElement("tr");
+      for (var c = 0; c < cols.length; c++) {
+        var td = document.createElement("td"); td.textContent = String(series[r][cols[c]] ?? ""); tr.appendChild(td);
+      }
+      tbody.appendChild(tr);
+    }
+    tbl.appendChild(tbody);
+    el.appendChild(tbl);
+  }
+}
+var analyticsLoadBtn = $("#analytics-load");
+if (analyticsLoadBtn) analyticsLoadBtn.addEventListener("click", loadAnalytics);
 (async function init() {
     try {
         var testR = await fetch("/api/admin/ops-stats", { credentials: "include" });

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -1040,6 +1040,45 @@ if (attendanceForm) {
         }
     });
 }
+async function loadStreams() {
+  var days = ($("#streams-days") || {}).value || "30";
+  var tb = $("#streams-table tbody");
+  var empty = $("#streams-empty");
+  if (tb) tb.textContent = "";
+  if (empty) empty.hidden = true;
+  try {
+    var data = await fetchJson("/api/admin/streams?days=" + days);
+    var streams = data.streams || [];
+    if (streams.length === 0) { if (empty) empty.hidden = false; return; }
+    for (var i = 0; i < streams.length; i++) {
+      var s = streams[i];
+      var tr = document.createElement("tr");
+      var tdDate = document.createElement("td"); tdDate.textContent = s.scheduled_date || "—";
+      var tdTitle = document.createElement("td");
+      if (s.yt_video_id) {
+        var a = document.createElement("a");
+        a.href = "https://www.youtube.com/watch?v=" + encodeURIComponent(s.yt_video_id);
+        a.target = "_blank"; a.rel = "noopener"; a.style.color = "#7cc3ff";
+        a.textContent = s.title || s.yt_video_id;
+        tdTitle.appendChild(a);
+      } else {
+        tdTitle.textContent = s.title || "—";
+      }
+      var tdState = document.createElement("td");
+      tdState.className = s.state === "ended" ? "ok" : (s.state === "live" ? "warn" : "muted");
+      tdState.textContent = s.state || "—";
+      var tdAtt = document.createElement("td"); tdAtt.textContent = s.attendance_count != null ? s.attendance_count : "—";
+      var tdStart = document.createElement("td"); tdStart.className = "muted"; tdStart.textContent = s.actual_start_at ? s.actual_start_at.slice(11, 19) : "—";
+      var tdEnd = document.createElement("td"); tdEnd.className = "muted"; tdEnd.textContent = s.actual_end_at ? s.actual_end_at.slice(11, 19) : "—";
+      tr.append(tdDate, tdTitle, tdState, tdAtt, tdStart, tdEnd);
+      tb.appendChild(tr);
+    }
+  } catch (e) {
+    if (tb) { var errTr = document.createElement("tr"); var errTd = document.createElement("td"); errTd.colSpan = 6; errTd.className = "stale"; errTd.textContent = e.message; errTr.appendChild(errTd); tb.appendChild(errTr); }
+  }
+}
+var streamsLoadBtn = $("#streams-load");
+if (streamsLoadBtn) streamsLoadBtn.addEventListener("click", loadStreams);
 async function loadAnalytics() {
   var range = ($("#analytics-range") || {}).value || "30d";
   var qs = "?range=" + range;

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -285,6 +285,21 @@
             <p id="prefs-msg" class="muted prefs-hint" hidden></p>
         </div>
 
+        <div class="card" id="email-prefs-card" hidden>
+            <h2 class="card-heading">Email preferences</h2>
+            <p class="muted rotate-desc">
+                Choose which engagement emails you receive. Transactional emails
+                (registration, cert delivery, security) are always sent.
+            </p>
+            <div class="prefs-radios" id="email-prefs-checks">
+                <label><input type="checkbox" data-cat="monthly_digest" checked> Monthly digest</label>
+                <label><input type="checkbox" data-cat="cert_nudge" checked> Certificate reminders</label>
+                <label><input type="checkbox" data-cat="renewal_nudge" checked> Renewal reminders</label>
+                <label><input type="checkbox" data-cat="streak_milestone" checked> Streak milestones</label>
+            </div>
+            <p id="email-prefs-msg" class="muted prefs-hint" hidden></p>
+        </div>
+
         <div class="card" id="leaderboard-card" hidden>
             <h2 class="card-heading">Community leaderboard</h2>
             <label class="check">

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -95,6 +95,13 @@ async function load() {
 
         document.getElementById("leaderboard-card").hidden = false;
         document.getElementById("leaderboard-toggle").checked = !!d.user.show_on_leaderboard;
+
+        document.getElementById("email-prefs-card").hidden = false;
+        var unsubs = (d.user.email_prefs && d.user.email_prefs.unsubscribed) || [];
+        var checks = document.querySelectorAll("#email-prefs-checks input[data-cat]");
+        for (var ci = 0; ci < checks.length; ci++) {
+            checks[ci].checked = unsubs.indexOf(checks[ci].dataset.cat) === -1;
+        }
     }
 
     if (d.user.state === "pending_verification") {
@@ -1108,6 +1115,32 @@ document.getElementById("leaderboard-toggle").addEventListener("change", async f
     } catch (err) {
         msg.textContent = "Failed: " + err.message;
         e.target.checked = !e.target.checked;
+    }
+});
+
+// --- Email preferences ---
+document.getElementById("email-prefs-checks").addEventListener("change", async function (e) {
+    var cb = e.target.closest("input[data-cat]");
+    if (!cb) return;
+    var msg = document.getElementById("email-prefs-msg");
+    msg.hidden = false;
+    msg.textContent = "saving…";
+    var checks = document.querySelectorAll("#email-prefs-checks input[data-cat]");
+    var unsubs = [];
+    for (var i = 0; i < checks.length; i++) {
+        if (!checks[i].checked) unsubs.push(checks[i].dataset.cat);
+    }
+    try {
+        var r = await fetch("/api/me/" + encodeURIComponent(token) + "/prefs", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ unsubscribed: unsubs }),
+        });
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        msg.textContent = "saved";
+    } catch (err) {
+        msg.textContent = "failed: " + err.message;
+        cb.checked = !cb.checked;
     }
 });
 

--- a/pages/functions/api/admin/analytics/_helpers.js
+++ b/pages/functions/api/admin/analytics/_helpers.js
@@ -1,4 +1,4 @@
-import { json, isAdmin } from "../../../_lib.js";
+import { json, isAdmin, rateLimit, clientIp, ipHash } from "../../../_lib.js";
 
 export function parseRange(url) {
     const range = url.searchParams.get("range") || "30d";
@@ -26,5 +26,8 @@ export async function guardAdmin(env, request) {
     if (!(await isAdmin(env, request))) {
         return json({ error: "unauthorized" }, 401);
     }
+    const ipH = await ipHash(clientIp(request));
+    const rl = await rateLimit(env, `admin_analytics:${ipH}`, 60);
+    if (!rl.ok) return json(rl.body, rl.status, rl.headers);
     return null;
 }

--- a/pages/functions/api/admin/analytics/analytics.test.mjs
+++ b/pages/functions/api/admin/analytics/analytics.test.mjs
@@ -1,0 +1,152 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestGet as growthGet } from "./growth.js";
+import { onRequestGet as engagementGet } from "./engagement.js";
+import { onRequestGet as certsGet } from "./certs.js";
+import { onRequestGet as systemGet } from "./system.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function auth(url) {
+    return new Request(url, {
+        headers: { Authorization: "Bearer adm" },
+    });
+}
+
+function stubDB(overrides = {}) {
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([pattern]) =>
+                new RegExp(pattern, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => ({ meta: {} }),
+            };
+            return stmt;
+        },
+    };
+}
+
+function analyticsDB() {
+    return stubDB({
+        "COUNT.*FROM users": () => ({ n: 10 }),
+        "COUNT.*FROM attendance": () => ({ n: 5 }),
+        "COUNT.*DISTINCT": () => ({ n: 8 }),
+        "AVG": () => ({ avg_att: 12.3, avg_secs: 3600, total: 100 }),
+        "SUM": () => ({ total: 456.5 }),
+        "SELECT.*period": (sql) => [],
+        "COUNT.*FROM certs": () => ({ n: 20 }),
+        "COUNT.*FROM streams": () => ({ n: 2 }),
+        "CASE WHEN state": () => ({ sent: 90, failed: 5, total: 100 }),
+        "CASE WHEN first_viewed": () => ({ viewed: 80, total: 100 }),
+        "FROM email_outbox": () => ({ sent: 90, failed: 5, total: 100 }),
+        "FROM appeals": () => ({ n: 3 }),
+    });
+}
+
+// ── growth ──────────────────────────────────────────────────────────────
+
+test("analytics/growth: unauthorized → 401", async () => {
+    const r = await growthGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/analytics/growth`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("analytics/growth: valid → 200 with headlines and series", async () => {
+    const db = stubDB({
+        "deleted_at IS NULL": () => ({ n: 10 }),
+        "state = 'active'": () => ({ n: 8 }),
+        "verified_at IS NOT NULL": () => ({ n: 9 }),
+        "DISTINCT user_id": () => ({ n: 5 }),
+        "GROUP BY period": () => [],
+        "COUNT.*FROM users": () => ({ n: 3 }),
+    });
+    const r = await growthGet({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/analytics/growth?range=30d`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.ok("total_users" in j.headlines);
+    assert.ok("active_users" in j.headlines);
+    assert.ok("verified_users" in j.headlines);
+    assert.ok("new_registrations" in j.headlines);
+    assert.ok(Array.isArray(j.series));
+});
+
+// ── engagement ──────────────────────────────────────────────────────────
+
+test("analytics/engagement: unauthorized → 401", async () => {
+    const r = await engagementGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/analytics/engagement`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("analytics/engagement: valid → 200 with attendance data", async () => {
+    const r = await engagementGet({
+        env: { DB: analyticsDB(), ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/analytics/engagement?range=7d`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.ok("avg_attendance_per_stream" in j.headlines);
+    assert.ok("total_cpe_awarded" in j.headlines);
+    assert.ok(Array.isArray(j.series));
+});
+
+// ── certs ───────────────────────────────────────────────────────────────
+
+test("analytics/certs: unauthorized → 401", async () => {
+    const r = await certsGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/analytics/certs`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("analytics/certs: valid → 200 with cert stats", async () => {
+    const r = await certsGet({
+        env: { DB: analyticsDB(), ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/analytics/certs?range=90d`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.ok("issued_this_period" in j.headlines);
+    assert.ok("pending_now" in j.headlines);
+    assert.ok(Array.isArray(j.series));
+});
+
+// ── system ──────────────────────────────────────────────────────────────
+
+test("analytics/system: unauthorized → 401", async () => {
+    const r = await systemGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/analytics/system`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("analytics/system: valid → 200 with email throughput", async () => {
+    const r = await systemGet({
+        env: { DB: analyticsDB(), ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/analytics/system?range=all`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.ok("emails_sent" in j.headlines);
+    assert.ok("appeals_open" in j.headlines);
+    assert.ok(Array.isArray(j.series));
+});

--- a/pages/functions/api/admin/analytics/analytics.test.mjs
+++ b/pages/functions/api/admin/analytics/analytics.test.mjs
@@ -8,6 +8,15 @@ import { onRequestGet as systemGet } from "./system.js";
 
 const BASE = "https://sc-cpe-web.pages.dev";
 
+function mkKV(initial = {}) {
+    const store = new Map(Object.entries(initial));
+    return {
+        get: async (k) => store.get(k) ?? null,
+        put: async (k, v, opts) => { store.set(k, v); },
+        delete: async (k) => { store.delete(k); },
+    };
+}
+
 function auth(url) {
     return new Request(url, {
         headers: { Authorization: "Bearer adm" },
@@ -69,7 +78,7 @@ test("analytics/growth: valid → 200 with headlines and series", async () => {
         "COUNT.*FROM users": () => ({ n: 3 }),
     });
     const r = await growthGet({
-        env: { DB: db, ADMIN_TOKEN: "adm" },
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
         request: auth(`${BASE}/api/admin/analytics/growth?range=30d`),
     });
     assert.equal(r.status, 200);
@@ -94,7 +103,7 @@ test("analytics/engagement: unauthorized → 401", async () => {
 
 test("analytics/engagement: valid → 200 with attendance data", async () => {
     const r = await engagementGet({
-        env: { DB: analyticsDB(), ADMIN_TOKEN: "adm" },
+        env: { DB: analyticsDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
         request: auth(`${BASE}/api/admin/analytics/engagement?range=7d`),
     });
     assert.equal(r.status, 200);
@@ -117,7 +126,7 @@ test("analytics/certs: unauthorized → 401", async () => {
 
 test("analytics/certs: valid → 200 with cert stats", async () => {
     const r = await certsGet({
-        env: { DB: analyticsDB(), ADMIN_TOKEN: "adm" },
+        env: { DB: analyticsDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
         request: auth(`${BASE}/api/admin/analytics/certs?range=90d`),
     });
     assert.equal(r.status, 200);
@@ -140,7 +149,7 @@ test("analytics/system: unauthorized → 401", async () => {
 
 test("analytics/system: valid → 200 with email throughput", async () => {
     const r = await systemGet({
-        env: { DB: analyticsDB(), ADMIN_TOKEN: "adm" },
+        env: { DB: analyticsDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
         request: auth(`${BASE}/api/admin/analytics/system?range=all`),
     });
     assert.equal(r.status, 200);

--- a/pages/functions/api/admin/appeals.test.mjs
+++ b/pages/functions/api/admin/appeals.test.mjs
@@ -1,0 +1,183 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestGet as appealsGet } from "./appeals.js";
+import { onRequestPost as resolvePost } from "./appeals/[id]/resolve.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function auth(url, opts = {}) {
+    return new Request(url, {
+        ...opts,
+        headers: { Authorization: "Bearer adm", ...(opts.headers || {}) },
+    });
+}
+
+function postAuth(url, body) {
+    return auth(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+function stubDB(overrides = {}) {
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([pattern]) =>
+                new RegExp(pattern, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => ({ meta: {} }),
+            };
+            return stmt;
+        },
+    };
+}
+
+function auditDB(overrides = {}) {
+    return stubDB({
+        ...overrides,
+        "INSERT INTO audit_log": () => null,
+        "SELECT id, ts, prev_hash FROM audit_log ORDER BY ts DESC": () => ({
+            id: "01X", ts: "2026-04-22T00:00:00Z", prev_hash: "abc",
+        }),
+    });
+}
+
+function mkKV() {
+    const store = new Map();
+    return {
+        get: async (k) => store.get(k) ?? null,
+        put: async (k, v) => { store.set(k, v); },
+        delete: async (k) => { store.delete(k); },
+    };
+}
+
+// ── GET appeals ────────────────────────────────────────────────────────
+
+test("appeals GET: unauthorized → 401", async () => {
+    const r = await appealsGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/appeals`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("appeals GET: valid → 200 with appeals array", async () => {
+    const db = stubDB({
+        "FROM appeals": () => [
+            { id: "01A", user_id: "01U", claimed_date: "2026-04-20", state: "open",
+              email: "a@b.com", legal_name: "Test" },
+        ],
+    });
+    const r = await appealsGet({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/appeals?state=open`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.ok(Array.isArray(j.appeals));
+    assert.equal(j.appeals.length, 1);
+});
+
+test("appeals GET: invalid state → 400", async () => {
+    const r = await appealsGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/appeals?state=bogus`),
+    });
+    assert.equal(r.status, 400);
+});
+
+// ── POST resolve ───────────────────────────────────────────────────────
+
+test("appeals resolve: unauthorized → 401", async () => {
+    const r = await resolvePost({
+        params: { id: "01APPEALID12345" },
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/appeals/01APPEALID12345/resolve`, { method: "POST" }),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("appeals resolve: appeal not found → 404", async () => {
+    const db = auditDB({ "FROM appeals WHERE id": () => null });
+    const r = await resolvePost({
+        params: { id: "01NOTEXIST12345" },
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/appeals/01NOTEXIST12345/resolve`, {
+            decision: "deny", resolver: "admin1", notes: "no evidence",
+        }),
+    });
+    assert.equal(r.status, 404);
+});
+
+test("appeals resolve: already resolved → 409", async () => {
+    const db = auditDB({
+        "FROM appeals WHERE id": () => ({
+            id: "01A", user_id: "01U", claimed_stream_id: "01S", state: "granted",
+        }),
+    });
+    const r = await resolvePost({
+        params: { id: "01A0000000000000" },
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/appeals/01A0000000000000/resolve`, {
+            decision: "deny", resolver: "admin1",
+        }),
+    });
+    assert.equal(r.status, 409);
+});
+
+test("appeals resolve deny: valid → 200", async () => {
+    const db = auditDB({
+        "FROM appeals WHERE id": () => ({
+            id: "01A", user_id: "01U", claimed_stream_id: "01S", state: "open",
+        }),
+        "UPDATE appeals": () => null,
+        "FROM users WHERE id": () => ({
+            email: "test@invalid", legal_name: "Test", dashboard_token: "tok",
+        }),
+        "INSERT INTO email_outbox": () => null,
+    });
+    const r = await resolvePost({
+        params: { id: "01A0000000000000" },
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/appeals/01A0000000000000/resolve`, {
+            decision: "deny", resolver: "admin1", notes: "insufficient evidence",
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.state, "denied");
+    assert.equal(j.attendance_inserted, false);
+});
+
+test("appeals resolve grant: valid → 200 with attendance", async () => {
+    const db = auditDB({
+        "FROM appeals WHERE id": () => ({
+            id: "01A", user_id: "01U", claimed_stream_id: "01S", state: "open",
+        }),
+        "FROM attendance WHERE user_id": () => null,
+        "INSERT INTO attendance": () => null,
+        "UPDATE appeals": () => null,
+        "rule_version": () => ({ v: "0.5" }),
+    });
+    const r = await resolvePost({
+        params: { id: "01A0000000000000" },
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/appeals/01A0000000000000/resolve`, {
+            decision: "grant", resolver: "admin1", rule_version: 1,
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.state, "granted");
+    assert.equal(j.attendance_inserted, true);
+});

--- a/pages/functions/api/admin/audit-chain.test.mjs
+++ b/pages/functions/api/admin/audit-chain.test.mjs
@@ -1,0 +1,115 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestGet } from "./audit-chain-verify.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function auth(url) {
+    return new Request(url, {
+        headers: { Authorization: "Bearer adm" },
+    });
+}
+
+function stubDB(overrides = {}) {
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([pattern]) =>
+                new RegExp(pattern, "is").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => ({ meta: {} }),
+            };
+            return stmt;
+        },
+    };
+}
+
+test("audit-chain-verify: unauthorized → 401", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/audit-chain-verify`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("audit-chain-verify: empty table → ok with 0 rows", async () => {
+    const db = stubDB({
+        "sqlite_master.*LIKE": () => ({ name: "audit_prev_hash_unique" }),
+        "sqlite_master.*type = 'index'": () => [
+            { name: "audit_prev_hash_unique", sql: "CREATE UNIQUE INDEX audit_prev_hash_unique ON audit_log(prev_hash)" },
+        ],
+        "FROM audit_log.*ORDER": () => [],
+        "COUNT.*FROM audit_log": () => ({ n: 0 }),
+    });
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/audit-chain-verify`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.rows_checked, 0);
+    assert.equal(j.first_break, null);
+});
+
+test("audit-chain-verify: missing unique index → unique_index false", async () => {
+    const db = stubDB({
+        "sqlite_master.*LIKE": () => null,
+        "sqlite_master.*type = 'index'": () => [],
+        "FROM audit_log.*ORDER": () => [],
+        "COUNT.*FROM audit_log": () => ({ n: 0 }),
+    });
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/audit-chain-verify`),
+    });
+    const j = await r.json();
+    assert.equal(j.unique_index_on_prev_hash, false);
+    assert.ok(j.index_warning);
+});
+
+test("audit-chain-verify: valid chain with unique index → ok true", async () => {
+    const db = stubDB({
+        "sqlite_master.*LIKE": () => ({ name: "audit_prev_hash_unique" }),
+        "sqlite_master.*type = 'index'": () => [
+            { name: "audit_prev_hash_unique", sql: "CREATE UNIQUE INDEX audit_prev_hash_unique ON audit_log(prev_hash)" },
+        ],
+        "FROM audit_log.*ORDER": () => [
+            { id: "01A", actor_type: "system", actor_id: null, action: "genesis", entity_type: "system", entity_id: "init", before_json: null, after_json: null, ip_hash: null, user_agent: null, ts: "2026-01-01T00:00:00Z", prev_hash: null },
+        ],
+        "COUNT.*FROM audit_log": () => ({ n: 1 }),
+    });
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/audit-chain-verify?limit=50`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.rows_checked, 1);
+    assert.equal(j.first_break, null);
+    assert.equal(j.unique_index_on_prev_hash, true);
+});
+
+test("audit-chain-verify: limit param clamped", async () => {
+    const db = stubDB({
+        "sqlite_master.*LIKE": () => ({ name: "audit_prev_hash_unique" }),
+        "sqlite_master.*type = 'index'": () => [
+            { name: "audit_prev_hash_unique", sql: "CREATE UNIQUE INDEX audit_prev_hash_unique ON audit_log(prev_hash)" },
+        ],
+        "FROM audit_log.*ORDER": (sql, binds) => {
+            assert.ok(binds[0] <= 50000);
+            return [];
+        },
+        "COUNT.*FROM audit_log": () => ({ n: 0 }),
+    });
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/audit-chain-verify?limit=999999`),
+    });
+    assert.equal(r.status, 200);
+});

--- a/pages/functions/api/admin/cert-reissue.test.mjs
+++ b/pages/functions/api/admin/cert-reissue.test.mjs
@@ -1,0 +1,158 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestPost } from "./cert/[id]/reissue.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function auth(url, opts = {}) {
+    return new Request(url, {
+        ...opts,
+        headers: { Authorization: "Bearer adm", ...(opts.headers || {}) },
+    });
+}
+
+function postAuth(url, body) {
+    return auth(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+function stubDB(overrides = {}) {
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([pattern]) =>
+                new RegExp(pattern, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => ({ meta: {} }),
+            };
+            return stmt;
+        },
+    };
+}
+
+function auditDB(overrides = {}) {
+    return stubDB({
+        ...overrides,
+        "INSERT INTO audit_log": () => null,
+        "SELECT id, ts, prev_hash FROM audit_log ORDER BY ts DESC": () => ({
+            id: "01X", ts: "2026-04-22T00:00:00Z", prev_hash: "abc",
+        }),
+    });
+}
+
+test("cert reissue: unauthorized → 401", async () => {
+    const r = await onRequestPost({
+        params: { id: "01CERTID0000000" },
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/cert/01CERTID0000000/reissue`, { method: "POST" }),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("cert reissue: cert not found → 404", async () => {
+    const db = auditDB({ "FROM certs WHERE id": () => null });
+    const r = await onRequestPost({
+        params: { id: "01NOTEXIST12345" },
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/cert/01NOTEXIST12345/reissue`, {
+            reason: "Name correction",
+        }),
+    });
+    assert.equal(r.status, 404);
+});
+
+test("cert reissue: missing reason → 400", async () => {
+    const db = auditDB({
+        "FROM certs WHERE id": () => ({
+            id: "01C", user_id: "01U", state: "delivered",
+            period_yyyymm: "202604", cert_kind: "bundled",
+        }),
+    });
+    const r = await onRequestPost({
+        params: { id: "01C0000000000000" },
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/cert/01C0000000000000/reissue`, {}),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "reason_required_under_500_chars");
+});
+
+test("cert reissue: revoked cert → 409", async () => {
+    const db = auditDB({
+        "FROM certs WHERE id": () => ({
+            id: "01C", user_id: "01U", state: "revoked",
+            period_yyyymm: "202604", cert_kind: "bundled",
+        }),
+    });
+    const r = await onRequestPost({
+        params: { id: "01C0000000000000" },
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/cert/01C0000000000000/reissue`, {
+            reason: "Name correction",
+        }),
+    });
+    assert.equal(r.status, 409);
+    const j = await r.json();
+    assert.equal(j.error, "cannot_reissue_revoked");
+});
+
+test("cert reissue: already pending reissue → 200 with reissued false", async () => {
+    const db = auditDB({
+        "FROM certs WHERE id": () => ({
+            id: "01C", user_id: "01U", state: "delivered",
+            period_yyyymm: "202604", cert_kind: "bundled",
+        }),
+        "supersedes_cert_id.*pending": () => ({
+            id: "01PENDING", state: "pending",
+        }),
+    });
+    const r = await onRequestPost({
+        params: { id: "01C0000000000000" },
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/cert/01C0000000000000/reissue`, {
+            reason: "Name correction",
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.reissued, false);
+    assert.equal(j.pending_cert_id, "01PENDING");
+});
+
+test("cert reissue: valid → 200 with new pending cert", async () => {
+    const db = auditDB({
+        "FROM certs WHERE id": () => ({
+            id: "01C", user_id: "01U", state: "delivered",
+            period_yyyymm: "202604", period_start: "2026-04-01",
+            period_end: "2026-04-30", cert_kind: "bundled",
+            stream_id: null, cpe_total: 5.0, sessions_count: 10,
+            session_video_ids: "vid1,vid2",
+        }),
+        "supersedes_cert_id.*pending": () => null,
+        "UPDATE certs SET state": () => null,
+        "INSERT INTO certs": () => null,
+    });
+    const r = await onRequestPost({
+        params: { id: "01C0000000000000" },
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/cert/01C0000000000000/reissue`, {
+            reason: "Name correction",
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.reissued, true);
+    assert.ok(j.pending_cert_id);
+    assert.equal(j.supersedes_cert_id, "01C");
+});

--- a/pages/functions/api/admin/new-admin-features.test.mjs
+++ b/pages/functions/api/admin/new-admin-features.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import { onRequestPost as suspendPost } from "./suspend.js";
 import { onRequestGet as suppressionGet, onRequestDelete as suppressionDelete } from "./email-suppression.js";
+import { onRequestGet as streamsGet } from "./streams.js";
 
 const BASE = "https://sc-cpe-web.pages.dev";
 
@@ -211,4 +212,34 @@ test("email-suppression DELETE: valid → 200", async () => {
     assert.equal(r.status, 200);
     const j = await r.json();
     assert.equal(j.ok, true);
+});
+
+// ── streams ─────────────────────────────────────────────────────────────
+
+test("streams: unauthorized → 401", async () => {
+    const r = await streamsGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/streams`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("streams: valid → 200 with streams array", async () => {
+    const db = stubDB({
+        "FROM streams": () => [
+            { id: "01S", yt_video_id: "abc123", title: "Daily Threat Briefing",
+              scheduled_date: "2026-04-22", state: "ended",
+              actual_start_at: "2026-04-22T14:00:00Z", actual_end_at: "2026-04-22T15:00:00Z",
+              attendance_count: 42 },
+        ],
+    });
+    const r = await streamsGet({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: auth(`${BASE}/api/admin/streams?days=7`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.ok(Array.isArray(j.streams));
+    assert.equal(j.streams[0].attendance_count, 42);
 });

--- a/pages/functions/api/admin/new-admin-features.test.mjs
+++ b/pages/functions/api/admin/new-admin-features.test.mjs
@@ -80,7 +80,7 @@ test("suspend: unauthorized → 401", async () => {
 
 test("suspend: missing fields → 400", async () => {
     const r = await suspendPost({
-        env: { DB: auditDB(), ADMIN_TOKEN: "adm" },
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
         request: postAuth(`${BASE}/api/admin/suspend`, { user_id: "01U" }),
     });
     assert.equal(r.status, 400);
@@ -93,7 +93,7 @@ test("suspend: user not found → 404", async () => {
         "FROM users WHERE id": () => null,
     });
     const r = await suspendPost({
-        env: { DB: db, ADMIN_TOKEN: "adm" },
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
         request: postAuth(`${BASE}/api/admin/suspend`, {
             user_id: "01NOTEXIST12345",
             suspended: true,
@@ -111,7 +111,7 @@ test("suspend: valid suspend → 200", async () => {
         "UPDATE users SET suspended_at": () => null,
     });
     const r = await suspendPost({
-        env: { DB: db, ADMIN_TOKEN: "adm" },
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
         request: postAuth(`${BASE}/api/admin/suspend`, {
             user_id: "01USERID1234",
             suspended: true,
@@ -132,7 +132,7 @@ test("suspend: valid unsuspend → 200", async () => {
         "UPDATE users SET suspended_at": () => null,
     });
     const r = await suspendPost({
-        env: { DB: db, ADMIN_TOKEN: "adm" },
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
         request: postAuth(`${BASE}/api/admin/suspend`, {
             user_id: "01USERID1234",
             suspended: false,

--- a/pages/functions/api/admin/new-admin-features.test.mjs
+++ b/pages/functions/api/admin/new-admin-features.test.mjs
@@ -1,0 +1,214 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestPost as suspendPost } from "./suspend.js";
+import { onRequestGet as suppressionGet, onRequestDelete as suppressionDelete } from "./email-suppression.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function auth(url, opts = {}) {
+    return new Request(url, {
+        ...opts,
+        headers: { Authorization: "Bearer adm", ...(opts.headers || {}) },
+    });
+}
+
+function postAuth(url, body) {
+    return auth(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+function deleteAuth(url, body) {
+    return auth(url, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+function stubDB(overrides = {}) {
+    const noop = { meta: {} };
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([pattern]) =>
+                new RegExp(pattern, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => noop,
+            };
+            return stmt;
+        },
+    };
+}
+
+function auditDB(overrides = {}) {
+    return stubDB({
+        ...overrides,
+        "INSERT INTO audit_log": () => null,
+        "SELECT id, ts, prev_hash FROM audit_log ORDER BY ts DESC": () => ({
+            id: "01X", ts: "2026-04-22T00:00:00Z", prev_hash: "abc",
+        }),
+    });
+}
+
+function mkKV(initial = {}) {
+    const store = new Map(Object.entries(initial));
+    return {
+        get: async (k) => store.get(k) ?? null,
+        put: async (k, v) => { store.set(k, v); },
+        delete: async (k) => { store.delete(k); },
+    };
+}
+
+// ── suspend ─────────────────────────────────────────────────────────────
+
+test("suspend: unauthorized → 401", async () => {
+    const r = await suspendPost({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/suspend`, { method: "POST" }),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("suspend: missing fields → 400", async () => {
+    const r = await suspendPost({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/suspend`, { user_id: "01U" }),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "reason_required_under_500_chars");
+});
+
+test("suspend: user not found → 404", async () => {
+    const db = auditDB({
+        "FROM users WHERE id": () => null,
+    });
+    const r = await suspendPost({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/suspend`, {
+            user_id: "01NOTEXIST12345",
+            suspended: true,
+            reason: "Policy violation",
+        }),
+    });
+    assert.equal(r.status, 404);
+});
+
+test("suspend: valid suspend → 200", async () => {
+    const db = auditDB({
+        "FROM users WHERE id": () => ({
+            id: "01USERID1234", state: "active", suspended_at: null,
+        }),
+        "UPDATE users SET suspended_at": () => null,
+    });
+    const r = await suspendPost({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/suspend`, {
+            user_id: "01USERID1234",
+            suspended: true,
+            reason: "Policy violation",
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.ok(j.suspended_at);
+});
+
+test("suspend: valid unsuspend → 200", async () => {
+    const db = auditDB({
+        "FROM users WHERE id": () => ({
+            id: "01USERID1234", state: "active", suspended_at: "2026-04-22T00:00:00Z",
+        }),
+        "UPDATE users SET suspended_at": () => null,
+    });
+    const r = await suspendPost({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/suspend`, {
+            user_id: "01USERID1234",
+            suspended: false,
+            reason: "Appeal granted",
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.suspended_at, null);
+});
+
+// ── email-suppression GET ───────────────────────────────────────────────
+
+test("email-suppression GET: unauthorized → 401", async () => {
+    const r = await suppressionGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/email-suppression`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("email-suppression GET: valid → 200 with suppressions", async () => {
+    const db = stubDB({
+        "FROM email_suppression": () => [
+            { email: "test@example.com", reason: "hard_bounce", event_id: "evt_1", created_at: "2026-04-22T00:00:00Z" },
+        ],
+    });
+    const r = await suppressionGet({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: auth(`${BASE}/api/admin/email-suppression`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.ok(Array.isArray(j.suppressions));
+    assert.equal(j.suppressions.length, 1);
+    assert.ok(j.suppressions[0].email_masked.includes("***"));
+});
+
+// ── email-suppression DELETE ────────────────────────────────────────────
+
+test("email-suppression DELETE: unauthorized → 401", async () => {
+    const r = await suppressionDelete({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/email-suppression`, { method: "DELETE" }),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("email-suppression DELETE: not found → 404", async () => {
+    const db = auditDB({
+        "FROM email_suppression WHERE email": () => null,
+    });
+    const r = await suppressionDelete({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: deleteAuth(`${BASE}/api/admin/email-suppression`, {
+            email: "nobody@example.com",
+        }),
+    });
+    assert.equal(r.status, 404);
+    const j = await r.json();
+    assert.equal(j.error, "not_found");
+});
+
+test("email-suppression DELETE: valid → 200", async () => {
+    const db = auditDB({
+        "FROM email_suppression WHERE email": () => ({ email: "test@example.com" }),
+        "DELETE FROM email_suppression": () => null,
+    });
+    const r = await suppressionDelete({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: deleteAuth(`${BASE}/api/admin/email-suppression`, {
+            email: "test@example.com",
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+});

--- a/pages/functions/api/admin/revoke.test.mjs
+++ b/pages/functions/api/admin/revoke.test.mjs
@@ -1,0 +1,138 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestPost } from "./revoke.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function auth(url, opts = {}) {
+    return new Request(url, {
+        ...opts,
+        headers: { Authorization: "Bearer adm", ...(opts.headers || {}) },
+    });
+}
+
+function postAuth(url, body) {
+    return auth(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+function stubDB(overrides = {}) {
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([pattern]) =>
+                new RegExp(pattern, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => ({ meta: {} }),
+            };
+            return stmt;
+        },
+    };
+}
+
+function auditDB(overrides = {}) {
+    return stubDB({
+        ...overrides,
+        "INSERT INTO audit_log": () => null,
+        "SELECT id, ts, prev_hash FROM audit_log ORDER BY ts DESC": () => ({
+            id: "01X", ts: "2026-04-22T00:00:00Z", prev_hash: "abc",
+        }),
+    });
+}
+
+test("revoke: unauthorized → 401", async () => {
+    const r = await onRequestPost({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/revoke`, { method: "POST" }),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("revoke: missing/short token → 400", async () => {
+    const r = await onRequestPost({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/revoke`, {
+            public_token: "short", reason: "test",
+        }),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "invalid_public_token");
+});
+
+test("revoke: missing reason → 400", async () => {
+    const token = "a".repeat(64);
+    const r = await onRequestPost({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/revoke`, {
+            public_token: token,
+        }),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "reason_required_under_500_chars");
+});
+
+test("revoke: cert not found → 404", async () => {
+    const token = "a".repeat(64);
+    const db = auditDB({ "FROM certs WHERE public_token": () => null });
+    const r = await onRequestPost({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/revoke`, {
+            public_token: token, reason: "Policy violation",
+        }),
+    });
+    assert.equal(r.status, 404);
+});
+
+test("revoke: already revoked → 200 with already_revoked", async () => {
+    const token = "a".repeat(64);
+    const db = auditDB({
+        "FROM certs WHERE public_token": () => ({
+            id: "01C", state: "revoked", revoked_at: "2026-04-20T00:00:00Z",
+            revocation_reason: "prior", user_id: "01U", period_yyyymm: "202604",
+        }),
+    });
+    const r = await onRequestPost({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/revoke`, {
+            public_token: token, reason: "Duplicate revoke",
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.already_revoked, true);
+    assert.ok(j.revoked_at);
+});
+
+test("revoke: valid → 200 with cert_id and revoked_at", async () => {
+    const token = "a".repeat(64);
+    const db = auditDB({
+        "FROM certs WHERE public_token": () => ({
+            id: "01CERT123", state: "delivered", revoked_at: null,
+            revocation_reason: null, user_id: "01U", period_yyyymm: "202604",
+        }),
+        "UPDATE certs": () => null,
+    });
+    const r = await onRequestPost({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: postAuth(`${BASE}/api/admin/revoke`, {
+            public_token: token, reason: "Fraud detected",
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.cert_id, "01CERT123");
+    assert.ok(j.revoked_at);
+    assert.equal(j.revocation_reason, "Fraud detected");
+});

--- a/pages/functions/api/admin/streams.js
+++ b/pages/functions/api/admin/streams.js
@@ -1,0 +1,24 @@
+import { json, isAdmin, rateLimit, clientIp, ipHash } from "../../_lib.js";
+
+export async function onRequestGet({ request, env }) {
+    if (!(await isAdmin(env, request))) return json({ error: "unauthorized" }, 401);
+
+    const ipH = await ipHash(clientIp(request));
+    const rl = await rateLimit(env, `admin_streams:${ipH}`, 60);
+    if (!rl.ok) return json(rl.body, rl.status, rl.headers);
+
+    const url = new URL(request.url);
+    const daysParam = parseInt(url.searchParams.get("days"), 10);
+    const days = (daysParam > 0 && daysParam <= 365) ? daysParam : 30;
+
+    const rows = await env.DB.prepare(
+        `SELECT id, yt_video_id, title, scheduled_date, state, actual_start_at, actual_end_at,
+                (SELECT COUNT(*) FROM attendance a WHERE a.stream_id = s.id) AS attendance_count
+         FROM streams s
+         WHERE scheduled_date >= date('now', '-' || ?1 || ' days')
+         ORDER BY scheduled_date DESC
+         LIMIT 100`
+    ).bind(days).all();
+
+    return json({ ok: true, streams: rows.results || [] });
+}

--- a/pages/functions/api/admin/suspend.js
+++ b/pages/functions/api/admin/suspend.js
@@ -1,7 +1,10 @@
-import { json, isAdmin, audit, clientIp, ipHash, now } from "../../_lib.js";
+import { json, isAdmin, audit, clientIp, ipHash, now, rateLimit } from "../../_lib.js";
 
 export async function onRequestPost({ request, env }) {
     if (!(await isAdmin(env, request))) return json({ error: "unauthorized" }, 401);
+
+    const rl = await rateLimit(env, `admin_suspend:${await ipHash(clientIp(request))}`, 30);
+    if (!rl.ok) return json(rl.body, rl.status, rl.headers);
 
     let body;
     try { body = await request.json(); }

--- a/pages/functions/api/me/user-features.test.mjs
+++ b/pages/functions/api/me/user-features.test.mjs
@@ -1,0 +1,172 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestPost as certResendPost } from "./[token]/cert-resend/[cert_id].js";
+import { onRequestGet as unsubGet, onRequestPost as unsubPost } from "./[token]/unsubscribe.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+const VALID_TOKEN = "a".repeat(64);
+
+function stubDB(overrides = {}) {
+    const noop = { meta: {} };
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([pattern]) =>
+                new RegExp(pattern, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => noop,
+            };
+            return stmt;
+        },
+    };
+}
+
+function mkKV(initial = {}) {
+    const store = new Map(Object.entries(initial));
+    return {
+        get: async (k) => store.get(k) ?? null,
+        put: async (k, v) => { store.set(k, v); },
+        delete: async (k) => { store.delete(k); },
+    };
+}
+
+// ── cert-resend ─────────────────────────────────────────────────────────
+
+test("cert-resend: missing origin → 403", async () => {
+    const r = await certResendPost({
+        params: { token: VALID_TOKEN, cert_id: "01CERTID1234" },
+        env: { DB: stubDB(), SITE_ORIGIN: BASE },
+        request: new Request(`${BASE}/api/me/${VALID_TOKEN}/cert-resend/01CERTID1234`, {
+            method: "POST",
+        }),
+    });
+    assert.equal(r.status, 403);
+});
+
+test("cert-resend: cert not found → 404", async () => {
+    const db = stubDB({
+        "FROM users WHERE dashboard_token": () => ({ id: "01U" }),
+        "FROM certs WHERE id": () => null,
+    });
+    const r = await certResendPost({
+        params: { token: VALID_TOKEN, cert_id: "01CERTID1234" },
+        env: { DB: db, RATE_KV: mkKV(), SITE_ORIGIN: BASE },
+        request: new Request(`${BASE}/api/me/${VALID_TOKEN}/cert-resend/01CERTID1234`, {
+            method: "POST",
+            headers: { Origin: BASE },
+        }),
+    });
+    assert.equal(r.status, 404);
+});
+
+test("cert-resend: not eligible (pending cert) → 400", async () => {
+    const db = stubDB({
+        "FROM users WHERE dashboard_token": () => ({ id: "01U" }),
+        "FROM certs WHERE id": () => ({ id: "01C", public_token: "x".repeat(64), user_id: "01U", state: "pending" }),
+    });
+    const r = await certResendPost({
+        params: { token: VALID_TOKEN, cert_id: "01C" },
+        env: { DB: db, RATE_KV: mkKV(), SITE_ORIGIN: BASE },
+        request: new Request(`${BASE}/api/me/${VALID_TOKEN}/cert-resend/01C`, {
+            method: "POST",
+            headers: { Origin: BASE },
+        }),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "not_eligible");
+});
+
+test("cert-resend: valid → 200", async () => {
+    const db = stubDB({
+        "FROM users WHERE dashboard_token": () => ({ id: "01U" }),
+        "FROM certs WHERE id": () => ({ id: "01C", public_token: "x".repeat(64), user_id: "01U", state: "delivered" }),
+        "FROM email_outbox WHERE idempotency_key": () => ({ state: "bounced" }),
+        "SELECT email, legal_name, dashboard_token FROM users": () => ({
+            email: "test@example.com", legal_name: "Test", dashboard_token: VALID_TOKEN,
+        }),
+        "INSERT INTO email_outbox": () => null,
+    });
+    const r = await certResendPost({
+        params: { token: VALID_TOKEN, cert_id: "01C" },
+        env: { DB: db, RATE_KV: mkKV(), SITE_ORIGIN: BASE },
+        request: new Request(`${BASE}/api/me/${VALID_TOKEN}/cert-resend/01C`, {
+            method: "POST",
+            headers: { Origin: BASE },
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.message, "Cert email re-queued");
+});
+
+// ── unsubscribe GET ─────────────────────────────────────────────────────
+
+test("unsubscribe GET: returns HTML page", async () => {
+    const db = stubDB({
+        "FROM users WHERE dashboard_token": () => ({ id: "01U" }),
+    });
+    const r = await unsubGet({
+        params: { token: VALID_TOKEN },
+        env: { DB: db },
+        request: new Request(`${BASE}/api/me/${VALID_TOKEN}/unsubscribe?cat=monthly_digest`),
+    });
+    assert.equal(r.status, 200);
+    const ct = r.headers.get("Content-Type");
+    assert.ok(ct.includes("text/html"));
+    const body = await r.text();
+    assert.ok(body.includes("Monthly Digest"));
+    assert.ok(body.includes("Unsubscribe"));
+});
+
+test("unsubscribe GET: invalid category → 400", async () => {
+    const r = await unsubGet({
+        params: { token: VALID_TOKEN },
+        env: { DB: stubDB() },
+        request: new Request(`${BASE}/api/me/${VALID_TOKEN}/unsubscribe?cat=bogus`),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "invalid_category");
+});
+
+// ── unsubscribe POST ────────────────────────────────────────────────────
+
+test("unsubscribe POST: toggles category", async () => {
+    const db = stubDB({
+        "FROM users WHERE dashboard_token": () => ({
+            id: "01U", email_prefs: JSON.stringify({ unsubscribed: [] }),
+        }),
+        "UPDATE users SET email_prefs": () => null,
+    });
+    const r = await unsubPost({
+        params: { token: VALID_TOKEN },
+        env: { DB: db },
+        request: new Request(`${BASE}/api/me/${VALID_TOKEN}/unsubscribe?cat=cert_nudge`, {
+            method: "POST",
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.unsubscribed, "cert_nudge");
+});
+
+test("unsubscribe POST: invalid category → 400", async () => {
+    const r = await unsubPost({
+        params: { token: VALID_TOKEN },
+        env: { DB: stubDB() },
+        request: new Request(`${BASE}/api/me/${VALID_TOKEN}/unsubscribe?cat=invalid`, {
+            method: "POST",
+        }),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "invalid_category");
+});

--- a/scripts/smoke_hardening.sh
+++ b/scripts/smoke_hardening.sh
@@ -132,6 +132,24 @@ else
     echo "  ok   no test fixtures in prod: $pollution"; pass=$((pass+1))
 fi
 
+echo "== admin/streams endpoint =="
+STREAMS_URL="$ORIGIN/api/admin/streams"
+check "streams no auth → 401" 401 "$(code "$STREAMS_URL")"
+check "streams valid bearer → 200" 200 "$(code -H "Authorization: Bearer $ADMIN_TOKEN" "$STREAMS_URL")"
+
+echo "== admin/analytics endpoints =="
+for metric in growth engagement certs system; do
+    A_URL="$ORIGIN/api/admin/analytics/$metric"
+    check "analytics/$metric no auth → 401" 401 "$(code "$A_URL")"
+    check "analytics/$metric valid bearer → 200" 200 "$(code -H "Authorization: Bearer $ADMIN_TOKEN" "$A_URL")"
+done
+
+echo "== admin/suspend endpoint =="
+check "suspend no auth → 401" 401 "$(code -X POST -H 'Content-Type: application/json' -d '{}' "$ORIGIN/api/admin/suspend")"
+
+echo "== admin/email-suppression endpoint =="
+check "email-suppression no auth → 401" 401 "$(code "$ORIGIN/api/admin/email-suppression")"
+
 echo
 echo "== summary: $pass passed, $fail failed =="
 [[ $fail -eq 0 ]]

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,4 +26,7 @@ node --test \
     pages/functions/api/ob/credential.test.mjs \
     scripts/test_audit_pii_scrub.mjs \
     pages/functions/api/email-webhook.test.mjs \
-    scripts/test_e2e.mjs
+    scripts/test_e2e.mjs \
+    pages/functions/api/admin/analytics/analytics.test.mjs \
+    pages/functions/api/admin/new-admin-features.test.mjs \
+    pages/functions/api/me/user-features.test.mjs

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -29,4 +29,8 @@ node --test \
     scripts/test_e2e.mjs \
     pages/functions/api/admin/analytics/analytics.test.mjs \
     pages/functions/api/admin/new-admin-features.test.mjs \
-    pages/functions/api/me/user-features.test.mjs
+    pages/functions/api/me/user-features.test.mjs \
+    pages/functions/api/admin/audit-chain.test.mjs \
+    pages/functions/api/admin/appeals.test.mjs \
+    pages/functions/api/admin/revoke.test.mjs \
+    pages/functions/api/admin/cert-reissue.test.mjs


### PR DESCRIPTION
## Summary

- **Test coverage expansion** — 22 new handler-level mock tests covering analytics (growth/engagement/certs/system), suspend/unsuspend, email suppression GET/DELETE, streams, cert-resend, and unsubscribe endpoints
- **Admin analytics dashboard** — wires existing 4 analytics endpoints into admin.html with date range selector (7d/30d/90d/all), stat cards, and time-series tables
- **Admin streams view** — new `GET /api/admin/streams` endpoint with attendance counts; admin UI table with YouTube links and day range selector
- **Dashboard email preferences** — checkboxes for monthly digest, cert nudge, renewal reminder, and streak milestones in dashboard Settings
- **Admin user detail expansion** — Details toggle on user search rows reveals full metadata grid (timestamps, YT info, suspension state)
- **Admin cron trigger buttons** — Manual Triggers section with one-click buttons for each purge worker block (purge, security_alerts, weekly_digest, cert_nudge, link_enrichment, all)
- **Documentation** — `docs/DEV_SETUP.md` (dev environment, tests, preview env, common issues) and `docs/ADMIN_ONBOARDING.md` (auth, dashboard walkthrough, common tasks, emergency procedures)

## Test plan

- [x] `bash scripts/test.sh` passes (318 tests, 0 failures)
- [ ] Deploy to preview and verify analytics section loads data
- [ ] Verify streams table renders with YouTube links
- [ ] Verify email preferences checkboxes toggle correctly on dashboard
- [ ] Verify user detail panel expands/collapses in admin search
- [ ] Verify cron trigger buttons POST to purge worker
- [ ] Review docs for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)