### PR TITLE
test: security function + email-sender worker coverage

### DIFF
--- a/pages/functions/_lib-security.test.mjs
+++ b/pages/functions/_lib-security.test.mjs
@@ -1,0 +1,223 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isAdmin, audit, rateLimit, constantTimeEqual, canonicalAuditRow, sha256Hex } from "./_lib.js";
+
+function mkKV() {
+    const store = new Map();
+    return {
+        get: async (k) => store.get(k) ?? null,
+        put: async (k, v, opts) => { store.set(k, v); },
+        delete: async (k) => { store.delete(k); },
+    };
+}
+
+function stubDB(overrides = {}) {
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([pattern]) =>
+                new RegExp(pattern, "is").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => ({ meta: {} }),
+            };
+            return stmt;
+        },
+    };
+}
+
+// ── isAdmin ───────────────────────────────────────────────────────────
+
+test("isAdmin: missing Authorization header → false", async () => {
+    const r = await isAdmin(
+        { ADMIN_TOKEN: "secret123" },
+        new Request("https://x.dev/api/admin/test"),
+    );
+    assert.equal(r, false);
+});
+
+test("isAdmin: wrong bearer token → false", async () => {
+    const r = await isAdmin(
+        { ADMIN_TOKEN: "correct_token" },
+        new Request("https://x.dev/api/admin/test", {
+            headers: { Authorization: "Bearer wrong_token" },
+        }),
+    );
+    assert.equal(r, false);
+});
+
+test("isAdmin: correct bearer token → true", async () => {
+    const r = await isAdmin(
+        { ADMIN_TOKEN: "correct_token" },
+        new Request("https://x.dev/api/admin/test", {
+            headers: { Authorization: "Bearer correct_token" },
+        }),
+    );
+    assert.equal(r, true);
+});
+
+test("isAdmin: case-insensitive 'bearer' prefix → true", async () => {
+    const r = await isAdmin(
+        { ADMIN_TOKEN: "tok" },
+        new Request("https://x.dev/api/admin/test", {
+            headers: { Authorization: "bearer tok" },
+        }),
+    );
+    assert.equal(r, true);
+});
+
+test("isAdmin: empty ADMIN_TOKEN env → false (never matches)", async () => {
+    const r = await isAdmin(
+        { ADMIN_TOKEN: "" },
+        new Request("https://x.dev/api/admin/test", {
+            headers: { Authorization: "Bearer " },
+        }),
+    );
+    assert.equal(r, false);
+});
+
+// ── constantTimeEqual ─────────────────────────────────────────────────
+
+test("constantTimeEqual: equal strings → true", async () => {
+    assert.equal(await constantTimeEqual("hello", "hello"), true);
+});
+
+test("constantTimeEqual: different strings → false", async () => {
+    assert.equal(await constantTimeEqual("hello", "world"), false);
+});
+
+test("constantTimeEqual: different lengths → false", async () => {
+    assert.equal(await constantTimeEqual("short", "longer_string"), false);
+});
+
+// ── rateLimit ─────────────────────────────────────────────────────────
+
+test("rateLimit: first call within window → ok: true", async () => {
+    const env = { RATE_KV: mkKV() };
+    const result = await rateLimit(env, "test_key", 10, 60);
+    assert.equal(result.ok, true);
+    assert.ok(result.headers);
+    assert.equal(result.headers["X-RateLimit-Limit"], "10");
+});
+
+test("rateLimit: exceeds max → ok: false with 429", async () => {
+    const kv = mkKV();
+    const env = { RATE_KV: kv };
+    await kv.put("test_key", "10");
+    const result = await rateLimit(env, "test_key", 10, 60);
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 429);
+    assert.equal(result.body.error, "rate_limited");
+    assert.equal(result.headers["Retry-After"], "60");
+});
+
+test("rateLimit: missing RATE_KV → ok: false with 503 (fail-closed)", async () => {
+    const result = await rateLimit({}, "test_key", 10);
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 503);
+    assert.equal(result.body.error, "rate_limiter_unavailable");
+});
+
+test("rateLimit: different keys are independent", async () => {
+    const env = { RATE_KV: mkKV() };
+    await env.RATE_KV.put("key_a", "9");
+    const resultA = await rateLimit(env, "key_a", 10, 60);
+    assert.equal(resultA.ok, true);
+    const resultB = await rateLimit(env, "key_b", 10, 60);
+    assert.equal(resultB.ok, true);
+    assert.equal(resultB.headers["X-RateLimit-Remaining"], "9");
+});
+
+// ── audit ─────────────────────────────────────────────────────────────
+
+test("audit: genesis row (empty table) has prev_hash = null", async () => {
+    let insertedBinds = null;
+    const db = {
+        prepare(sql) {
+            const isSelect = /SELECT/.test(sql);
+            const stmt = {
+                bind(...args) { if (!isSelect) insertedBinds = args; return stmt; },
+                first: async () => null,
+                run: async () => ({ meta: {} }),
+            };
+            return stmt;
+        },
+    };
+    await audit({ DB: db }, "system", null, "genesis", "system", "init", null, null);
+    assert.ok(insertedBinds, "INSERT should have been called");
+    assert.equal(insertedBinds[11], null, "prev_hash should be null for genesis row");
+});
+
+test("audit: second row gets prev_hash = sha256(canonical(tip))", async () => {
+    const tipRow = {
+        id: "01GENESIS",
+        actor_type: "system", actor_id: null,
+        action: "genesis", entity_type: "system", entity_id: "init",
+        before_json: null, after_json: null,
+        ip_hash: null, user_agent: null,
+        ts: "2026-04-24T00:00:00Z", prev_hash: null,
+    };
+    const expectedHash = await sha256Hex(canonicalAuditRow(tipRow));
+
+    let insertedBinds = null;
+    const db = {
+        prepare(sql) {
+            const isSelect = /SELECT/.test(sql);
+            const stmt = {
+                bind(...args) { if (!isSelect) insertedBinds = args; return stmt; },
+                first: async () => isSelect ? tipRow : null,
+                run: async () => ({ meta: {} }),
+            };
+            return stmt;
+        },
+    };
+    await audit({ DB: db }, "admin", "a1", "test_action", "user", "u1", null, { x: 1 });
+    assert.ok(insertedBinds);
+    assert.equal(insertedBinds[11], expectedHash, "prev_hash should match sha256(canonical(tip))");
+});
+
+test("audit: ip_hash lands in ip_hash column (bind position 9)", async () => {
+    let insertedBinds = null;
+    const db = {
+        prepare(sql) {
+            const isSelect = /SELECT/.test(sql);
+            const stmt = {
+                bind(...args) { if (!isSelect) insertedBinds = args; return stmt; },
+                first: async () => null,
+                run: async () => ({ meta: {} }),
+            };
+            return stmt;
+        },
+    };
+    await audit({ DB: db }, "system", null, "test", "user", "u1", null, null, { ip_hash: "abc123" });
+    assert.ok(insertedBinds);
+    assert.equal(insertedBinds[8], "abc123", "ip_hash should be in bind position 9 (0-indexed 8)");
+});
+
+test("audit: retries on UNIQUE constraint violation", async () => {
+    let attempts = 0;
+    const db = {
+        prepare(sql) {
+            const isSelect = /SELECT/.test(sql);
+            const stmt = {
+                bind(...args) { return stmt; },
+                first: async () => null,
+                run: async () => {
+                    attempts++;
+                    if (attempts <= 2) {
+                        throw new Error("UNIQUE constraint failed: audit_log.prev_hash");
+                    }
+                    return { meta: {} };
+                },
+            };
+            return stmt;
+        },
+    };
+    const id = await audit({ DB: db }, "system", null, "test", "system", "init", null, null);
+    assert.ok(id, "should return an id after retry");
+    assert.equal(attempts, 3, "should have retried twice then succeeded on 3rd");
+});

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -33,4 +33,6 @@ node --test \
     pages/functions/api/admin/audit-chain.test.mjs \
     pages/functions/api/admin/appeals.test.mjs \
     pages/functions/api/admin/revoke.test.mjs \
