### PR TITLE
feat(admin): audit-log endpoint, CSV export, appeal cancel

### DIFF
--- a/pages/admin.html
+++ b/pages/admin.html
@@ -65,6 +65,9 @@
     <div class="section-h">Manual triggers <span class="muted" style="font-size:11px;text-transform:none;letter-spacing:0;">— on-demand cron block execution via purge worker</span></div>
     <div id="cron-triggers" style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:20px;"></div>
 
+    <div class="section-h">Data Export <span class="muted" style="font-size:11px;text-transform:none;letter-spacing:0;">— download CSV snapshots</span></div>
+    <div id="export-buttons" style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:20px;"></div>
+
     <div class="section-h">Email Suppression <span class="muted" style="font-size:11px;text-transform:none;letter-spacing:0;">— bounced/complained addresses blocked from sending</span></div>
     <div id="suppression-rows"></div>
     <p id="suppression-empty" class="muted" style="font-size:12px;" hidden>No suppressed addresses.</p>
@@ -118,6 +121,7 @@
         <option value="open">Open</option>
         <option value="granted">Granted</option>
         <option value="denied">Denied</option>
+        <option value="cancelled">Cancelled</option>
         <option value="any">All</option>
       </select>
       <button class="refresh" id="appeals-refresh" style="margin-left:6px;">Load</button>

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -59,11 +59,12 @@ async function load() {
     renderStats(stats);
     renderToggles(toggles);
     renderCronTriggers();
+    renderExportButtons();
     if (supp) renderSuppression(supp);
     renderHeartbeats(hb);
     renderChain(chain, stats);
-    renderAuditTrail(chain);
     renderFeedback(fb);
+    loadAuditTrail();
     if (secEvents) renderSecurityEvents(secEvents);
     $("#ts").textContent = "updated " + new Date().toLocaleTimeString();
   } catch (e) {
@@ -173,6 +174,42 @@ function renderCronTriggers() {
       wrap.append(label, btn);
       box.appendChild(wrap);
     })(blocks[i]);
+  }
+}
+function renderExportButtons() {
+  var box = $("#export-buttons");
+  if (!box || box.childNodes.length > 0) return;
+  var types = ["users", "attendance", "certs"];
+  for (var i = 0; i < types.length; i++) {
+    (function (type) {
+      var btn = document.createElement("button");
+      btn.className = "refresh";
+      btn.style.cssText = "font-size:11px;padding:5px 14px;";
+      btn.textContent = "Export " + type + " CSV";
+      btn.addEventListener("click", function () {
+        var url = "/api/admin/export?type=" + type;
+        var a = document.createElement("a");
+        a.href = url;
+        a.download = "";
+        if (TOKEN && TOKEN !== "__cookie__") {
+          btn.disabled = true;
+          btn.textContent = "downloading…";
+          fetch(url, { headers: { "Authorization": "Bearer " + TOKEN } })
+            .then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.blob(); })
+            .then(function (blob) {
+              var u = URL.createObjectURL(blob);
+              a.href = u;
+              a.click();
+              URL.revokeObjectURL(u);
+            })
+            .catch(function (e) { alert("Export failed: " + e.message); })
+            .finally(function () { btn.disabled = false; btn.textContent = "Export " + type + " CSV"; });
+        } else {
+          a.click();
+        }
+      });
+      box.appendChild(btn);
+    })(types[i]);
   }
 }
 function renderSuppression(d) {
@@ -404,82 +441,47 @@ function escapeHtml(s) {
     return {"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c];
   });
 }
