### PR TITLE
docs: strengthen README problem statement + API heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 # SC-CPE
 
-Automated CPE/CEU certificate issuance for security professionals who attend the Simply Cyber Daily Threat Briefing livestream, with cryptographic proof of attendance and offline-verifiable signed credentials.
+Security professionals need CPE/CEU credits to keep their certifications active, but tracking attendance is manual, records are inconsistent, and there's no way for an auditor to independently verify a claim. SC-CPE fixes this — it watches the Simply Cyber Daily Threat Briefing YouTube live chat, matches per-user verification codes, and issues PAdES-T signed PDF certificates that are cryptographically verifiable offline, years later, without contacting the issuer.
 
 ---
 
@@ -246,8 +246,10 @@ D1 migrations in `db/migrations/` are applied automatically during deploy — th
 
 ---
 
+## API
+
 <details>
-<summary><strong>API Surface (49 endpoints)</strong></summary>
+<summary><strong>49 endpoints — expand for full table</strong></summary>
 
 ### Public
 


### PR DESCRIPTION
## Summary
- H1 paragraph now leads with the **problem** (manual CPE tracking is painful) before describing the solution — stronger hook for readers and scorers
- API surface section gets a proper `## API` heading above the `<details>` block so section detectors (and humans scanning headings) find it
- Scored with `readme-engineer/scripts/score.mjs`: **28/30 → 30/30** (Technical 8→10, all 13 sections now detected)

## Test plan
- [x] `bash scripts/test.sh` — 388 tests pass
- [x] `node readme-engineer/scripts/score.mjs` — 30/30, 0 missing sections
- [x] Visual review of README rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)