-    pages/functions/api/admin/cert-reissue.test.mjs
+    pages/functions/api/admin/cert-reissue.test.mjs \
+    pages/functions/_lib-security.test.mjs \
+    workers/email-sender/src/email-sender.test.mjs

--- a/workers/email-sender/src/email-sender.test.mjs
+++ b/workers/email-sender/src/email-sender.test.mjs
@@ -1,0 +1,282 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const mod = await import("./index.js");
+const handler = mod.default;
+
+function stubDB(overrides = {}) {
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([pattern]) =>
+                new RegExp(pattern, "is").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => handler ? (handler[1](sql, binds) ?? { meta: { changes: 1 } }) : { meta: { changes: 1 } },
+            };
+            return stmt;
+        },
+    };
+}
+
+function mkRow(overrides = {}) {
+    return {
+        id: "01ROW",
+        user_id: "01USER",
+        template: "monthly_cert",
+        to_email: "test@example.com",
+        subject: "Your cert",
+        payload_json: JSON.stringify({ html_body: "<p>Hi</p>", text_body: "Hi" }),
+        idempotency_key: "idem_01ROW",
+        attempts: 0,
+        ...overrides,
+    };
+}
+
+// ── fetch handler ─────────────────────────────────────────────────────
+
+test("fetch: non-/drain path → 404", async () => {
+    const r = await handler.fetch(
+        new Request("https://worker.dev/other", { method: "POST" }),
+        {},
+    );
+    assert.equal(r.status, 404);
+});
+
+test("fetch: GET /drain → 405", async () => {
+    const r = await handler.fetch(
+        new Request("https://worker.dev/drain"),
+        {},
+    );
+    assert.equal(r.status, 405);
+});
+
+test("fetch: POST /drain without auth → 401", async () => {
+    const r = await handler.fetch(
+        new Request("https://worker.dev/drain", { method: "POST" }),
+        { ADMIN_TOKEN: "secret" },
+    );
+    assert.equal(r.status, 401);
+});
+
+test("fetch: POST /drain with correct auth → 200", async () => {
+    const db = stubDB({
+        "UPDATE email_outbox SET state = 'queued'": () => ({ meta: {} }),
+        "FROM email_outbox.*WHERE state = 'queued'.*ORDER": () => [],
+        "COUNT.*FROM email_outbox": () => ({ n: 0 }),
+        "MIN.*FROM email_outbox": () => ({ ts: null }),
+        "INSERT INTO heartbeats": () => null,
+    });
+    const r = await handler.fetch(
+        new Request("https://worker.dev/drain", {
+            method: "POST",
+            headers: { Authorization: "Bearer secret" },
+        }),
+        { ADMIN_TOKEN: "secret", RESEND_API_KEY: "re_test", FROM_EMAIL: "noreply@x.com", DB: db },
+    );
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.attempted, 0);
+    assert.equal(j.sent, 0);
+});
+
+// ── drain logic ───────────────────────────────────────────────────────
+
+test("drain: missing RESEND_API_KEY → throws", async () => {
+    const db = stubDB({
+        "INSERT INTO heartbeats": () => null,
+    });
+    await assert.rejects(
+        handler.fetch(
+            new Request("https://worker.dev/drain", {
+                method: "POST",
+                headers: { Authorization: "Bearer secret" },
+            }),
+            { ADMIN_TOKEN: "secret", DB: db, FROM_EMAIL: "noreply@x.com" },
+        ),
+        /RESEND_API_KEY_unset/,
+    );
+});
+
+test("drain: suppressed email → marked bounced, not sent", async () => {
+    const row = mkRow();
+    let finalState = null;
+    let finalError = null;
+    const db = stubDB({
+        "UPDATE email_outbox SET state = 'queued'": () => ({ meta: {} }),
+        "FROM email_outbox.*WHERE state = 'queued'.*ORDER": () => [row],
+        "UPDATE email_outbox SET state = 'sending'": () => ({ meta: { changes: 1 } }),
+        "FROM email_suppression WHERE email": () => ({ "1": 1 }),
+        "UPDATE email_outbox.*SET state = 'bounced'": (sql, binds) => {
+            finalState = "bounced";
+            return { meta: { changes: 1 } };
+        },
+        "COUNT.*FROM email_outbox": () => ({ n: 0 }),
+        "MIN.*FROM email_outbox": () => ({ ts: null }),
+        "INSERT INTO heartbeats": () => null,
+    });
+    const r = await handler.fetch(
+        new Request("https://worker.dev/drain", {
+            method: "POST",
+            headers: { Authorization: "Bearer secret" },
+        }),
+        { ADMIN_TOKEN: "secret", RESEND_API_KEY: "re_test", FROM_EMAIL: "noreply@x.com", DB: db },
+    );
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.failed, 1);
+    assert.equal(j.sent, 0);
+    assert.equal(finalState, "bounced");
+});
+
+test("drain: successful Resend POST → state = sent", async () => {
+    const row = mkRow();
+    let sentId = null;
+    const db = stubDB({
+        "UPDATE email_outbox SET state = 'queued'": () => ({ meta: {} }),
+        "FROM email_outbox.*WHERE state = 'queued'.*ORDER": () => [row],
+        "UPDATE email_outbox SET state = 'sending'": () => ({ meta: { changes: 1 } }),
+        "FROM email_suppression WHERE email": () => null,
+        "UPDATE email_outbox.*SET state = 'sent'": (sql, binds) => {
+            sentId = binds[2];
+            return { meta: { changes: 1 } };
+        },
+        "COUNT.*FROM email_outbox": () => ({ n: 0 }),
+        "MIN.*FROM email_outbox": () => ({ ts: null }),
+        "INSERT INTO heartbeats": () => null,
+    });
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, opts) => {
+        if (url === "https://api.resend.com/emails") {
+            return new Response(JSON.stringify({ id: "resend_msg_123" }), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            });
+        }
+        return origFetch(url, opts);
+    };
+    try {
+        const r = await handler.fetch(
+            new Request("https://worker.dev/drain", {
+                method: "POST",
+                headers: { Authorization: "Bearer secret" },
+            }),
+            { ADMIN_TOKEN: "secret", RESEND_API_KEY: "re_test", FROM_EMAIL: "noreply@x.com", DB: db },
+        );
+        assert.equal(r.status, 200);
+        const j = await r.json();
+        assert.equal(j.sent, 1);
+        assert.equal(j.failed, 0);
+        assert.equal(sentId, "01ROW");
+    } finally {
+        globalThis.fetch = origFetch;
+    }
+});
+
+test("drain: Resend 4xx → row back to queued with error", async () => {
+    const row = mkRow({ attempts: 0 });
+    let errorState = null;
+    let lastError = null;
+    const db = stubDB({
+        "UPDATE email_outbox SET state = 'queued'.*WHERE state = 'sending'": () => ({ meta: {} }),
+        "FROM email_outbox.*WHERE state = 'queued'.*ORDER": () => [row],
+        "UPDATE email_outbox SET state = 'sending'": () => ({ meta: { changes: 1 } }),
+        "FROM email_suppression WHERE email": () => null,
+        "UPDATE email_outbox.*SET state = \\?": (sql, binds) => {
+            errorState = binds[0];
+            lastError = binds[1];
+            return { meta: { changes: 1 } };
+        },
+        "COUNT.*FROM email_outbox": () => ({ n: 0 }),
+        "MIN.*FROM email_outbox": () => ({ ts: null }),
+        "INSERT INTO heartbeats": () => null,
+    });
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+        if (url === "https://api.resend.com/emails") {
+            return new Response(JSON.stringify({ message: "bad request" }), { status: 400 });
+        }
+        return origFetch(url);
+    };
+    try {
+        const r = await handler.fetch(
+            new Request("https://worker.dev/drain", {
+                method: "POST",
+                headers: { Authorization: "Bearer secret" },
+            }),
+            { ADMIN_TOKEN: "secret", RESEND_API_KEY: "re_test", FROM_EMAIL: "noreply@x.com", DB: db },
+        );
+        assert.equal(r.status, 200);
+        const j = await r.json();
+        assert.equal(j.failed, 1);
+        assert.equal(errorState, "queued");
+        assert.ok(lastError.includes("resend_400"));
+    } finally {
+        globalThis.fetch = origFetch;
+    }
+});
+
+test("drain: max attempts reached → state = failed permanently", async () => {
+    const row = mkRow({ attempts: 4 });
+    let errorState = null;
+    const db = stubDB({
+        "UPDATE email_outbox SET state = 'queued'.*WHERE state = 'sending'": () => ({ meta: {} }),
+        "FROM email_outbox.*WHERE state = 'queued'.*ORDER": () => [row],
+        "UPDATE email_outbox SET state = 'sending'": () => ({ meta: { changes: 1 } }),
+        "FROM email_suppression WHERE email": () => null,
+        "UPDATE email_outbox.*SET state = \\?": (sql, binds) => {
+            errorState = binds[0];
+            return { meta: { changes: 1 } };
+        },
+        "COUNT.*FROM email_outbox": () => ({ n: 0 }),
+        "MIN.*FROM email_outbox": () => ({ ts: null }),
+        "INSERT INTO heartbeats": () => null,
+    });
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+        if (url === "https://api.resend.com/emails") {
+            return new Response("server error", { status: 500 });
+        }
+        return origFetch(url);
+    };
+    try {
+        const r = await handler.fetch(
+            new Request("https://worker.dev/drain", {
+                method: "POST",
+                headers: { Authorization: "Bearer secret" },
+            }),
+            { ADMIN_TOKEN: "secret", RESEND_API_KEY: "re_test", FROM_EMAIL: "noreply@x.com", DB: db },
+        );
+        assert.equal(r.status, 200);
+        const j = await r.json();
+        assert.equal(j.failed, 1);
+        assert.equal(errorState, "failed");
+    } finally {
+        globalThis.fetch = origFetch;
+    }
+});
+
+test("drain: writes heartbeat on each run", async () => {
+    let heartbeatWritten = false;
+    const db = stubDB({
+        "UPDATE email_outbox SET state = 'queued'": () => ({ meta: {} }),
+        "FROM email_outbox.*WHERE state = 'queued'.*ORDER": () => [],
+        "COUNT.*FROM email_outbox": () => ({ n: 0 }),
+        "MIN.*FROM email_outbox": () => ({ ts: null }),
+        "INSERT INTO heartbeats": () => { heartbeatWritten = true; return null; },
+    });
+    await handler.fetch(
+        new Request("https://worker.dev/drain", {
+            method: "POST",
+            headers: { Authorization: "Bearer secret" },
+        }),
+        { ADMIN_TOKEN: "secret", RESEND_API_KEY: "re_test", FROM_EMAIL: "noreply@x.com", DB: db },
+    );
+    assert.ok(heartbeatWritten, "heartbeat should be written");
+});


### PR DESCRIPTION
## Summary
- 16 tests for `_lib.js` security-critical functions (`isAdmin`, `audit`, `rateLimit`, `constantTimeEqual`) — previously 0% coverage
- 10 tests for `email-sender` worker (drain flow, suppression skip, Resend integration, retry/failure states, heartbeat) — previously 0% coverage
- Total suite: 344 → 370 tests

## Test plan
- [x] All 370 tests pass locally
- [x] `isAdmin` tested: missing header, wrong token, correct token, case-insensitive prefix, empty env
- [x] `audit` tested: genesis prev_hash=null, chain linking, ip_hash placement, UNIQUE retry
- [x] `rateLimit` tested: under limit, over limit, missing KV (fail-closed), key independence
- [x] email-sender: fetch routing, auth, suppression, success, retry, permanent failure, heartbeat

🤖 Generated with [Claude Code](https://claude.com/claude-code)