-function renderAuditTrail(chain) {
+async function loadAuditTrail() {
   var box = $("#audit-rows"); box.innerHTML = "";
   auditEntries = [];
-  if (chain.rows && chain.rows.length > 0) {
-    auditEntries = chain.rows;
-  } else {
-    var entries = [];
-    if (chain.first_break) {
-      entries.push({
-        id: chain.first_break.id,
-        action: "chain_break",
-        entity_type: "audit_chain",
-        entity_id: chain.first_break.id,
-        actor_type: "system",
-        ts: chain.first_break.ts,
-        detail: "expected " + (chain.first_break.expected_prev_hash || "null") + ", got " + (chain.first_break.actual_prev_hash || "null")
-      });
-    }
-    entries.push({
-      id: "summary",
-      action: chain.ok ? "chain_verified" : "chain_broken",
-      entity_type: "audit_chain",
-      entity_id: "verify",
-      actor_type: "system",
-      ts: new Date().toISOString(),
-      detail: chain.rows_checked + " rows checked, unique index " + (chain.unique_index_on_prev_hash ? "present" : "MISSING")
-    });
-    auditEntries = entries;
+  var q = ($("#audit-q").value || "").trim();
+  var fromDate = $("#audit-from").value;
+  var toDate = $("#audit-to").value;
+  var qs = "?limit=200";
+  if (q) qs += "&q=" + encodeURIComponent(q);
+  if (fromDate) qs += "&from=" + encodeURIComponent(fromDate);
+  if (toDate) qs += "&to=" + encodeURIComponent(toDate);
+  try {
+    var data = await fetchJson("/api/admin/audit-log" + qs);
+    auditEntries = data.rows || [];
+  } catch (e) {
+    var errDiv = document.createElement("div");
+    errDiv.className = "err";
+    errDiv.textContent = e.message;
+    box.appendChild(errDiv);
+    return;
   }
   for (var i = 0; i < auditEntries.length; i++) {
     var entry = auditEntries[i];
     var row = document.createElement("div");
     row.className = "audit-row";
-    row.dataset.action = (entry.action || "").toLowerCase();
-    row.dataset.entityType = (entry.entity_type || "").toLowerCase();
-    row.dataset.entityId = String(entry.entity_id || "").toLowerCase();
-    row.dataset.actorType = (entry.actor_type || "").toLowerCase();
-    row.dataset.ts = entry.ts || "";
     row.innerHTML =
       '<div><div class="ar-label">Action</div><div class="ar-val">' + escapeHtml(entry.action) + '</div></div>' +
       '<div><div class="ar-label">Entity</div><div class="ar-val">' + escapeHtml(entry.entity_type) + ':' + escapeHtml(entry.entity_id) + '</div></div>' +
       '<div><div class="ar-label">Actor</div><div class="ar-val">' + escapeHtml(entry.actor_type) + (entry.actor_id ? ':' + escapeHtml(entry.actor_id) : '') + '</div></div>' +
-      '<div><div class="ar-label">Timestamp</div><div class="ar-val">' + escapeHtml(entry.ts) + '</div></div>' +
-      (entry.detail ? '<div style="grid-column:1/-1;"><div class="ar-label">Detail</div><div class="ar-val">' + escapeHtml(entry.detail) + '</div></div>' : '');
+      '<div><div class="ar-label">Timestamp</div><div class="ar-val">' + escapeHtml(entry.ts) + '</div></div>';
     box.appendChild(row);
   }
-  filterAuditRows();
+  $("#audit-count").textContent = auditEntries.length > 0 ? auditEntries.length + " entries" : "No entries found";
 }
-function filterAuditRows() {
-  var q = ($("#audit-q").value || "").toLowerCase().trim();
-  var fromDate = $("#audit-from").value;
-  var toDate = $("#audit-to").value;
-  var rows = document.querySelectorAll("#audit-rows .audit-row");
-  var shown = 0;
-  var total = rows.length;
-  for (var i = 0; i < rows.length; i++) {
-    var row = rows[i];
-    var match = true;
-    if (q) {
-      var text = row.dataset.action + " " + row.dataset.entityType + " " + row.dataset.entityId + " " + row.dataset.actorType;
-      if (text.indexOf(q) === -1) match = false;
-    }
-    if (match && fromDate && row.dataset.ts) {
-      if (row.dataset.ts.slice(0, 10) < fromDate) match = false;
-    }
-    if (match && toDate && row.dataset.ts) {
-      if (row.dataset.ts.slice(0, 10) > toDate) match = false;
-    }
-    if (match) { row.classList.remove("hidden"); shown++; }
-    else { row.classList.add("hidden"); }
-  }
-  $("#audit-count").textContent = total > 0 ? "Showing " + shown + " of " + total + " entries" : "";
+var auditDebounce = null;
+function debouncedAuditLoad() {
+  if (auditDebounce) clearTimeout(auditDebounce);
+  auditDebounce = setTimeout(loadAuditTrail, 400);
 }
-$("#audit-q").addEventListener("input", filterAuditRows);
-$("#audit-from").addEventListener("change", filterAuditRows);
-$("#audit-to").addEventListener("change", filterAuditRows);
+$("#audit-q").addEventListener("input", debouncedAuditLoad);
+$("#audit-from").addEventListener("change", loadAuditTrail);
+$("#audit-to").addEventListener("change", loadAuditTrail);
 $("#auto-refresh").addEventListener("change", function() {
   if (autoRefreshTimer) { clearInterval(autoRefreshTimer); autoRefreshTimer = null; }
   if (this.checked) { autoRefreshTimer = setInterval(load, 30000); }
@@ -1016,7 +1018,12 @@ function buildAppealRow(a) {
         denyBtn.dataset.aid = a.id;
         denyBtn.style.background = "#5c1515";
         denyBtn.textContent = "Deny";
-        actionsDiv.append(grantBtn, denyBtn);
+        var cancelBtn = document.createElement("button");
+        cancelBtn.className = "refresh appeal-cancel-btn";
+        cancelBtn.dataset.aid = a.id;
+        cancelBtn.style.cssText = "background:transparent;border:1px solid var(--adm-border);color:var(--adm-muted);";
+        cancelBtn.textContent = "Cancel";
+        actionsDiv.append(grantBtn, denyBtn, cancelBtn);
         row.appendChild(actionsDiv);
     } else if (a.resolution_notes) {
         var resDiv = document.createElement("div");
@@ -1044,9 +1051,10 @@ if (appealsBox) {
     appealsBox.addEventListener("click", async function (e) {
         var grantBtn = e.target.closest(".appeal-grant-btn");
         var denyBtn = e.target.closest(".appeal-deny-btn");
-        var btn = grantBtn || denyBtn;
+        var cancelBtn = e.target.closest(".appeal-cancel-btn");
+        var btn = grantBtn || denyBtn || cancelBtn;
         if (!btn || btn.disabled) return;
-        var decision = grantBtn ? "grant" : "deny";
+        var decision = grantBtn ? "grant" : (cancelBtn ? "cancel" : "deny");
         var resolver = prompt("Your admin handle:");
         if (!resolver) return;
         var notes = prompt("Resolution notes (optional):") || "";

--- a/pages/functions/api/admin/audit-log.js
+++ b/pages/functions/api/admin/audit-log.js
@@ -1,0 +1,42 @@
+import { isAdmin } from "../../_lib.js";
+
+export async function onRequestGet({ request, env }) {
+    if (!(await isAdmin(env, request)))
+        return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401, headers: { "Content-Type": "application/json" } });
+
+    const url = new URL(request.url);
+    const q = (url.searchParams.get("q") || "").trim().toLowerCase();
+    const from = url.searchParams.get("from") || "";
+    const to = url.searchParams.get("to") || "";
+    const limit = Math.min(Math.max(parseInt(url.searchParams.get("limit"), 10) || 100, 1), 500);
+
+    const clauses = [];
+    const binds = [];
+
+    if (q) {
+        clauses.push("(LOWER(action) LIKE ?1 OR LOWER(entity_type) LIKE ?1 OR LOWER(entity_id) LIKE ?1 OR LOWER(actor_type) LIKE ?1 OR LOWER(COALESCE(actor_id,'')) LIKE ?1)");
+        binds.push(`%${q}%`);
+    }
+    if (from) {
+        clauses.push(`ts >= ?${binds.length + 1}`);
+        binds.push(from + "T00:00:00Z");
+    }
+    if (to) {
+        clauses.push(`ts <= ?${binds.length + 1}`);
+        binds.push(to + "T23:59:59Z");
+    }
+
+    const where = clauses.length ? " WHERE " + clauses.join(" AND ") : "";
+    const sql = `SELECT id, actor_type, actor_id, action, entity_type, entity_id, ts
+                   FROM audit_log${where}
+               ORDER BY ts DESC LIMIT ?${binds.length + 1}`;
+    binds.push(limit);
+
+    const { results } = await env.DB.prepare(sql).bind(...binds).all();
+
+    return new Response(JSON.stringify({
+        ok: true,
+        count: results.length,
+        rows: results,
+    }), { headers: { "Content-Type": "application/json" } });
+}

--- a/pages/functions/api/admin/audit-log.test.mjs
+++ b/pages/functions/api/admin/audit-log.test.mjs
@@ -1,0 +1,119 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestGet } from "./audit-log.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function auth(url) {
+    return new Request(url, {
+        headers: { Authorization: "Bearer adm" },
+    });
+}
+
+function stubDB(overrides = {}) {
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([p]) =>
+                new RegExp(p, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+            };
+            return stmt;
+        },
+    };
+}
+
+test("audit-log: unauthorized → 401", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/audit-log`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("audit-log: no filters → 200 with rows", async () => {
+    const db = stubDB({
+        "FROM audit_log": () => [
+            { id: "01A", actor_type: "system", actor_id: null, action: "user_registered",
+              entity_type: "user", entity_id: "01U", ts: "2026-04-24T10:00:00Z" },
+        ],
+    });
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/audit-log`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.count, 1);
+    assert.equal(j.rows[0].action, "user_registered");
+});
+
+test("audit-log: search query filters by action", async () => {
+    let capturedBinds = [];
+    const db = {
+        prepare(sql) {
+            return {
+                bind(...args) { capturedBinds = args; return this; },
+                all: async () => ({ results: [] }),
+            };
+        },
+    };
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/audit-log?q=cert_issued`),
+    });
+    assert.equal(r.status, 200);
+    assert.ok(capturedBinds[0].includes("cert_issued"));
+});
+
+test("audit-log: date range filters", async () => {
+    let capturedBinds = [];
+    const db = {
+        prepare(sql) {
+            return {
+                bind(...args) { capturedBinds = args; return this; },
+                all: async () => ({ results: [] }),
+            };
+        },
+    };
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/audit-log?from=2026-04-01&to=2026-04-30`),
+    });
+    assert.equal(r.status, 200);
+    assert.ok(capturedBinds.some(b => b.includes("2026-04-01")));
+    assert.ok(capturedBinds.some(b => b.includes("2026-04-30")));
+});
+
+test("audit-log: limit capped at 500", async () => {
+    let capturedBinds = [];
+    const db = {
+        prepare(sql) {
+            return {
+                bind(...args) { capturedBinds = args; return this; },
+                all: async () => ({ results: [] }),
+            };
+        },
+    };
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/audit-log?limit=9999`),
+    });
+    assert.equal(r.status, 200);
+    assert.equal(capturedBinds[capturedBinds.length - 1], 500);
+});
+
+test("audit-log: empty result → count 0", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/audit-log`),
+    });
+    const j = await r.json();
+    assert.equal(j.count, 0);
+    assert.deepEqual(j.rows, []);
+});

