### PR TITLE
fix(admin): XSS, analytics resilience, accessibility, 20 new tests

### DIFF
--- a/pages/admin.js
+++ b/pages/admin.js
@@ -13,7 +13,13 @@ function fmtAge(s) {
 function card(k, v, cls) {
   var n = document.createElement("div");
   n.className = "card";
-  n.innerHTML = '<div class="k">' + k + '</div><div class="v ' + (cls||'') + '">' + v + '</div>';
+  var kDiv = document.createElement("div");
+  kDiv.className = "k";
+  kDiv.textContent = k;
+  var vDiv = document.createElement("div");
+  vDiv.className = "v " + (cls || "");
+  vDiv.textContent = v;
+  n.append(kDiv, vDiv);
   return n;
 }
 async function fetchJson(path) {
@@ -279,7 +285,7 @@ function renderHeartbeats(d) {
     var s = d.sources[i];
     var tr = document.createElement("tr");
     var cls = s.stale ? "stale" : "ok";
-    var status = s.stale ? "STALE" : (s.last_status || "—");
+    var status = s.stale ? "✗ STALE" : ("✓ " + (s.last_status || "ok"));
     tr.innerHTML =
       '<td data-label="Source">' + s.source + "</td>" +
       '<td data-label="Status" class="' + cls + '">' + status + "</td>" +
@@ -293,12 +299,12 @@ function renderHeartbeats(d) {
 function renderChain(c, s) {
   var g = $("#chain"); g.innerHTML = "";
   g.append(
-    card("Chain OK", c.ok ? "YES" : "NO", c.ok ? "ok" : "stale"),
+    card("Chain OK", c.ok ? "✓ YES" : "✗ NO", c.ok ? "ok" : "stale"),
     card("Rows checked", c.rows_checked),
-    card("Unique index", c.unique_index_on_prev_hash ? "present" : "MISSING",
+    card("Unique index", c.unique_index_on_prev_hash ? "✓ present" : "✗ MISSING",
          c.unique_index_on_prev_hash ? "ok" : "stale"),
-    card("Tip id", '<span class="v small">' + ((s.audit_tip && s.audit_tip.id) || "—") + "</span>"),
-    card("Tip ts", '<span class="v small">' + ((s.audit_tip && s.audit_tip.ts) || "—") + "</span>"),
+    card("Tip id", (s.audit_tip && s.audit_tip.id) || "—"),
+    card("Tip ts", (s.audit_tip && s.audit_tip.ts) || "—"),
   );
   if (c.first_break) {
     var n = document.createElement("div");
@@ -771,7 +777,9 @@ if (userResultsBox) {
             var isSusp = suspBtn.dataset.suspended === "1";
             var reason = prompt(isSusp ? "Reason for unsuspension:" : "Reason for suspension (required):");
             if (!reason) return;
-            if (!isSusp && !confirm("Suspend user " + suspBtn.dataset.uid.slice(0, 10) + "…?")) return;
+            var userHeader = suspBtn.closest(".user-row").querySelector(".user-name");
+            var userName = userHeader ? userHeader.textContent : suspBtn.dataset.uid;
+            if (!isSusp && !confirm("Suspend user " + userName + " (" + suspBtn.dataset.uid + ")?")) return;
             suspBtn.disabled = true;
             suspBtn.textContent = isSusp ? "unsuspending…" : "suspending…";
             try {
@@ -1181,37 +1189,27 @@ async function loadAnalytics() {
     var el = $("#analytics-" + sections[i]);
     if (el) { el.textContent = ""; var p = document.createElement("p"); p.className = "muted"; p.style.fontSize = "12px"; p.textContent = "Loading…"; el.appendChild(p); }
   }
-  try {
-    var results = await Promise.all([
-      fetchJson("/api/admin/analytics/growth" + qs),
-      fetchJson("/api/admin/analytics/engagement" + qs),
-      fetchJson("/api/admin/analytics/certs" + qs),
-      fetchJson("/api/admin/analytics/system" + qs),
-    ]);
-    renderAnalyticsSection("analytics-growth", "Growth", results[0].headlines, {
-      total_users: "Total users", active_users: "Active", verified_users: "Verified",
-      active_attenders_30d: "Active attenders (30d)", new_registrations: "New registrations",
-    }, results[0].series);
-    renderAnalyticsSection("analytics-engagement", "Engagement", results[1].headlines, {
-      avg_attendance_per_stream: "Avg attendance / stream",
-      total_cpe_awarded: "Total CPE awarded",
-      streams_with_zero_attendance: "Streams (0 attendance)",
-    }, results[1].series);
-    renderAnalyticsSection("analytics-certs", "Certificates", results[2].headlines, {
-      issued_this_period: "Issued (period)",
-      pending_now: "Pending now",
-      avg_delivery_seconds: "Avg delivery (s)",
-      view_rate_pct: "View rate %",
-    }, results[2].series);
-    renderAnalyticsSection("analytics-system", "System", results[3].headlines, {
-      email_success_rate_pct: "Email success %",
-      emails_sent: "Emails sent",
-      appeals_open: "Open appeals",
-      avg_appeal_resolution_seconds: "Avg appeal resolution (s)",
-    }, results[3].series);
-  } catch (e) {
-    var el = $("#analytics-growth");
-    if (el) { el.textContent = ""; var d = document.createElement("div"); d.className = "err"; d.textContent = e.message; el.appendChild(d); }
+  var settled = await Promise.allSettled([
+    fetchJson("/api/admin/analytics/growth" + qs),
+    fetchJson("/api/admin/analytics/engagement" + qs),
+    fetchJson("/api/admin/analytics/certs" + qs),
+    fetchJson("/api/admin/analytics/system" + qs),
+  ]);
+  var configs = [
+    ["analytics-growth", "Growth", { total_users: "Total users", active_users: "Active", verified_users: "Verified", active_attenders_30d: "Active attenders (30d)", new_registrations: "New registrations" }],
+    ["analytics-engagement", "Engagement", { avg_attendance_per_stream: "Avg attendance / stream", total_cpe_awarded: "Total CPE awarded", streams_with_zero_attendance: "Streams (0 attendance)" }],
+    ["analytics-certs", "Certificates", { issued_this_period: "Issued (period)", pending_now: "Pending now", avg_delivery_seconds: "Avg delivery (s)", view_rate_pct: "View rate %" }],
+    ["analytics-system", "System", { email_success_rate_pct: "Email success %", emails_sent: "Emails sent", appeals_open: "Open appeals", avg_appeal_resolution_seconds: "Avg appeal resolution (s)" }],
+  ];
+  for (var i = 0; i < settled.length; i++) {
+    var el = $("#" + configs[i][0]);
+    if (!el) continue;
+    if (settled[i].status === "fulfilled") {
+      renderAnalyticsSection(configs[i][0], configs[i][1], settled[i].value.headlines, configs[i][2], settled[i].value.series);
+    } else {
+      el.textContent = "";
+      var d = document.createElement("div"); d.className = "err"; d.textContent = configs[i][1] + ": " + settled[i].reason.message; el.appendChild(d);
+    }
   }
 }
 function renderAnalyticsSection(containerId, title, headlines, labels, series) {

--- a/pages/functions/api/admin/email-suppression.test.mjs
+++ b/pages/functions/api/admin/email-suppression.test.mjs
@@ -1,0 +1,146 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestGet, onRequestDelete } from "./email-suppression.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function auth(url, opts = {}) {
+    return new Request(url, {
+        ...opts,
+        headers: { Authorization: "Bearer adm", ...(opts.headers || {}) },
+    });
+}
+
+function deleteAuth(url, body) {
+    return auth(url, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+function stubDB(overrides = {}) {
+    const noop = { meta: {} };
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([p]) =>
+                new RegExp(p, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => noop,
+            };
+            return stmt;
+        },
+    };
+}
+
+function auditDB(overrides = {}) {
+    return stubDB({
+        ...overrides,
+        "INSERT INTO audit_log": () => null,
+        "SELECT id, ts, prev_hash FROM audit_log ORDER BY ts DESC": () => ({
+            id: "01X", ts: "2026-04-24T00:00:00Z", prev_hash: "abc",
+        }),
+    });
+}
+
+function mkKV() {
+    const store = new Map();
+    return {
+        get: async (k) => store.get(k) ?? null,
+        put: async (k, v) => store.set(k, v),
+        delete: async (k) => store.delete(k),
+    };
+}
+
+// ── GET ────────────────────────────────────────────────────────────────
+
+test("email-suppression GET: unauthorized → 401", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: new Request(`${BASE}/api/admin/email-suppression`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("email-suppression GET: returns masked emails", async () => {
+    const db = stubDB({
+        "FROM email_suppression": () => [
+            { email: "bob@example.com", reason: "hard_bounce", event_id: "ev1", created_at: "2026-04-24T00:00:00Z" },
+        ],
+    });
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: auth(`${BASE}/api/admin/email-suppression`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.suppressions.length, 1);
+    assert.equal(j.suppressions[0].email_masked, "bob***@example.com");
+    assert.equal(j.suppressions[0].reason, "hard_bounce");
+});
+
+test("email-suppression GET: empty → empty array", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: auth(`${BASE}/api/admin/email-suppression`),
+    });
+    const j = await r.json();
+    assert.deepEqual(j.suppressions, []);
+});
+
+// ── DELETE ─────────────────────────────────────────────────────────────
+
+test("email-suppression DELETE: unauthorized → 401", async () => {
+    const r = await onRequestDelete({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/email-suppression`, { method: "DELETE" }),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("email-suppression DELETE: missing email → 400", async () => {
+    const r = await onRequestDelete({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm" },
+        request: deleteAuth(`${BASE}/api/admin/email-suppression`, {}),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "invalid_email");
+});
+
+test("email-suppression DELETE: email without @ → 400", async () => {
+    const r = await onRequestDelete({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm" },
+        request: deleteAuth(`${BASE}/api/admin/email-suppression`, { email: "notanemail" }),
+    });
+    assert.equal(r.status, 400);
+});
+
+test("email-suppression DELETE: not found → 404", async () => {
+    const r = await onRequestDelete({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm" },
+        request: deleteAuth(`${BASE}/api/admin/email-suppression`, { email: "nobody@example.com" }),
+    });
+    assert.equal(r.status, 404);
+});
+
+test("email-suppression DELETE: valid → 200", async () => {
+    const db = auditDB({
+        "SELECT email FROM email_suppression": () => ({ email: "bob@example.com" }),
+        "DELETE FROM email_suppression": () => null,
+    });
+    const r = await onRequestDelete({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: deleteAuth(`${BASE}/api/admin/email-suppression`, { email: "bob@example.com" }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+});

--- a/pages/functions/api/admin/streams.test.mjs
+++ b/pages/functions/api/admin/streams.test.mjs
@@ -1,0 +1,134 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestGet } from "./streams.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function auth(url) {
+    return new Request(url, {
+        headers: { Authorization: "Bearer adm" },
+    });
+}
+
+function stubDB(overrides = {}) {
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([p]) =>
+                new RegExp(p, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+            };
+            return stmt;
+        },
+    };
+}
+
+function mkKV() {
+    const store = new Map();
+    return {
+        get: async (k) => store.get(k) ?? null,
+        put: async (k, v) => store.set(k, v),
+        delete: async (k) => store.delete(k),
+    };
+}
+
+test("streams: unauthorized → 401", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: new Request(`${BASE}/api/admin/streams`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("streams: no params → 200 with default 30 days", async () => {
+    let capturedBinds = [];
+    const db = {
+        prepare(sql) {
+            return {
+                bind(...args) { capturedBinds = args; return this; },
+                all: async () => ({ results: [
+                    { id: "01S", yt_video_id: "abc", title: "DTB", scheduled_date: "2026-04-24",
+                      state: "ended", actual_start_at: "2026-04-24T14:00:00Z",
+                      actual_end_at: "2026-04-24T15:00:00Z", attendance_count: 12 },
+                ] }),
+            };
+        },
+    };
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: auth(`${BASE}/api/admin/streams`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.streams.length, 1);
+    assert.equal(j.streams[0].attendance_count, 12);
+    assert.equal(capturedBinds[0], 30);
+});
+
+test("streams: custom days param", async () => {
+    let capturedBinds = [];
+    const db = {
+        prepare(sql) {
+            return {
+                bind(...args) { capturedBinds = args; return this; },
+                all: async () => ({ results: [] }),
+            };
+        },
+    };
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: auth(`${BASE}/api/admin/streams?days=90`),
+    });
+    assert.equal(r.status, 200);
+    assert.equal(capturedBinds[0], 90);
+});
+
+test("streams: invalid days → defaults to 30", async () => {
+    let capturedBinds = [];
+    const db = {
+        prepare(sql) {
+            return {
+                bind(...args) { capturedBinds = args; return this; },
+                all: async () => ({ results: [] }),
+            };
+        },
+    };
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: auth(`${BASE}/api/admin/streams?days=-5`),
+    });
+    assert.equal(r.status, 200);
+    assert.equal(capturedBinds[0], 30);
+});
+
+test("streams: days > 365 → clamped to 30", async () => {
+    let capturedBinds = [];
+    const db = {
+        prepare(sql) {
+            return {
+                bind(...args) { capturedBinds = args; return this; },
+                all: async () => ({ results: [] }),
+            };
+        },
+    };
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: auth(`${BASE}/api/admin/streams?days=999`),
+    });
+    assert.equal(r.status, 200);
+    assert.equal(capturedBinds[0], 30);
+});
+
+test("streams: empty result → empty array", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: auth(`${BASE}/api/admin/streams`),
+    });
+    const j = await r.json();
+    assert.deepEqual(j.streams, []);
+});

--- a/pages/functions/api/admin/suspend.test.mjs
+++ b/pages/functions/api/admin/suspend.test.mjs
@@ -1,0 +1,125 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestPost } from "./suspend.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function postAuth(url, body) {
+    return new Request(url, {
+        method: "POST",
+        headers: { Authorization: "Bearer adm", "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+function stubDB(overrides = {}) {
+    const noop = { meta: {} };
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([p]) =>
+                new RegExp(p, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => noop,
+            };
+            return stmt;
+        },
+    };
+}
+
+function auditDB(overrides = {}) {
+    return stubDB({
+        ...overrides,
+        "INSERT INTO audit_log": () => null,
+        "SELECT id, ts, prev_hash FROM audit_log ORDER BY ts DESC": () => ({
+            id: "01X", ts: "2026-04-24T00:00:00Z", prev_hash: "abc",
+        }),
+    });
+}
+
+function mkKV() {
+    const store = new Map();
+    return {
+        get: async (k) => store.get(k) ?? null,
+        put: async (k, v) => store.set(k, v),
+        delete: async (k) => store.delete(k),
+    };
+}
+
+test("suspend: unauthorized → 401", async () => {
+    const r = await onRequestPost({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: new Request(`${BASE}/api/admin/suspend`, { method: "POST" }),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("suspend: missing user_id → 400", async () => {
+    const r = await onRequestPost({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: postAuth(`${BASE}/api/admin/suspend`, { suspended: true, reason: "test" }),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "invalid_user_id");
+});
+
+test("suspend: missing reason → 400", async () => {
+    const r = await onRequestPost({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: postAuth(`${BASE}/api/admin/suspend`, { user_id: "01USERID1234", suspended: true }),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "reason_required_under_500_chars");
+});
+
+test("suspend: user not found → 404", async () => {
+    const r = await onRequestPost({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: postAuth(`${BASE}/api/admin/suspend`, {
+            user_id: "01NOTFOUND12", suspended: true, reason: "Abuse",
+        }),
+    });
+    assert.equal(r.status, 404);
+});
+
+test("suspend: valid suspension → 200", async () => {
+    const db = auditDB({
+        "FROM users WHERE id": () => ({ id: "01USERID1234", state: "active", suspended_at: null }),
+        "UPDATE users SET suspended_at": () => null,
+    });
+    const r = await onRequestPost({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: postAuth(`${BASE}/api/admin/suspend`, {
+            user_id: "01USERID1234", suspended: true, reason: "Abuse detected",
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.user_id, "01USERID1234");
+    assert.ok(j.suspended_at);
+});
+
+test("suspend: unsuspend → 200 with null suspended_at", async () => {
+    const db = auditDB({
+        "FROM users WHERE id": () => ({ id: "01USERID1234", state: "active", suspended_at: "2026-04-20T00:00:00Z" }),
+        "UPDATE users SET suspended_at": () => null,
+    });
+    const r = await onRequestPost({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: postAuth(`${BASE}/api/admin/suspend`, {
+            user_id: "01USERID1234", suspended: false, reason: "Appeal resolved",
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.suspended_at, null);
+});

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -38,4 +38,7 @@ node --test \
     workers/email-sender/src/email-sender.test.mjs \
     workers/purge/src/scheduled-tasks.test.mjs \
     pages/functions/api/admin/audit-log.test.mjs \
-    pages/functions/api/admin/export.test.mjs
+    pages/functions/api/admin/export.test.mjs \
+    pages/functions/api/admin/streams.test.mjs \
+    pages/functions/api/admin/suspend.test.mjs \
+    pages/functions/api/admin/email-suppression.test.mjs


### PR DESCRIPTION
## Summary
- **XSS fix**: `card()` rewritten from `innerHTML` to `createElement`+`textContent` — prevents injection through stat values
- **Analytics resilience**: `Promise.all` → `Promise.allSettled` so a single failing analytics sub-endpoint no longer blanks all 4 sections; each section shows its own error independently
- **Accessibility**: heartbeat and chain status indicators now include ✓/✗ symbols alongside color, so status is not color-only
- **Suspend UX**: confirmation dialog shows full user name + ID instead of truncated ID
- **Chain tip cleanup**: removed inline HTML wrappers from chain tip card values (now plain text through safe `textContent`)
- **20 new tests**: `streams.test.mjs` (6), `suspend.test.mjs` (6), `email-suppression.test.mjs` (8) — covers auth, validation, happy paths, and edge cases

## Test plan
- [x] Full test suite passes (421 tests, 0 failures)
- [ ] Verify admin dashboard loads without console errors
- [ ] Confirm heartbeat/chain status shows ✓/✗ symbols
- [ ] Trigger a single analytics sub-endpoint failure and verify other sections still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)