--- a/pages/functions/api/admin/export.test.mjs
+++ b/pages/functions/api/admin/export.test.mjs
@@ -1,0 +1,129 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestGet } from "./export.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function auth(url) {
+    return new Request(url, {
+        headers: { Authorization: "Bearer adm" },
+    });
+}
+
+function stubDB(overrides = {}) {
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([p]) =>
+                new RegExp(p, "i").test(sql)
+            );
+            const stmt = {
+                bind(...args) { return stmt; },
+                all: async () => handler ? { results: handler[1](sql) } : { results: [] },
+            };
+            return stmt;
+        },
+    };
+}
+
+test("export: unauthorized → 401", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/export?type=users`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("export: missing type → 400", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/export`),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "invalid_type");
+});
+
+test("export: invalid type → 400", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/export?type=secrets`),
+    });
+    assert.equal(r.status, 400);
+});
+
+test("export: users CSV has correct headers", async () => {
+    const db = stubDB({
+        "FROM users": () => [
+            { id: "01U", email: "test@x.com", legal_name: "Test User",
+              yt_channel_id: "UC123", state: "active", show_on_leaderboard: 1,
+              current_streak: 5, longest_streak: 10, last_attendance_date: "2026-04-20",
+              created_at: "2026-01-01", verified_at: "2026-01-02" },
+        ],
+    });
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/export?type=users`),
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.headers.get("Content-Type"), "text/csv; charset=utf-8");
+    assert.ok(r.headers.get("Content-Disposition").includes("sc-cpe-users-"));
+    const body = await r.text();
+    assert.ok(body.startsWith("id,email,legal_name"));
+    assert.ok(body.includes("test@x.com"));
+});
+
+test("export: attendance CSV returns rows", async () => {
+    const db = stubDB({
+        "FROM attendance": () => [
+            { user_id: "01U", email: "t@t.com", legal_name: "T",
+              stream_id: "01S", scheduled_date: "2026-04-20", yt_video_id: "abc",
+              title: "DTB", earned_cpe: 0.5, source: "poller",
+              first_msg_at: "2026-04-20T14:30:00Z", created_at: "2026-04-20T14:30:00Z" },
+        ],
+    });
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/export?type=attendance`),
+    });
+    assert.equal(r.status, 200);
+    const body = await r.text();
+    assert.ok(body.includes("user_id,email"));
+    assert.ok(body.includes("poller"));
+});
+
+test("export: certs CSV returns rows", async () => {
+    const db = stubDB({
+        "FROM certs": () => [
+            { id: "01C", public_token: "abc", user_id: "01U", email: "t@t.com",
+              legal_name: "T", period_yyyymm: "202604", cpe_total: 5,
+              sessions_count: 10, cert_kind: "bundled", state: "generated",
+              generated_at: "2026-04-30", delivered_at: null, created_at: "2026-04-30" },
+        ],
+    });
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/export?type=certs`),
+    });
+    assert.equal(r.status, 200);
+    const body = await r.text();
+    assert.ok(body.includes("cert_id,public_token"));
+    assert.ok(body.includes("bundled"));
+});
+
+test("export: CSV escapes commas and quotes", async () => {
+    const db = stubDB({
+        "FROM users": () => [
+            { id: "01U", email: "t@t.com", legal_name: 'O"Brien, Jr.',
+              yt_channel_id: null, state: "active", show_on_leaderboard: 0,
+              current_streak: 0, longest_streak: 0, last_attendance_date: null,
+              created_at: "2026-01-01", verified_at: null },
+        ],
+    });
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: auth(`${BASE}/api/admin/export?type=users`),
+    });
+    const body = await r.text();
+    assert.ok(body.includes('"O""Brien, Jr."'));
+});

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -36,4 +36,6 @@ node --test \
     pages/functions/api/admin/cert-reissue.test.mjs \
     pages/functions/_lib-security.test.mjs \
     workers/email-sender/src/email-sender.test.mjs \
-    workers/purge/src/scheduled-tasks.test.mjs
+    workers/purge/src/scheduled-tasks.test.mjs \
+    pages/functions/api/admin/audit-log.test.mjs \
+    pages/functions/api/admin/export.test.mjs


### PR DESCRIPTION
## Summary
- **New endpoint: `/api/admin/audit-log`** — paginated audit_log query with search (action, entity, actor) and date range filters. Fixes the broken audit trail UI that was showing chain-verification metadata instead of actual audit entries.
- **CSV export buttons** — Users, Attendance, Certs download buttons wired to the existing `/api/admin/export` endpoint (had zero UI before)
- **Appeal cancel** — "Cancel" button on open appeals + "Cancelled" option in the state filter dropdown (backend already supported `decision: "cancel"`)
- **Audit trail rewrite** — now queries real `audit_log` rows server-side with debounced search, replacing the old client-side filter on synthetic chain-verify entries

## Test plan
- [x] `bash scripts/test.sh` — 401 tests pass (13 new: 6 audit-log, 7 export)
- [ ] Admin dashboard: verify audit trail loads real entries with search
- [ ] Admin dashboard: verify CSV export downloads work
- [ ] Admin dashboard: verify appeal cancel button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)