### PR TITLE
feat(admin): passkey login, 7-day sessions, role-based admin management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,6 +422,27 @@ tag instead of `width="100%"`.
   unit tests across 3 test files. Docs: `docs/DEV_SETUP.md` (developer
   setup) and `docs/ADMIN_ONBOARDING.md` (admin guide).
 
+- **Admin passkey login + management** — added 2026-04-24. WebAuthn/passkey
+  authentication for admin dashboard: instant biometric login without
+  email dependency. Manual WebAuthn implementation using Web Crypto API
+  (no npm dependencies). Migration 014 adds `admin_passkeys` table +
+  `invited_by`/`display_name` columns on `admin_users`. Session extended
+  from 24h to 7 days. `isAdmin()` now returns `{ id, email, role }` or
+  `false` (bearer token returns `role: "owner"`). New endpoints:
+  `POST /api/admin/auth/passkey/register-options`,
+  `POST /api/admin/auth/passkey/register-verify`,
+  `POST /api/admin/auth/passkey/auth-options`,
+  `POST /api/admin/auth/passkey/auth-verify`,
+  `GET/DELETE /api/admin/auth/passkeys` (manage own passkeys),
+  `GET/POST/DELETE /api/admin/auth/admins` (owner-only admin management
+  with invite emails), `GET /api/admin/auth/me` (identity + role).
+  Roles: `owner` (full control, can manage admins) vs `admin` (operator,
+  read/write but no admin management). Admin dashboard UI: passkey login
+  button on login screen, passkey enrollment section, admin list with
+  invite/remove (owner only). Requires `ADMIN_COOKIE_SECRET` Pages
+  secret. RP ID is bound to hostname — if custom domain is added, existing
+  passkeys will need re-registration.
+
 ## Where to look for more context
 
 - `docs/RUNBOOK.md` — operator-facing ops procedures

--- a/db/migrations/014_admin_passkeys.sql
+++ b/db/migrations/014_admin_passkeys.sql
@@ -1,0 +1,17 @@
+-- WebAuthn passkey credentials for admin users.
+CREATE TABLE IF NOT EXISTS admin_passkeys (
+    id TEXT PRIMARY KEY,
+    admin_id INTEGER NOT NULL REFERENCES admin_users(id),
+    credential_id TEXT NOT NULL UNIQUE,
+    public_key BLOB NOT NULL,
+    counter INTEGER NOT NULL DEFAULT 0,
+    transports TEXT,
+    backed_up INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    last_used_at TEXT
+);
+
+ALTER TABLE admin_users ADD COLUMN invited_by INTEGER REFERENCES admin_users(id);
+ALTER TABLE admin_users ADD COLUMN display_name TEXT;
+
+UPDATE admin_users SET role = 'owner' WHERE email = 'ericrihm@gmail.com';

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -270,7 +270,21 @@ CREATE TABLE IF NOT EXISTS admin_users (
     email TEXT UNIQUE NOT NULL,
     role TEXT NOT NULL DEFAULT 'admin',
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    created_by TEXT NOT NULL DEFAULT 'migration'
+    created_by TEXT NOT NULL DEFAULT 'migration',
+    invited_by INTEGER REFERENCES admin_users(id),
+    display_name TEXT
+);
+
+CREATE TABLE IF NOT EXISTS admin_passkeys (
+    id TEXT PRIMARY KEY,
+    admin_id INTEGER NOT NULL REFERENCES admin_users(id),
+    credential_id TEXT NOT NULL UNIQUE,
+    public_key BLOB NOT NULL,
+    counter INTEGER NOT NULL DEFAULT 0,
+    transports TEXT,
+    backed_up INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    last_used_at TEXT
 );
 
 -- Email suppression list. Populated by the Resend bounce/complaint webhook.

--- a/pages/admin.html
+++ b/pages/admin.html
@@ -17,6 +17,11 @@
   <div class="sub" id="sub"><a href="/analytics.html">Analytics &rarr;</a></div>
 
   <div id="login" class="login">
+    <div id="passkey-login" hidden style="margin-bottom:16px;">
+      <button id="passkey-login-btn" style="width:100%;max-width:340px;padding:10px;font-size:1rem;cursor:pointer;">Sign in with passkey</button>
+      <div id="passkey-login-err" class="err" hidden style="margin-top:6px;"></div>
+      <p style="margin:12px 0 0;color:var(--adm-muted);font-size:12px;">Or use email below:</p>
+    </div>
     <p style="margin:0 0 12px;color:var(--adm-muted);">Enter your admin email and we'll send you a login link — no token needed.</p>
     <form id="login-form" style="display:flex;flex-direction:column;gap:8px;max-width:340px;">
       <input type="email" id="admin-email" placeholder="admin@example.com" required autocomplete="email" style="padding:8px;border:1px solid var(--adm-border);border-radius:4px;font-size:1rem;background:var(--adm-card);color:var(--adm-fg);">
@@ -156,6 +161,28 @@
     </thead><tbody></tbody></table>
     </div>
     <p id="fb-empty" class="muted" style="font-size:12px;" hidden>No outstanding typo/wrong reports.</p>
+
+    <div class="section-h">Passkeys <span class="muted" style="font-size:11px;text-transform:none;letter-spacing:0;">— passwordless login credentials</span></div>
+    <div id="passkey-enroll" style="margin-bottom:12px;">
+      <button id="passkey-register-btn" class="refresh">Register new passkey</button>
+      <span id="passkey-register-status" class="muted" style="margin-left:8px;font-size:12px;"></span>
+    </div>
+    <div id="passkey-list"></div>
+    <p id="passkey-empty" class="muted" style="font-size:12px;" hidden>No passkeys registered. Add one for instant login.</p>
+
+    <div class="section-h" id="admin-mgmt-header" hidden>Admin management <span class="muted" style="font-size:11px;text-transform:none;letter-spacing:0;">— invite and manage admin accounts (owner only)</span></div>
+    <div id="admin-mgmt" hidden>
+      <form id="admin-invite-form" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:12px;">
+        <input type="email" id="invite-email" placeholder="Email address" required style="flex:1;min-width:200px;">
+        <select id="invite-role" style="background:var(--adm-card);color:var(--adm-fg);border:1px solid var(--adm-border);padding:4px 8px;border-radius:4px;">
+          <option value="admin">Operator</option>
+          <option value="owner">Owner</option>
+        </select>
+        <button type="submit" class="refresh">Invite</button>
+      </form>
+      <div id="admin-invite-err" class="err" hidden></div>
+      <div id="admin-list"></div>
+    </div>
   </div>
 </div>
 

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -1456,13 +1456,8 @@ if (adminInviteForm) {
         var role = $("#invite-role").value;
         if (!email) return;
         try {
-            var r = await fetch("/api/admin/auth/admins", {
-                method: "POST", credentials: "include",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ email: email, role: role }),
-            });
-            var data = await r.json();
-            if (!r.ok) { errEl.textContent = data.error || "Invite failed"; errEl.hidden = false; return; }
+            var data = await postJson("/api/admin/auth/admins", {}, "POST", { email: email, role: role });
+            if (data.error) { errEl.textContent = data.error || "Invite failed"; errEl.hidden = false; return; }
             $("#invite-email").value = "";
             loadAdminList();
         } catch (x) {

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -13,7 +13,13 @@ function fmtAge(s) {
 function card(k, v, cls) {
   var n = document.createElement("div");
   n.className = "card";
-  n.innerHTML = '<div class="k">' + k + '</div><div class="v ' + (cls||'') + '">' + v + '</div>';
+  var kDiv = document.createElement("div");
+  kDiv.className = "k";
+  kDiv.textContent = k;
+  var vDiv = document.createElement("div");
+  vDiv.className = "v " + (cls || "");
+  vDiv.textContent = v;
+  n.append(kDiv, vDiv);
   return n;
 }
 async function fetchJson(path) {
@@ -279,7 +285,7 @@ function renderHeartbeats(d) {
     var s = d.sources[i];
     var tr = document.createElement("tr");
     var cls = s.stale ? "stale" : "ok";
-    var status = s.stale ? "STALE" : (s.last_status || "—");
+    var status = s.stale ? "✗ STALE" : ("✓ " + (s.last_status || "ok"));
     tr.innerHTML =
       '<td data-label="Source">' + s.source + "</td>" +
       '<td data-label="Status" class="' + cls + '">' + status + "</td>" +
@@ -293,12 +299,12 @@ function renderHeartbeats(d) {
 function renderChain(c, s) {
   var g = $("#chain"); g.innerHTML = "";
   g.append(
-    card("Chain OK", c.ok ? "YES" : "NO", c.ok ? "ok" : "stale"),
+    card("Chain OK", c.ok ? "✓ YES" : "✗ NO", c.ok ? "ok" : "stale"),
     card("Rows checked", c.rows_checked),
-    card("Unique index", c.unique_index_on_prev_hash ? "present" : "MISSING",
+    card("Unique index", c.unique_index_on_prev_hash ? "✓ present" : "✗ MISSING",
          c.unique_index_on_prev_hash ? "ok" : "stale"),
-    card("Tip id", '<span class="v small">' + ((s.audit_tip && s.audit_tip.id) || "—") + "</span>"),
-    card("Tip ts", '<span class="v small">' + ((s.audit_tip && s.audit_tip.ts) || "—") + "</span>"),
+    card("Tip id", (s.audit_tip && s.audit_tip.id) || "—"),
+    card("Tip ts", (s.audit_tip && s.audit_tip.ts) || "—"),
   );
   if (c.first_break) {
     var n = document.createElement("div");
@@ -771,7 +777,9 @@ if (userResultsBox) {
             var isSusp = suspBtn.dataset.suspended === "1";
             var reason = prompt(isSusp ? "Reason for unsuspension:" : "Reason for suspension (required):");
             if (!reason) return;
-            if (!isSusp && !confirm("Suspend user " + suspBtn.dataset.uid.slice(0, 10) + "…?")) return;
+            var userHeader = suspBtn.closest(".user-row").querySelector(".user-name");
+            var userName = userHeader ? userHeader.textContent : suspBtn.dataset.uid;
+            if (!isSusp && !confirm("Suspend user " + userName + " (" + suspBtn.dataset.uid + ")?")) return;
             suspBtn.disabled = true;
             suspBtn.textContent = isSusp ? "unsuspending…" : "suspending…";
             try {
@@ -1181,37 +1189,27 @@ async function loadAnalytics() {
     var el = $("#analytics-" + sections[i]);
     if (el) { el.textContent = ""; var p = document.createElement("p"); p.className = "muted"; p.style.fontSize = "12px"; p.textContent = "Loading…"; el.appendChild(p); }
   }
-  try {
-    var results = await Promise.all([
-      fetchJson("/api/admin/analytics/growth" + qs),
-      fetchJson("/api/admin/analytics/engagement" + qs),
-      fetchJson("/api/admin/analytics/certs" + qs),
-      fetchJson("/api/admin/analytics/system" + qs),
-    ]);
-    renderAnalyticsSection("analytics-growth", "Growth", results[0].headlines, {
-      total_users: "Total users", active_users: "Active", verified_users: "Verified",
-      active_attenders_30d: "Active attenders (30d)", new_registrations: "New registrations",
-    }, results[0].series);
-    renderAnalyticsSection("analytics-engagement", "Engagement", results[1].headlines, {
-      avg_attendance_per_stream: "Avg attendance / stream",
-      total_cpe_awarded: "Total CPE awarded",
-      streams_with_zero_attendance: "Streams (0 attendance)",
-    }, results[1].series);
-    renderAnalyticsSection("analytics-certs", "Certificates", results[2].headlines, {
-      issued_this_period: "Issued (period)",
-      pending_now: "Pending now",
-      avg_delivery_seconds: "Avg delivery (s)",
-      view_rate_pct: "View rate %",
-    }, results[2].series);
-    renderAnalyticsSection("analytics-system", "System", results[3].headlines, {
-      email_success_rate_pct: "Email success %",
-      emails_sent: "Emails sent",
-      appeals_open: "Open appeals",
-      avg_appeal_resolution_seconds: "Avg appeal resolution (s)",
-    }, results[3].series);
-  } catch (e) {
-    var el = $("#analytics-growth");
-    if (el) { el.textContent = ""; var d = document.createElement("div"); d.className = "err"; d.textContent = e.message; el.appendChild(d); }
+  var settled = await Promise.allSettled([
+    fetchJson("/api/admin/analytics/growth" + qs),
+    fetchJson("/api/admin/analytics/engagement" + qs),
+    fetchJson("/api/admin/analytics/certs" + qs),
+    fetchJson("/api/admin/analytics/system" + qs),
+  ]);
+  var configs = [
+    ["analytics-growth", "Growth", { total_users: "Total users", active_users: "Active", verified_users: "Verified", active_attenders_30d: "Active attenders (30d)", new_registrations: "New registrations" }],
+    ["analytics-engagement", "Engagement", { avg_attendance_per_stream: "Avg attendance / stream", total_cpe_awarded: "Total CPE awarded", streams_with_zero_attendance: "Streams (0 attendance)" }],
+    ["analytics-certs", "Certificates", { issued_this_period: "Issued (period)", pending_now: "Pending now", avg_delivery_seconds: "Avg delivery (s)", view_rate_pct: "View rate %" }],
+    ["analytics-system", "System", { email_success_rate_pct: "Email success %", emails_sent: "Emails sent", appeals_open: "Open appeals", avg_appeal_resolution_seconds: "Avg appeal resolution (s)" }],
+  ];
+  for (var i = 0; i < settled.length; i++) {
+    var el = $("#" + configs[i][0]);
+    if (!el) continue;
+    if (settled[i].status === "fulfilled") {
+      renderAnalyticsSection(configs[i][0], configs[i][1], settled[i].value.headlines, configs[i][2], settled[i].value.series);
+    } else {
+      el.textContent = "";
+      var d = document.createElement("div"); d.className = "err"; d.textContent = configs[i][1] + ": " + settled[i].reason.message; el.appendChild(d);
+    }
   }
 }
 function renderAnalyticsSection(containerId, title, headlines, labels, series) {

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -1254,6 +1254,224 @@ function renderAnalyticsSection(containerId, title, headlines, labels, series) {
 }
 var analyticsLoadBtn = $("#analytics-load");
 if (analyticsLoadBtn) analyticsLoadBtn.addEventListener("click", loadAnalytics);
+
+// ── Passkey helpers ───────────────────────────────────────────────────
+function bufToB64url(buf) {
+    var bytes = new Uint8Array(buf);
+    var s = "";
+    for (var i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+    return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+function b64urlToBuf(str) {
+    var padded = str.replace(/-/g, "+").replace(/_/g, "/");
+    var bin = atob(padded);
+    var bytes = new Uint8Array(bin.length);
+    for (var i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return bytes.buffer;
+}
+
+async function passkeyLogin() {
+    var errEl = $("#passkey-login-err");
+    errEl.hidden = true;
+    try {
+        var optR = await fetch("/api/admin/auth/passkey/auth-options", { method: "POST" });
+        if (!optR.ok) throw new Error("Failed to get options");
+        var options = await optR.json();
+        options.challenge = b64urlToBuf(options.challenge);
+        var cred = await navigator.credentials.get({ publicKey: options });
+        var body = {
+            id: cred.id,
+            rawId: bufToB64url(cred.rawId),
+            type: cred.type,
+            response: {
+                clientDataJSON: bufToB64url(cred.response.clientDataJSON),
+                authenticatorData: bufToB64url(cred.response.authenticatorData),
+                signature: bufToB64url(cred.response.signature),
+                userHandle: cred.response.userHandle ? bufToB64url(cred.response.userHandle) : null,
+            },
+        };
+        var verR = await fetch("/api/admin/auth/passkey/auth-verify", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+        });
+        if (!verR.ok) {
+            var errJ = await verR.json().catch(function() { return {}; });
+            throw new Error(errJ.error || "Verification failed");
+        }
+        location.reload();
+    } catch (e) {
+        if (e.name === "NotAllowedError") return;
+        errEl.textContent = e.message;
+        errEl.hidden = false;
+    }
+}
+
+async function passkeyRegister() {
+    var status = $("#passkey-register-status");
+    var btn = $("#passkey-register-btn");
+    btn.disabled = true;
+    status.textContent = "Starting…";
+    try {
+        var optR = await fetch("/api/admin/auth/passkey/register-options", {
+            method: "POST", credentials: "include",
+        });
+        if (!optR.ok) throw new Error("Failed to get options");
+        var options = await optR.json();
+        options.challenge = b64urlToBuf(options.challenge);
+        options.user.id = b64urlToBuf(options.user.id);
+        if (options.excludeCredentials) {
+            for (var i = 0; i < options.excludeCredentials.length; i++) {
+                options.excludeCredentials[i].id = b64urlToBuf(options.excludeCredentials[i].id);
+            }
+        }
+        var cred = await navigator.credentials.create({ publicKey: options });
+        var body = {
+            id: cred.id,
+            rawId: bufToB64url(cred.rawId),
+            type: cred.type,
+            response: {
+                clientDataJSON: bufToB64url(cred.response.clientDataJSON),
+                attestationObject: bufToB64url(cred.response.attestationObject),
+                transports: cred.response.getTransports ? cred.response.getTransports() : [],
+            },
+        };
+        var verR = await fetch("/api/admin/auth/passkey/register-verify", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+            body: JSON.stringify(body),
+        });
+        var result = await verR.json();
+        if (!verR.ok) throw new Error(result.error || "Registration failed");
+        status.textContent = "Passkey registered!";
+        status.style.color = "var(--adm-ok)";
+        loadPasskeys();
+    } catch (e) {
+        if (e.name === "NotAllowedError") { status.textContent = "Cancelled."; btn.disabled = false; return; }
+        status.textContent = e.message;
+        status.style.color = "var(--bad)";
+    }
+    btn.disabled = false;
+}
+
+async function loadPasskeys() {
+    try {
+        var data = await fetchJson("/api/admin/auth/passkeys");
+        var list = $("#passkey-list");
+        var empty = $("#passkey-empty");
+        list.innerHTML = "";
+        if (!data.passkeys || data.passkeys.length === 0) {
+            empty.hidden = false;
+            return;
+        }
+        empty.hidden = true;
+        for (var i = 0; i < data.passkeys.length; i++) {
+            var pk = data.passkeys[i];
+            var row = document.createElement("div");
+            row.style.cssText = "display:flex;align-items:center;gap:8px;padding:6px 0;border-bottom:1px solid var(--adm-border);font-size:13px;";
+            var info = document.createElement("span");
+            info.textContent = "Key " + pk.credential_id_prefix + "… " +
+                (pk.backed_up ? "(synced)" : "(device-bound)") +
+                " — registered " + (pk.created_at || "").slice(0, 10) +
+                (pk.last_used_at ? ", last used " + pk.last_used_at.slice(0, 10) : "");
+            var del = document.createElement("button");
+            del.className = "refresh";
+            del.style.cssText = "font-size:11px;padding:2px 8px;background:#5c1515;margin-left:auto;";
+            del.textContent = "Remove";
+            del.dataset.id = pk.id;
+            del.addEventListener("click", function() {
+                var id = this.dataset.id;
+                if (!confirm("Remove this passkey?")) return;
+                postJson("/api/admin/auth/passkeys", {}, "DELETE", { passkey_id: id }).then(loadPasskeys);
+            });
+            row.append(info, del);
+            list.appendChild(row);
+        }
+    } catch (e) {}
+}
+
+async function loadAdminList() {
+    try {
+        var data = await fetchJson("/api/admin/auth/admins");
+        if (data.your_role === "owner") {
+            var hdr = $("#admin-mgmt-header");
+            var mgmt = $("#admin-mgmt");
+            if (hdr) hdr.hidden = false;
+            if (mgmt) mgmt.hidden = false;
+        }
+        var list = $("#admin-list");
+        if (!list) return;
+        list.innerHTML = "";
+        for (var i = 0; i < data.admins.length; i++) {
+            var a = data.admins[i];
+            var row = document.createElement("div");
+            row.style.cssText = "display:flex;align-items:center;gap:8px;padding:6px 0;border-bottom:1px solid var(--adm-border);font-size:13px;";
+            var info = document.createElement("span");
+            info.textContent = a.email + " — " +
+                (a.role === "owner" ? "Owner" : "Operator") +
+                " — " + (a.passkey_count || 0) + " passkey(s)" +
+                " — joined " + (a.created_at || "").slice(0, 10);
+            row.appendChild(info);
+            if (data.your_role === "owner") {
+                var del = document.createElement("button");
+                del.className = "refresh";
+                del.style.cssText = "font-size:11px;padding:2px 8px;background:#5c1515;margin-left:auto;";
+                del.textContent = "Remove";
+                del.dataset.id = a.id;
+                del.dataset.email = a.email;
+                del.addEventListener("click", function() {
+                    var id = parseInt(this.dataset.id);
+                    var email = this.dataset.email;
+                    if (!confirm("Remove admin " + email + "? They will lose all access.")) return;
+                    postJson("/api/admin/auth/admins", {}, "DELETE", { admin_id: id }).then(loadAdminList);
+                });
+                row.appendChild(del);
+            }
+            list.appendChild(row);
+        }
+    } catch (e) {}
+}
+
+function postJson(path, headers, method, body) {
+    var opts = { method: method || "POST", credentials: "include", headers: { "Content-Type": "application/json" } };
+    if (TOKEN && TOKEN !== "__cookie__") opts.headers["Authorization"] = "Bearer " + TOKEN;
+    if (body) opts.body = JSON.stringify(body);
+    return fetch(path, opts).then(function(r) { return r.json(); });
+}
+
+var passkeyLoginBtn = $("#passkey-login-btn");
+if (passkeyLoginBtn) passkeyLoginBtn.addEventListener("click", passkeyLogin);
+
+var passkeyRegBtn = $("#passkey-register-btn");
+if (passkeyRegBtn) passkeyRegBtn.addEventListener("click", passkeyRegister);
+
+var adminInviteForm = $("#admin-invite-form");
+if (adminInviteForm) {
+    adminInviteForm.addEventListener("submit", async function(e) {
+        e.preventDefault();
+        var errEl = $("#admin-invite-err");
+        errEl.hidden = true;
+        var email = $("#invite-email").value.trim();
+        var role = $("#invite-role").value;
+        if (!email) return;
+        try {
+            var r = await fetch("/api/admin/auth/admins", {
+                method: "POST", credentials: "include",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ email: email, role: role }),
+            });
+            var data = await r.json();
+            if (!r.ok) { errEl.textContent = data.error || "Invite failed"; errEl.hidden = false; return; }
+            $("#invite-email").value = "";
+            loadAdminList();
+        } catch (x) {
+            errEl.textContent = "Network error";
+            errEl.hidden = false;
+        }
+    });
+}
+
 (async function init() {
     try {
         var testR = await fetch("/api/admin/ops-stats", { credentials: "include" });
@@ -1263,9 +1481,16 @@ if (analyticsLoadBtn) analyticsLoadBtn.addEventListener("click", loadAnalytics);
             $("#app").style.display = "";
             load();
             loadAppeals();
+            loadPasskeys();
+            loadAdminList();
             return;
         }
     } catch (e) {}
+
+    if (window.PublicKeyCredential) {
+        var pkl = $("#passkey-login");
+        if (pkl) pkl.hidden = false;
+    }
 
     var params = new URLSearchParams(location.search);
     if (params.get("error") === "expired") {

--- a/pages/functions/_lib-security.test.mjs
+++ b/pages/functions/_lib-security.test.mjs
@@ -50,24 +50,27 @@ test("isAdmin: wrong bearer token → false", async () => {
     assert.equal(r, false);
 });
 
-test("isAdmin: correct bearer token → true", async () => {
+test("isAdmin: correct bearer token → returns admin object", async () => {
     const r = await isAdmin(
         { ADMIN_TOKEN: "correct_token" },
         new Request("https://x.dev/api/admin/test", {
             headers: { Authorization: "Bearer correct_token" },
         }),
     );
-    assert.equal(r, true);
+    assert.ok(r);
+    assert.equal(r.role, "owner");
+    assert.equal(r.email, "__bearer__");
 });
 
-test("isAdmin: case-insensitive 'bearer' prefix → true", async () => {
+test("isAdmin: case-insensitive 'bearer' prefix → returns admin object", async () => {
     const r = await isAdmin(
         { ADMIN_TOKEN: "tok" },
         new Request("https://x.dev/api/admin/test", {
             headers: { Authorization: "bearer tok" },
         }),
     );
-    assert.equal(r, true);
+    assert.ok(r);
+    assert.equal(r.role, "owner");
 });
 
 test("isAdmin: empty ADMIN_TOKEN env → false (never matches)", async () => {

--- a/pages/functions/_lib.js
+++ b/pages/functions/_lib.js
@@ -386,7 +386,7 @@ export async function isAdmin(env, request) {
             securityEvent(env, "auth_fail:bearer", "").catch(() => {});
             return false;
         }
-        return true;
+        return { id: 0, email: "__bearer__", role: "owner" };
     }
 
     if (!env.ADMIN_COOKIE_SECRET) return false;
@@ -399,9 +399,9 @@ export async function isAdmin(env, request) {
     const session = await parseSessionCookie(cookieValue, env.ADMIN_COOKIE_SECRET);
     if (!session) return false;
     const admin = await env.DB.prepare(
-        "SELECT id FROM admin_users WHERE lower(email) = ?1"
+        "SELECT id, email, role FROM admin_users WHERE lower(email) = ?1"
     ).bind(session.email.toLowerCase()).first();
-    return !!admin;
+    return admin || false;
 }
 
 export async function constantTimeEqual(a, b) {

--- a/pages/functions/api/admin/auth/_auth_helpers.js
+++ b/pages/functions/api/admin/auth/_auth_helpers.js
@@ -94,9 +94,9 @@ export function parseCookies(cookieHeader) {
 }
 
 export const COOKIE_NAME = "__Host-sc-admin";
-export const SESSION_MAX_AGE = 24 * 60 * 60 * 1000;
+export const SESSION_MAX_AGE = 7 * 24 * 60 * 60 * 1000;
 export const MAGIC_LINK_MAX_AGE = 15 * 60 * 1000;
 
-export function sessionCookieHeader(value, maxAge = 86400) {
+export function sessionCookieHeader(value, maxAge = 604800) {
     return `${COOKIE_NAME}=${value}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=${maxAge}`;
 }

--- a/pages/functions/api/admin/auth/_webauthn.js
+++ b/pages/functions/api/admin/auth/_webauthn.js
@@ -1,0 +1,306 @@
+const enc = new TextEncoder();
+
+function b64url(buf) {
+    const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+    let s = "";
+    for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+    return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function b64urlDecode(str) {
+    const padded = str.replace(/-/g, "+").replace(/_/g, "/");
+    const bin = atob(padded);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return bytes;
+}
+
+// ── Minimal CBOR decoder (handles types needed for WebAuthn) ──────────
+
+function decodeCBOR(buf) {
+    const data = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+    let offset = 0;
+
+    function readUint8() { return data[offset++]; }
+    function readUint16() {
+        const v = (data[offset] << 8) | data[offset + 1]; offset += 2; return v;
+    }
+    function readUint32() {
+        const v = (data[offset] << 24 | data[offset+1] << 16 | data[offset+2] << 8 | data[offset+3]) >>> 0;
+        offset += 4; return v;
+    }
+    function readBytes(n) {
+        const s = data.slice(offset, offset + n); offset += n; return s;
+    }
+
+    function readLength(ai) {
+        if (ai < 24) return ai;
+        if (ai === 24) return readUint8();
+        if (ai === 25) return readUint16();
+        if (ai === 26) return readUint32();
+        throw new Error("cbor: unsupported length encoding " + ai);
+    }
+
+    function decode() {
+        const initial = readUint8();
+        const major = initial >> 5;
+        const ai = initial & 0x1f;
+
+        if (major === 0) return readLength(ai);
+        if (major === 1) return -1 - readLength(ai);
+        if (major === 2) return readBytes(readLength(ai));
+        if (major === 3) {
+            const bytes = readBytes(readLength(ai));
+            return new TextDecoder().decode(bytes);
+        }
+        if (major === 4) {
+            const len = readLength(ai);
+            const arr = [];
+            for (let i = 0; i < len; i++) arr.push(decode());
+            return arr;
+        }
+        if (major === 5) {
+            const len = readLength(ai);
+            const map = new Map();
+            for (let i = 0; i < len; i++) {
+                const k = decode();
+                map.set(k, decode());
+            }
+            return map;
+        }
+        if (major === 7) {
+            if (ai === 20) return false;
+            if (ai === 21) return true;
+            if (ai === 22) return null;
+        }
+        throw new Error("cbor: unsupported major type " + major + " ai " + ai);
+    }
+    return decode();
+}
+
+// ── WebAuthn helpers ──────────────────────────────────────────────────
+
+export function generateChallenge() {
+    return b64url(crypto.getRandomValues(new Uint8Array(32)));
+}
+
+export function buildRegistrationOptions({ rpId, rpName, userName, userId, challenge, excludeCredentials }) {
+    return {
+        rp: { id: rpId, name: rpName },
+        user: {
+            id: b64url(enc.encode(userId)),
+            name: userName,
+            displayName: userName,
+        },
+        challenge,
+        pubKeyCredParams: [
+            { type: "public-key", alg: -7 },   // ES256
+            { type: "public-key", alg: -257 },  // RS256
+        ],
+        authenticatorSelection: {
+            residentKey: "required",
+            userVerification: "preferred",
+        },
+        attestation: "none",
+        excludeCredentials: (excludeCredentials || []).map(c => ({
+            type: "public-key",
+            id: c.credential_id,
+            transports: c.transports ? JSON.parse(c.transports) : [],
+        })),
+        timeout: 300000,
+    };
+}
+
+export function buildAuthenticationOptions({ rpId, challenge }) {
+    return {
+        rpId,
+        challenge,
+        userVerification: "preferred",
+        timeout: 300000,
+    };
+}
+
+function parseAuthData(authData) {
+    const rpIdHash = authData.slice(0, 32);
+    const flags = authData[32];
+    const signCount = (authData[33] << 24 | authData[34] << 16 | authData[35] << 8 | authData[36]) >>> 0;
+    const userPresent = !!(flags & 0x01);
+    const userVerified = !!(flags & 0x04);
+    const attestedData = !!(flags & 0x40);
+    const result = { rpIdHash, flags, signCount, userPresent, userVerified };
+
+    if (attestedData && authData.length > 37) {
+        const aaguid = authData.slice(37, 53);
+        const credIdLen = (authData[53] << 8) | authData[54];
+        const credentialId = authData.slice(55, 55 + credIdLen);
+        const coseKeyBytes = authData.slice(55 + credIdLen);
+        result.aaguid = aaguid;
+        result.credentialId = credentialId;
+        result.coseKeyBytes = coseKeyBytes;
+    }
+    return result;
+}
+
+async function coseToPublicKey(coseBytes) {
+    const coseMap = decodeCBOR(coseBytes);
+    const kty = coseMap.get(1);
+    const alg = coseMap.get(3);
+
+    if (kty === 2 && alg === -7) {
+        const crv = coseMap.get(-1);
+        if (crv !== 1) throw new Error("unsupported curve: " + crv);
+        const x = coseMap.get(-2);
+        const y = coseMap.get(-3);
+        const rawKey = new Uint8Array(65);
+        rawKey[0] = 0x04;
+        rawKey.set(x, 1);
+        rawKey.set(y, 33);
+        const key = await crypto.subtle.importKey(
+            "raw", rawKey,
+            { name: "ECDSA", namedCurve: "P-256" },
+            true, ["verify"],
+        );
+        return { key, alg: -7, rawKey };
+    }
+
+    if (kty === 3 && alg === -257) {
+        const n = coseMap.get(-1);
+        const e = coseMap.get(-2);
+        const jwk = {
+            kty: "RSA",
+            n: b64url(n),
+            e: b64url(e),
+            alg: "RS256",
+        };
+        const key = await crypto.subtle.importKey(
+            "jwk", jwk,
+            { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+            true, ["verify"],
+        );
+        return { key, alg: -257 };
+    }
+
+    throw new Error("unsupported COSE key type " + kty + " alg " + alg);
+}
+
+export async function verifyRegistration({ response, expectedChallenge, expectedOrigin, expectedRpId }) {
+    const clientDataJSON = b64urlDecode(response.clientDataJSON);
+    const clientData = JSON.parse(new TextDecoder().decode(clientDataJSON));
+
+    if (clientData.type !== "webauthn.create") throw new Error("invalid clientData type");
+    if (clientData.challenge !== expectedChallenge) throw new Error("challenge mismatch");
+    const origin = clientData.origin;
+    if (origin !== expectedOrigin) throw new Error("origin mismatch: " + origin);
+
+    const attestationObject = decodeCBOR(b64urlDecode(response.attestationObject));
+    const authData = attestationObject.get("authData");
+    if (!(authData instanceof Uint8Array)) throw new Error("missing authData");
+
+    const parsed = parseAuthData(authData);
+    if (!parsed.userPresent) throw new Error("user not present");
+
+    const rpIdHashExpected = new Uint8Array(
+        await crypto.subtle.digest("SHA-256", enc.encode(expectedRpId))
+    );
+    if (!constantTimeEq(parsed.rpIdHash, rpIdHashExpected)) throw new Error("rpId mismatch");
+
+    if (!parsed.credentialId || !parsed.coseKeyBytes) throw new Error("no attested credential data");
+
+    const { key, alg, rawKey } = await coseToPublicKey(parsed.coseKeyBytes);
+    const exported = await crypto.subtle.exportKey("spki", key);
+
+    return {
+        credentialId: b64url(parsed.credentialId),
+        publicKey: new Uint8Array(exported),
+        counter: parsed.signCount,
+        transports: response.transports || [],
+        backedUp: !!(parsed.flags & 0x10),
+    };
+}
+
+export async function verifyAuthentication({ response, expectedChallenge, expectedOrigin, expectedRpId, credential }) {
+    const clientDataJSON = b64urlDecode(response.clientDataJSON);
+    const clientData = JSON.parse(new TextDecoder().decode(clientDataJSON));
+
+    if (clientData.type !== "webauthn.get") throw new Error("invalid clientData type");
+    if (clientData.challenge !== expectedChallenge) throw new Error("challenge mismatch");
+    if (clientData.origin !== expectedOrigin) throw new Error("origin mismatch");
+
+    const authDataBytes = b64urlDecode(response.authenticatorData);
+    const parsed = parseAuthData(authDataBytes);
+    if (!parsed.userPresent) throw new Error("user not present");
+
+    const rpIdHashExpected = new Uint8Array(
+        await crypto.subtle.digest("SHA-256", enc.encode(expectedRpId))
+    );
+    if (!constantTimeEq(parsed.rpIdHash, rpIdHashExpected)) throw new Error("rpId mismatch");
+
+    if (credential.counter > 0 && parsed.signCount <= credential.counter) {
+        throw new Error("counter not incremented — possible cloned authenticator");
+    }
+
+    const publicKey = await crypto.subtle.importKey(
+        "spki",
+        credential.publicKey instanceof Uint8Array ? credential.publicKey : new Uint8Array(credential.publicKey),
+        credential.alg === -257
+            ? { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" }
+            : { name: "ECDSA", namedCurve: "P-256" },
+        false,
+        ["verify"],
+    );
+
+    const clientDataHash = new Uint8Array(
+        await crypto.subtle.digest("SHA-256", clientDataJSON)
+    );
+    const signedData = new Uint8Array(authDataBytes.length + clientDataHash.length);
+    signedData.set(authDataBytes, 0);
+    signedData.set(clientDataHash, authDataBytes.length);
+
+    const sigBytes = b64urlDecode(response.signature);
+
+    let sig = sigBytes;
+    if (credential.alg !== -257) {
+        sig = derToRaw(sigBytes);
+    }
+
+    const algorithm = credential.alg === -257
+        ? { name: "RSASSA-PKCS1-v1_5" }
+        : { name: "ECDSA", hash: "SHA-256" };
+
+    const valid = await crypto.subtle.verify(algorithm, publicKey, sig, signedData);
+    if (!valid) throw new Error("signature verification failed");
+
+    return { signCount: parsed.signCount };
+}
+
+function derToRaw(der) {
+    if (der[0] !== 0x30) return der;
+    let offset = 2;
+    if (der[1] & 0x80) offset += der[1] & 0x7f;
+
+    function readInt() {
+        if (der[offset++] !== 0x02) throw new Error("expected INTEGER");
+        let len = der[offset++];
+        let bytes = der.slice(offset, offset + len);
+        offset += len;
+        if (bytes[0] === 0 && bytes.length === 33) bytes = bytes.slice(1);
+        const padded = new Uint8Array(32);
+        padded.set(bytes, 32 - bytes.length);
+        return padded;
+    }
+    const r = readInt();
+    const s = readInt();
+    const raw = new Uint8Array(64);
+    raw.set(r, 0);
+    raw.set(s, 32);
+    return raw;
+}
+
+function constantTimeEq(a, b) {
+    if (a.length !== b.length) return false;
+    let diff = 0;
+    for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+    return diff === 0;
+}
+
+export { b64url, b64urlDecode, decodeCBOR };

--- a/pages/functions/api/admin/auth/admins.js
+++ b/pages/functions/api/admin/auth/admins.js
@@ -1,0 +1,142 @@
+import {
+    json, isAdmin, isValidEmail, audit, clientIp, ipHash,
+    emailShell, queueEmail, ulid,
+} from "../../../_lib.js";
+import { buildMagicLinkToken, MAGIC_LINK_MAX_AGE } from "./_auth_helpers.js";
+
+export async function onRequestGet({ request, env }) {
+    const admin = await isAdmin(env, request);
+    if (!admin) return json({ error: "unauthorized" }, 401);
+
+    const rows = await env.DB.prepare(
+        "SELECT id, email, role, display_name, created_at FROM admin_users ORDER BY id"
+    ).all();
+
+    const passkeys = await env.DB.prepare(
+        "SELECT admin_id, COUNT(*) as count FROM admin_passkeys GROUP BY admin_id"
+    ).all();
+    const pkMap = {};
+    for (const r of (passkeys.results || [])) pkMap[r.admin_id] = r.count;
+
+    return json({
+        ok: true,
+        admins: (rows.results || []).map(r => ({
+            id: r.id,
+            email: r.email,
+            role: r.role,
+            display_name: r.display_name,
+            created_at: r.created_at,
+            passkey_count: pkMap[r.id] || 0,
+        })),
+        your_role: admin.role,
+    });
+}
+
+export async function onRequestPost({ request, env }) {
+    const admin = await isAdmin(env, request);
+    if (!admin) return json({ error: "unauthorized" }, 401);
+    if (admin.role !== "owner") return json({ error: "owner_only" }, 403);
+
+    let body;
+    try { body = await request.json(); }
+    catch { return json({ error: "invalid_json" }, 400); }
+
+    const email = (body.email || "").trim().toLowerCase();
+    const role = body.role || "admin";
+    const displayName = (body.display_name || "").trim() || null;
+
+    if (!isValidEmail(email)) return json({ error: "invalid_email" }, 400);
+    if (role !== "admin" && role !== "owner") return json({ error: "invalid_role" }, 400);
+
+    const existing = await env.DB.prepare(
+        "SELECT id FROM admin_users WHERE lower(email) = ?1"
+    ).bind(email).first();
+    if (existing) return json({ error: "already_exists" }, 409);
+
+    await env.DB.prepare(
+        `INSERT INTO admin_users (email, role, display_name, invited_by, created_by)
+         VALUES (?1, ?2, ?3, ?4, 'invite')`
+    ).bind(email, role, displayName, admin.id).run();
+
+    const newAdmin = await env.DB.prepare(
+        "SELECT id, email, role FROM admin_users WHERE lower(email) = ?1"
+    ).bind(email).first();
+
+    if (env.ADMIN_COOKIE_SECRET) {
+        const nonce = [...crypto.getRandomValues(new Uint8Array(16))]
+            .map(b => b.toString(16).padStart(2, "0")).join("");
+        const expires = Date.now() + MAGIC_LINK_MAX_AGE;
+        await env.RATE_KV.put("admin_nonce:" + nonce, email, { expirationTtl: 900 });
+        const token = await buildMagicLinkToken(email, expires, nonce, env.ADMIN_COOKIE_SECRET);
+        const siteBase = new URL(request.url).origin;
+        const callbackUrl = siteBase + "/api/admin/auth/callback?token=" +
+            encodeURIComponent(token) + "&redirect=" + encodeURIComponent("/admin.html");
+
+        const bodyHtml =
+            "<p>You've been invited to the SC-CPE admin panel.</p>" +
+            '<p><a href="' + callbackUrl + '"' +
+            ' style="display:inline-block;background:#0b3d5c;color:#fff;' +
+            'padding:10px 16px;border-radius:4px;text-decoration:none;">' +
+            "Accept Invite &amp; Sign In</a></p>" +
+            '<p style="color:#666;font-size:12px;">This link expires in 15 minutes. ' +
+            "After signing in you can set up a passkey for instant access.</p>";
+
+        await queueEmail(env, {
+            userId: null,
+            template: "admin_invite",
+            to: email,
+            subject: "SC-CPE Admin Invite",
+            html: emailShell({
+                title: "Admin Invite",
+                preheader: "You've been invited to the SC-CPE admin panel",
+                bodyHtml,
+            }),
+            text: "You've been invited to the SC-CPE admin panel.\n\n" +
+                  "Sign in: " + callbackUrl + "\n\nThis link expires in 15 minutes.",
+            idempotencyKey: "admin_invite:" + ulid(),
+        });
+    }
+
+    const ip = clientIp(request);
+    const ipH = await ipHash(ip);
+    await audit(
+        env, "admin", admin.id, "admin_invited", "admin_user", newAdmin.id,
+        null, { email, role },
+        { ip_hash: ipH },
+    );
+
+    return json({ ok: true, admin: { id: newAdmin.id, email, role, display_name: displayName } });
+}
+
+export async function onRequestDelete({ request, env }) {
+    const admin = await isAdmin(env, request);
+    if (!admin) return json({ error: "unauthorized" }, 401);
+    if (admin.role !== "owner") return json({ error: "owner_only" }, 403);
+
+    let body;
+    try { body = await request.json(); }
+    catch { return json({ error: "invalid_json" }, 400); }
+
+    const targetId = body.admin_id;
+    if (targetId == null) return json({ error: "missing_admin_id" }, 400);
+
+    if (targetId === admin.id) return json({ error: "cannot_remove_self" }, 400);
+
+    const target = await env.DB.prepare(
+        "SELECT id, email, role FROM admin_users WHERE id = ?1"
+    ).bind(targetId).first();
+    if (!target) return json({ error: "not_found" }, 404);
+
+    await env.DB.prepare("DELETE FROM admin_passkeys WHERE admin_id = ?1").bind(targetId).run();
+    await env.DB.prepare("DELETE FROM admin_users WHERE id = ?1").bind(targetId).run();
+
+    const ip = clientIp(request);
+    const ipH = await ipHash(ip);
+    await audit(
+        env, "admin", admin.id, "admin_removed", "admin_user", targetId,
+        null, { email: target.email, role: target.role },
+        { ip_hash: ipH },
+    );
+
+    return json({ ok: true });
+}

--- a/pages/functions/api/admin/auth/admins.test.mjs
+++ b/pages/functions/api/admin/auth/admins.test.mjs
@@ -1,0 +1,218 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestGet, onRequestPost, onRequestDelete } from "./admins.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function mkKV() {
+    const store = new Map();
+    return {
+        get: async (k) => store.get(k) ?? null,
+        put: async (k, v, opts) => store.set(k, v),
+        delete: async (k) => store.delete(k),
+    };
+}
+
+function stubDB(overrides = {}) {
+    const noop = { meta: {} };
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([p]) =>
+                new RegExp(p, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => noop,
+            };
+            return stmt;
+        },
+    };
+}
+
+function auditDB(overrides = {}) {
+    return stubDB({
+        ...overrides,
+        "INSERT INTO audit_log": () => null,
+        "SELECT id, ts, prev_hash FROM audit_log ORDER BY ts DESC": () => ({
+            id: "01X", ts: "2026-04-24T00:00:00Z", prev_hash: "abc",
+        }),
+    });
+}
+
+function authReq(url, opts = {}) {
+    return new Request(url, {
+        ...opts,
+        headers: { Authorization: "Bearer adm", ...(opts.headers || {}) },
+    });
+}
+
+function postAuth(url, body) {
+    return authReq(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+function deleteAuth(url, body) {
+    return authReq(url, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+// ── GET list ──────────────────────────────────────────────────────────
+
+test("admins GET: unauthorized → 401", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: new Request(`${BASE}/api/admin/auth/admins`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("admins GET: returns admin list with passkey counts", async () => {
+    const db = stubDB({
+        "FROM admin_users ORDER": () => [
+            { id: 1, email: "admin@test.com", role: "owner", display_name: null, created_at: "2026-04-24" },
+        ],
+        "FROM admin_passkeys GROUP BY": () => [
+            { admin_id: 1, count: 2 },
+        ],
+    });
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: authReq(`${BASE}/api/admin/auth/admins`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.admins.length, 1);
+    assert.equal(j.admins[0].passkey_count, 2);
+    assert.equal(j.your_role, "owner");
+});
+
+// ── POST invite ───────────────────────────────────────────────────────
+
+test("admins POST: unauthorized → 401", async () => {
+    const r = await onRequestPost({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: new Request(`${BASE}/api/admin/auth/admins`, { method: "POST" }),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("admins POST: bearer (owner role) succeeds at role check", async () => {
+    const db = auditDB({
+        "INSERT INTO admin_users": () => null,
+        "SELECT id, email, role FROM admin_users": () => ({ id: 5, email: "new@test.com", role: "admin" }),
+    });
+    const r = await onRequestPost({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: postAuth(`${BASE}/api/admin/auth/admins`, { email: "new@test.com", role: "admin" }),
+    });
+    assert.equal(r.status, 200);
+});
+
+test("admins POST: invalid email → 400", async () => {
+    const r = await onRequestPost({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: postAuth(`${BASE}/api/admin/auth/admins`, { email: "notanemail" }),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "invalid_email");
+});
+
+test("admins POST: invalid role → 400", async () => {
+    const r = await onRequestPost({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: postAuth(`${BASE}/api/admin/auth/admins`, { email: "new@test.com", role: "superadmin" }),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "invalid_role");
+});
+
+test("admins POST: duplicate email → 409", async () => {
+    const db = auditDB({
+        "SELECT id FROM admin_users WHERE lower": () => ({ id: 1 }),
+    });
+    const r = await onRequestPost({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: postAuth(`${BASE}/api/admin/auth/admins`, { email: "existing@test.com" }),
+    });
+    assert.equal(r.status, 409);
+});
+
+test("admins POST: valid invite → 200", async () => {
+    const db = auditDB({
+        "INSERT INTO admin_users": () => null,
+        "SELECT id, email, role FROM admin_users": () => ({ id: 5, email: "new@test.com", role: "admin" }),
+    });
+    const r = await onRequestPost({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: postAuth(`${BASE}/api/admin/auth/admins`, { email: "new@test.com", role: "admin" }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.admin.email, "new@test.com");
+    assert.equal(j.admin.role, "admin");
+});
+
+// ── DELETE ─────────────────────────────────────────────────────────────
+
+test("admins DELETE: unauthorized → 401", async () => {
+    const r = await onRequestDelete({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: new Request(`${BASE}/api/admin/auth/admins`, { method: "DELETE" }),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("admins DELETE: missing admin_id → 400", async () => {
+    const r = await onRequestDelete({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: deleteAuth(`${BASE}/api/admin/auth/admins`, {}),
+    });
+    assert.equal(r.status, 400);
+});
+
+test("admins DELETE: self-remove → 400", async () => {
+    const r = await onRequestDelete({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: deleteAuth(`${BASE}/api/admin/auth/admins`, { admin_id: 0 }),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "cannot_remove_self");
+});
+
+test("admins DELETE: not found → 404", async () => {
+    const r = await onRequestDelete({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: deleteAuth(`${BASE}/api/admin/auth/admins`, { admin_id: 999 }),
+    });
+    assert.equal(r.status, 404);
+});
+
+test("admins DELETE: valid → 200", async () => {
+    const db = auditDB({
+        "SELECT id, email, role FROM admin_users WHERE id": () => ({ id: 5, email: "other@test.com", role: "admin" }),
+        "DELETE FROM admin_passkeys": () => null,
+        "DELETE FROM admin_users": () => null,
+    });
+    const r = await onRequestDelete({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: deleteAuth(`${BASE}/api/admin/auth/admins`, { admin_id: 5 }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+});

--- a/pages/functions/api/admin/auth/me.js
+++ b/pages/functions/api/admin/auth/me.js
@@ -1,0 +1,18 @@
+import { json, isAdmin } from "../../../_lib.js";
+
+export async function onRequestGet({ request, env }) {
+    const admin = await isAdmin(env, request);
+    if (!admin) return json({ error: "unauthorized" }, 401);
+
+    const passkeys = await env.DB.prepare(
+        "SELECT COUNT(*) as count FROM admin_passkeys WHERE admin_id = ?1"
+    ).bind(admin.id).first();
+
+    return json({
+        ok: true,
+        id: admin.id,
+        email: admin.email,
+        role: admin.role,
+        passkey_count: passkeys ? passkeys.count : 0,
+    });
+}

--- a/pages/functions/api/admin/auth/me.test.mjs
+++ b/pages/functions/api/admin/auth/me.test.mjs
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestGet } from "./me.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function mkKV() {
+    const store = new Map();
+    return {
+        get: async (k) => store.get(k) ?? null,
+        put: async (k, v) => store.set(k, v),
+        delete: async (k) => store.delete(k),
+    };
+}
+
+function stubDB(overrides = {}) {
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([p]) =>
+                new RegExp(p, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => ({ meta: {} }),
+            };
+            return stmt;
+        },
+    };
+}
+
+test("me: unauthorized → 401", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: new Request(`${BASE}/api/admin/auth/me`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("me: returns admin identity and role", async () => {
+    const db = stubDB({
+        "COUNT.*FROM admin_passkeys": () => ({ count: 3 }),
+    });
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: new Request(`${BASE}/api/admin/auth/me`, {
+            headers: { Authorization: "Bearer adm" },
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.role, "owner");
+    assert.equal(j.email, "__bearer__");
+});

--- a/pages/functions/api/admin/auth/passkey-auth.test.mjs
+++ b/pages/functions/api/admin/auth/passkey-auth.test.mjs
@@ -1,0 +1,107 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestPost as authOptions } from "./passkey/auth-options.js";
+import { onRequestPost as authVerify } from "./passkey/auth-verify.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function mkKV() {
+    const store = new Map();
+    return {
+        get: async (k, fmt) => {
+            const v = store.get(k) ?? null;
+            return fmt === "json" && v ? JSON.parse(v) : v;
+        },
+        put: async (k, v, opts) => store.set(k, typeof v === "string" ? v : JSON.stringify(v)),
+        delete: async (k) => store.delete(k),
+    };
+}
+
+function stubDB(overrides = {}) {
+    const noop = { meta: {} };
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([p]) =>
+                new RegExp(p, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => noop,
+            };
+            return stmt;
+        },
+    };
+}
+
+test("passkey auth-options: rate limited after 10 requests", async () => {
+    const kv = mkKV();
+    const env = { RATE_KV: kv, DB: stubDB() };
+    for (let i = 0; i < 10; i++) {
+        const r = await authOptions({
+            request: new Request(`${BASE}/api/admin/auth/passkey/auth-options`, { method: "POST" }),
+            env,
+        });
+        assert.equal(r.status, 200);
+    }
+    const r = await authOptions({
+        request: new Request(`${BASE}/api/admin/auth/passkey/auth-options`, { method: "POST" }),
+        env,
+    });
+    assert.equal(r.status, 429);
+});
+
+test("passkey auth-options: returns challenge and rpId", async () => {
+    const kv = mkKV();
+    const r = await authOptions({
+        request: new Request(`${BASE}/api/admin/auth/passkey/auth-options`, { method: "POST" }),
+        env: { RATE_KV: kv, DB: stubDB() },
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.ok(j.challenge);
+    assert.equal(j.rpId, "sc-cpe-web.pages.dev");
+    assert.equal(j.userVerification, "preferred");
+});
+
+test("passkey auth-verify: missing credential → 400", async () => {
+    const r = await authVerify({
+        request: new Request(`${BASE}/api/admin/auth/passkey/auth-verify`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({}),
+        }),
+        env: { DB: stubDB(), RATE_KV: mkKV() },
+    });
+    assert.equal(r.status, 400);
+});
+
+test("passkey auth-verify: invalid challenge → 400", async () => {
+    const fakeClientData = btoa(JSON.stringify({
+        type: "webauthn.get",
+        challenge: "nonexistent_challenge",
+        origin: BASE,
+    })).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+
+    const r = await authVerify({
+        request: new Request(`${BASE}/api/admin/auth/passkey/auth-verify`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                id: "cred123",
+                response: {
+                    clientDataJSON: fakeClientData,
+                    authenticatorData: "AAAA",
+                    signature: "AAAA",
+                },
+            }),
+        }),
+        env: { DB: stubDB(), RATE_KV: mkKV() },
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "invalid_challenge");
+});

--- a/pages/functions/api/admin/auth/passkey/auth-options.js
+++ b/pages/functions/api/admin/auth/passkey/auth-options.js
@@ -1,0 +1,29 @@
+import { json, clientIp, ipHash, rateLimit } from "../../../../_lib.js";
+import { generateChallenge, buildAuthenticationOptions } from "../_webauthn.js";
+
+const MAX_PER_HOUR = 10;
+
+export async function onRequestPost({ request, env }) {
+    const ip = clientIp(request);
+    const ipH = await ipHash(ip);
+    const hourBucket = new Date().toISOString().slice(0, 13);
+    const rl = await rateLimit(env, "passkey_auth:" + ipH + ":" + hourBucket, MAX_PER_HOUR);
+    if (!rl.ok) {
+        if (rl.status === 429) return json({ error: "rate_limited" }, 429);
+        return json(rl.body, rl.status);
+    }
+
+    const url = new URL(request.url);
+    const rpId = url.hostname;
+    const challenge = generateChallenge();
+
+    const options = buildAuthenticationOptions({ rpId, challenge });
+
+    await env.RATE_KV.put(
+        "webauthn_challenge:" + challenge,
+        JSON.stringify({ challenge, type: "auth" }),
+        { expirationTtl: 300 },
+    );
+
+    return json(options);
+}

--- a/pages/functions/api/admin/auth/passkey/auth-verify.js
+++ b/pages/functions/api/admin/auth/passkey/auth-verify.js
@@ -1,0 +1,90 @@
+import { json, audit, clientIp, ipHash, securityEvent } from "../../../../_lib.js";
+import {
+    buildSessionCookie, sessionCookieHeader, SESSION_MAX_AGE,
+} from "../_auth_helpers.js";
+import { verifyAuthentication, b64urlDecode } from "../_webauthn.js";
+
+export async function onRequestPost({ request, env }) {
+    let body;
+    try { body = await request.json(); }
+    catch { return json({ error: "invalid_json" }, 400); }
+
+    if (!body.id || !body.response) return json({ error: "missing_credential" }, 400);
+
+    const clientDataRaw = body.response.clientDataJSON;
+    if (!clientDataRaw) return json({ error: "missing_client_data" }, 400);
+
+    let clientData;
+    try {
+        const decoded = atob(clientDataRaw.replace(/-/g, "+").replace(/_/g, "/"));
+        clientData = JSON.parse(decoded);
+    } catch { return json({ error: "invalid_client_data" }, 400); }
+
+    const challenge = clientData.challenge;
+    if (!challenge) return json({ error: "missing_challenge" }, 400);
+
+    const stored = await env.RATE_KV.get("webauthn_challenge:" + challenge, "json");
+    if (!stored || stored.type !== "auth") {
+        return json({ error: "invalid_challenge" }, 400);
+    }
+    await env.RATE_KV.delete("webauthn_challenge:" + challenge);
+
+    const credentialId = body.id;
+    const row = await env.DB.prepare(
+        `SELECT p.id, p.admin_id, p.credential_id, p.public_key, p.counter,
+                a.email, a.role
+         FROM admin_passkeys p
+         JOIN admin_users a ON a.id = p.admin_id
+         WHERE p.credential_id = ?1`
+    ).bind(credentialId).first();
+
+    if (!row) {
+        securityEvent(env, "auth_fail:passkey", "unknown credential").catch(() => {});
+        return json({ error: "unknown_credential" }, 401);
+    }
+
+    const url = new URL(request.url);
+    let result;
+    try {
+        result = await verifyAuthentication({
+            response: body.response,
+            expectedChallenge: challenge,
+            expectedOrigin: url.origin,
+            expectedRpId: url.hostname,
+            credential: {
+                publicKey: row.public_key,
+                counter: row.counter,
+                alg: -7,
+            },
+        });
+    } catch (e) {
+        securityEvent(env, "auth_fail:passkey", e.message).catch(() => {});
+        return json({ error: "verification_failed", detail: e.message }, 401);
+    }
+
+    await env.DB.prepare(
+        "UPDATE admin_passkeys SET counter = ?1, last_used_at = datetime('now') WHERE id = ?2"
+    ).bind(result.signCount, row.id).run();
+
+    if (!env.ADMIN_COOKIE_SECRET) return json({ error: "server_config" }, 500);
+
+    const sessionExpires = Date.now() + SESSION_MAX_AGE;
+    const cookieValue = await buildSessionCookie(row.email, sessionExpires, env.ADMIN_COOKIE_SECRET);
+
+    const ip = clientIp(request);
+    const ipH = await ipHash(ip);
+    await audit(
+        env, "admin", row.admin_id, "admin_login", "admin_user", row.admin_id,
+        null, { method: "passkey", passkey_id: row.id },
+        { ip_hash: ipH, user_agent: request.headers.get("User-Agent") || null },
+    );
+
+    return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {
+            "Content-Type": "application/json",
+            "Cache-Control": "no-store",
+            "Set-Cookie": sessionCookieHeader(cookieValue),
+        },
+    });
+}

--- a/pages/functions/api/admin/auth/passkey/register-options.js
+++ b/pages/functions/api/admin/auth/passkey/register-options.js
@@ -1,0 +1,32 @@
+import { json, ulid, isAdmin } from "../../../../_lib.js";
+import { generateChallenge, buildRegistrationOptions } from "../_webauthn.js";
+
+export async function onRequestPost({ request, env }) {
+    const admin = await isAdmin(env, request);
+    if (!admin) return json({ error: "unauthorized" }, 401);
+
+    const url = new URL(request.url);
+    const rpId = url.hostname;
+    const challenge = generateChallenge();
+
+    const existing = await env.DB.prepare(
+        "SELECT credential_id, transports FROM admin_passkeys WHERE admin_id = ?1"
+    ).bind(admin.id).all();
+
+    const options = buildRegistrationOptions({
+        rpId,
+        rpName: "SC-CPE Admin",
+        userName: admin.email,
+        userId: String(admin.id),
+        challenge,
+        excludeCredentials: existing.results || [],
+    });
+
+    await env.RATE_KV.put(
+        "webauthn_challenge:" + challenge,
+        JSON.stringify({ challenge, adminId: admin.id, type: "register" }),
+        { expirationTtl: 300 },
+    );
+
+    return json(options);
+}

--- a/pages/functions/api/admin/auth/passkey/register-verify.js
+++ b/pages/functions/api/admin/auth/passkey/register-verify.js
@@ -11,14 +11,10 @@ export async function onRequestPost({ request, env }) {
 
     if (!body.id || !body.response) return json({ error: "missing_credential" }, 400);
 
-    const challengeKey = "webauthn_challenge:" + (body.response.clientDataJSON
-        ? undefined : "");
-
     const url = new URL(request.url);
     const expectedOrigin = url.origin;
     const expectedRpId = url.hostname;
 
-    const allChallenges = [];
     const clientDataJSON = body.response.clientDataJSON;
     if (!clientDataJSON) return json({ error: "missing_client_data" }, 400);
 

--- a/pages/functions/api/admin/auth/passkey/register-verify.js
+++ b/pages/functions/api/admin/auth/passkey/register-verify.js
@@ -1,0 +1,69 @@
+import { json, ulid, audit, isAdmin, clientIp, ipHash } from "../../../../_lib.js";
+import { verifyRegistration } from "../_webauthn.js";
+
+export async function onRequestPost({ request, env }) {
+    const admin = await isAdmin(env, request);
+    if (!admin) return json({ error: "unauthorized" }, 401);
+
+    let body;
+    try { body = await request.json(); }
+    catch { return json({ error: "invalid_json" }, 400); }
+
+    if (!body.id || !body.response) return json({ error: "missing_credential" }, 400);
+
+    const challengeKey = "webauthn_challenge:" + (body.response.clientDataJSON
+        ? undefined : "");
+
+    const url = new URL(request.url);
+    const expectedOrigin = url.origin;
+    const expectedRpId = url.hostname;
+
+    const allChallenges = [];
+    const clientDataJSON = body.response.clientDataJSON;
+    if (!clientDataJSON) return json({ error: "missing_client_data" }, 400);
+
+    const clientDataRaw = atob(clientDataJSON.replace(/-/g, "+").replace(/_/g, "/"));
+    let clientData;
+    try { clientData = JSON.parse(clientDataRaw); }
+    catch { return json({ error: "invalid_client_data" }, 400); }
+
+    const challenge = clientData.challenge;
+    if (!challenge) return json({ error: "missing_challenge" }, 400);
+
+    const stored = await env.RATE_KV.get("webauthn_challenge:" + challenge, "json");
+    if (!stored || stored.adminId !== admin.id || stored.type !== "register") {
+        return json({ error: "invalid_challenge" }, 400);
+    }
+    await env.RATE_KV.delete("webauthn_challenge:" + challenge);
+
+    let result;
+    try {
+        result = await verifyRegistration({
+            response: body.response,
+            expectedChallenge: challenge,
+            expectedOrigin,
+            expectedRpId,
+        });
+    } catch (e) {
+        return json({ error: "verification_failed", detail: e.message }, 400);
+    }
+
+    const id = ulid();
+    await env.DB.prepare(
+        `INSERT INTO admin_passkeys (id, admin_id, credential_id, public_key, counter, transports, backed_up)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)`
+    ).bind(
+        id, admin.id, result.credentialId, result.publicKey,
+        result.counter, JSON.stringify(result.transports), result.backedUp ? 1 : 0,
+    ).run();
+
+    const ip = clientIp(request);
+    const ipH = await ipHash(ip);
+    await audit(
+        env, "admin", admin.id, "passkey_registered", "admin_passkey", id,
+        null, { credential_id_prefix: result.credentialId.slice(0, 16) },
+        { ip_hash: ipH },
+    );
+
+    return json({ ok: true, passkey_id: id });
+}

--- a/pages/functions/api/admin/auth/passkeys.js
+++ b/pages/functions/api/admin/auth/passkeys.js
@@ -1,0 +1,50 @@
+import { json, isAdmin, audit, clientIp, ipHash } from "../../../_lib.js";
+
+export async function onRequestGet({ request, env }) {
+    const admin = await isAdmin(env, request);
+    if (!admin) return json({ error: "unauthorized" }, 401);
+
+    const rows = await env.DB.prepare(
+        "SELECT id, credential_id, backed_up, created_at, last_used_at FROM admin_passkeys WHERE admin_id = ?1 ORDER BY created_at"
+    ).bind(admin.id).all();
+
+    return json({
+        ok: true,
+        passkeys: (rows.results || []).map(r => ({
+            id: r.id,
+            credential_id_prefix: r.credential_id.slice(0, 16),
+            backed_up: !!r.backed_up,
+            created_at: r.created_at,
+            last_used_at: r.last_used_at,
+        })),
+    });
+}
+
+export async function onRequestDelete({ request, env }) {
+    const admin = await isAdmin(env, request);
+    if (!admin) return json({ error: "unauthorized" }, 401);
+
+    let body;
+    try { body = await request.json(); }
+    catch { return json({ error: "invalid_json" }, 400); }
+
+    const passkeyId = body.passkey_id;
+    if (!passkeyId) return json({ error: "missing_passkey_id" }, 400);
+
+    const row = await env.DB.prepare(
+        "SELECT id, credential_id FROM admin_passkeys WHERE id = ?1 AND admin_id = ?2"
+    ).bind(passkeyId, admin.id).first();
+    if (!row) return json({ error: "not_found" }, 404);
+
+    await env.DB.prepare("DELETE FROM admin_passkeys WHERE id = ?1").bind(passkeyId).run();
+
+    const ip = clientIp(request);
+    const ipH = await ipHash(ip);
+    await audit(
+        env, "admin", admin.id, "passkey_removed", "admin_passkey", passkeyId,
+        null, { credential_id_prefix: row.credential_id.slice(0, 16) },
+        { ip_hash: ipH },
+    );
+
+    return json({ ok: true });
+}

--- a/pages/functions/api/admin/auth/passkeys.test.mjs
+++ b/pages/functions/api/admin/auth/passkeys.test.mjs
@@ -1,0 +1,140 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestGet, onRequestDelete } from "./passkeys.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function mkKV() {
+    const store = new Map();
+    return {
+        get: async (k) => store.get(k) ?? null,
+        put: async (k, v) => store.set(k, v),
+        delete: async (k) => store.delete(k),
+    };
+}
+
+function stubDB(overrides = {}) {
+    const noop = { meta: {} };
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([p]) =>
+                new RegExp(p, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => noop,
+            };
+            return stmt;
+        },
+    };
+}
+
+function auditDB(overrides = {}) {
+    return stubDB({
+        ...overrides,
+        "INSERT INTO audit_log": () => null,
+        "SELECT id, ts, prev_hash FROM audit_log ORDER BY ts DESC": () => ({
+            id: "01X", ts: "2026-04-24T00:00:00Z", prev_hash: "abc",
+        }),
+    });
+}
+
+function authReq(url, opts = {}) {
+    return new Request(url, {
+        ...opts,
+        headers: { Authorization: "Bearer adm", ...(opts.headers || {}) },
+    });
+}
+
+// ── GET ───────────────────────────────────────────────────────────────
+
+test("passkeys GET: unauthorized → 401", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: new Request(`${BASE}/api/admin/auth/passkeys`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("passkeys GET: returns passkey list", async () => {
+    const db = stubDB({
+        "FROM admin_passkeys WHERE admin_id": () => [
+            { id: "PK1", credential_id: "abcdef1234567890xyz", backed_up: 1, created_at: "2026-04-24", last_used_at: null },
+        ],
+    });
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: authReq(`${BASE}/api/admin/auth/passkeys`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.passkeys.length, 1);
+    assert.equal(j.passkeys[0].backed_up, true);
+    assert.equal(j.passkeys[0].credential_id_prefix, "abcdef1234567890");
+});
+
+test("passkeys GET: empty → empty array", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: authReq(`${BASE}/api/admin/auth/passkeys`),
+    });
+    const j = await r.json();
+    assert.deepEqual(j.passkeys, []);
+});
+
+// ── DELETE ─────────────────────────────────────────────────────────────
+
+test("passkeys DELETE: unauthorized → 401", async () => {
+    const r = await onRequestDelete({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: new Request(`${BASE}/api/admin/auth/passkeys`, { method: "DELETE" }),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("passkeys DELETE: missing passkey_id → 400", async () => {
+    const r = await onRequestDelete({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: authReq(`${BASE}/api/admin/auth/passkeys`, {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({}),
+        }),
+    });
+    assert.equal(r.status, 400);
+});
+
+test("passkeys DELETE: not found → 404", async () => {
+    const r = await onRequestDelete({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: authReq(`${BASE}/api/admin/auth/passkeys`, {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ passkey_id: "NOTFOUND" }),
+        }),
+    });
+    assert.equal(r.status, 404);
+});
+
+test("passkeys DELETE: valid → 200", async () => {
+    const db = auditDB({
+        "FROM admin_passkeys WHERE id": () => ({ id: "PK1", credential_id: "abcdef1234567890xyz" }),
+        "DELETE FROM admin_passkeys": () => null,
+    });
+    const r = await onRequestDelete({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: authReq(`${BASE}/api/admin/auth/passkeys`, {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ passkey_id: "PK1" }),
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+});

--- a/pages/functions/api/admin/auth/webauthn.test.mjs
+++ b/pages/functions/api/admin/auth/webauthn.test.mjs
@@ -1,0 +1,109 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+    generateChallenge, buildRegistrationOptions,
+    buildAuthenticationOptions, b64url, b64urlDecode, decodeCBOR,
+} from "./_webauthn.js";
+
+test("generateChallenge: returns base64url string", () => {
+    const c = generateChallenge();
+    assert.ok(typeof c === "string");
+    assert.ok(c.length > 20);
+    assert.ok(!/[+/=]/.test(c), "should not contain +, /, or =");
+});
+
+test("generateChallenge: each call is unique", () => {
+    const a = generateChallenge();
+    const b = generateChallenge();
+    assert.notEqual(a, b);
+});
+
+test("b64url roundtrip", () => {
+    const original = new Uint8Array([0, 1, 2, 255, 254, 253]);
+    const encoded = b64url(original);
+    const decoded = b64urlDecode(encoded);
+    assert.deepEqual(decoded, original);
+});
+
+test("b64url: no unsafe chars", () => {
+    const data = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) data[i] = i;
+    const encoded = b64url(data);
+    assert.ok(!/[+/=]/.test(encoded));
+});
+
+test("buildRegistrationOptions: correct structure", () => {
+    const opts = buildRegistrationOptions({
+        rpId: "example.com",
+        rpName: "Test",
+        userName: "user@example.com",
+        userId: "123",
+        challenge: "test_challenge",
+        excludeCredentials: [],
+    });
+    assert.equal(opts.rp.id, "example.com");
+    assert.equal(opts.rp.name, "Test");
+    assert.equal(opts.user.name, "user@example.com");
+    assert.equal(opts.challenge, "test_challenge");
+    assert.equal(opts.attestation, "none");
+    assert.equal(opts.authenticatorSelection.residentKey, "required");
+    assert.ok(opts.pubKeyCredParams.some(p => p.alg === -7));
+    assert.ok(opts.pubKeyCredParams.some(p => p.alg === -257));
+});
+
+test("buildAuthenticationOptions: correct structure", () => {
+    const opts = buildAuthenticationOptions({
+        rpId: "example.com",
+        challenge: "test_challenge",
+    });
+    assert.equal(opts.rpId, "example.com");
+    assert.equal(opts.challenge, "test_challenge");
+    assert.equal(opts.userVerification, "preferred");
+});
+
+test("decodeCBOR: unsigned integer", () => {
+    const buf = new Uint8Array([0x05]);
+    assert.equal(decodeCBOR(buf), 5);
+});
+
+test("decodeCBOR: text string", () => {
+    const buf = new Uint8Array([0x63, 0x66, 0x6f, 0x6f]);
+    assert.equal(decodeCBOR(buf), "foo");
+});
+
+test("decodeCBOR: byte string", () => {
+    const buf = new Uint8Array([0x43, 0x01, 0x02, 0x03]);
+    const result = decodeCBOR(buf);
+    assert.ok(result instanceof Uint8Array);
+    assert.deepEqual([...result], [1, 2, 3]);
+});
+
+test("decodeCBOR: map", () => {
+    // {1: 2, 3: 4}
+    const buf = new Uint8Array([0xa2, 0x01, 0x02, 0x03, 0x04]);
+    const result = decodeCBOR(buf);
+    assert.ok(result instanceof Map);
+    assert.equal(result.get(1), 2);
+    assert.equal(result.get(3), 4);
+});
+
+test("decodeCBOR: array", () => {
+    // [1, 2, 3]
+    const buf = new Uint8Array([0x83, 0x01, 0x02, 0x03]);
+    const result = decodeCBOR(buf);
+    assert.ok(Array.isArray(result));
+    assert.deepEqual(result, [1, 2, 3]);
+});
+
+test("decodeCBOR: negative integer", () => {
+    // -1
+    const buf = new Uint8Array([0x20]);
+    assert.equal(decodeCBOR(buf), -1);
+});
+
+test("decodeCBOR: boolean and null", () => {
+    assert.equal(decodeCBOR(new Uint8Array([0xf4])), false);
+    assert.equal(decodeCBOR(new Uint8Array([0xf5])), true);
+    assert.equal(decodeCBOR(new Uint8Array([0xf6])), null);
+});

--- a/pages/functions/api/admin/email-suppression.test.mjs
+++ b/pages/functions/api/admin/email-suppression.test.mjs
@@ -1,0 +1,146 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestGet, onRequestDelete } from "./email-suppression.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function auth(url, opts = {}) {
+    return new Request(url, {
+        ...opts,
+        headers: { Authorization: "Bearer adm", ...(opts.headers || {}) },
+    });
+}
+
+function deleteAuth(url, body) {
+    return auth(url, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+function stubDB(overrides = {}) {
+    const noop = { meta: {} };
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([p]) =>
+                new RegExp(p, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => noop,
+            };
+            return stmt;
+        },
+    };
+}
+
+function auditDB(overrides = {}) {
+    return stubDB({
+        ...overrides,
+        "INSERT INTO audit_log": () => null,
+        "SELECT id, ts, prev_hash FROM audit_log ORDER BY ts DESC": () => ({
+            id: "01X", ts: "2026-04-24T00:00:00Z", prev_hash: "abc",
+        }),
+    });
+}
+
+function mkKV() {
+    const store = new Map();
+    return {
+        get: async (k) => store.get(k) ?? null,
+        put: async (k, v) => store.set(k, v),
+        delete: async (k) => store.delete(k),
+    };
+}
+
+// ── GET ────────────────────────────────────────────────────────────────
+
+test("email-suppression GET: unauthorized → 401", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: new Request(`${BASE}/api/admin/email-suppression`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("email-suppression GET: returns masked emails", async () => {
+    const db = stubDB({
+        "FROM email_suppression": () => [
+            { email: "bob@example.com", reason: "hard_bounce", event_id: "ev1", created_at: "2026-04-24T00:00:00Z" },
+        ],
+    });
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: auth(`${BASE}/api/admin/email-suppression`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.suppressions.length, 1);
+    assert.equal(j.suppressions[0].email_masked, "bob***@example.com");
+    assert.equal(j.suppressions[0].reason, "hard_bounce");
+});
+
+test("email-suppression GET: empty → empty array", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: auth(`${BASE}/api/admin/email-suppression`),
+    });
+    const j = await r.json();
+    assert.deepEqual(j.suppressions, []);
+});
+
+// ── DELETE ─────────────────────────────────────────────────────────────
+
+test("email-suppression DELETE: unauthorized → 401", async () => {
+    const r = await onRequestDelete({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm" },
+        request: new Request(`${BASE}/api/admin/email-suppression`, { method: "DELETE" }),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("email-suppression DELETE: missing email → 400", async () => {
+    const r = await onRequestDelete({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm" },
+        request: deleteAuth(`${BASE}/api/admin/email-suppression`, {}),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "invalid_email");
+});
+
+test("email-suppression DELETE: email without @ → 400", async () => {
+    const r = await onRequestDelete({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm" },
+        request: deleteAuth(`${BASE}/api/admin/email-suppression`, { email: "notanemail" }),
+    });
+    assert.equal(r.status, 400);
+});
+
+test("email-suppression DELETE: not found → 404", async () => {
+    const r = await onRequestDelete({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm" },
+        request: deleteAuth(`${BASE}/api/admin/email-suppression`, { email: "nobody@example.com" }),
+    });
+    assert.equal(r.status, 404);
+});
+
+test("email-suppression DELETE: valid → 200", async () => {
+    const db = auditDB({
+        "SELECT email FROM email_suppression": () => ({ email: "bob@example.com" }),
+        "DELETE FROM email_suppression": () => null,
+    });
+    const r = await onRequestDelete({
+        env: { DB: db, ADMIN_TOKEN: "adm" },
+        request: deleteAuth(`${BASE}/api/admin/email-suppression`, { email: "bob@example.com" }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+});

--- a/pages/functions/api/admin/streams.test.mjs
+++ b/pages/functions/api/admin/streams.test.mjs
@@ -1,0 +1,134 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestGet } from "./streams.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function auth(url) {
+    return new Request(url, {
+        headers: { Authorization: "Bearer adm" },
+    });
+}
+
+function stubDB(overrides = {}) {
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([p]) =>
+                new RegExp(p, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+            };
+            return stmt;
+        },
+    };
+}
+
+function mkKV() {
+    const store = new Map();
+    return {
+        get: async (k) => store.get(k) ?? null,
+        put: async (k, v) => store.set(k, v),
+        delete: async (k) => store.delete(k),
+    };
+}
+
+test("streams: unauthorized → 401", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: new Request(`${BASE}/api/admin/streams`),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("streams: no params → 200 with default 30 days", async () => {
+    let capturedBinds = [];
+    const db = {
+        prepare(sql) {
+            return {
+                bind(...args) { capturedBinds = args; return this; },
+                all: async () => ({ results: [
+                    { id: "01S", yt_video_id: "abc", title: "DTB", scheduled_date: "2026-04-24",
+                      state: "ended", actual_start_at: "2026-04-24T14:00:00Z",
+                      actual_end_at: "2026-04-24T15:00:00Z", attendance_count: 12 },
+                ] }),
+            };
+        },
+    };
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: auth(`${BASE}/api/admin/streams`),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.streams.length, 1);
+    assert.equal(j.streams[0].attendance_count, 12);
+    assert.equal(capturedBinds[0], 30);
+});
+
+test("streams: custom days param", async () => {
+    let capturedBinds = [];
+    const db = {
+        prepare(sql) {
+            return {
+                bind(...args) { capturedBinds = args; return this; },
+                all: async () => ({ results: [] }),
+            };
+        },
+    };
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: auth(`${BASE}/api/admin/streams?days=90`),
+    });
+    assert.equal(r.status, 200);
+    assert.equal(capturedBinds[0], 90);
+});
+
+test("streams: invalid days → defaults to 30", async () => {
+    let capturedBinds = [];
+    const db = {
+        prepare(sql) {
+            return {
+                bind(...args) { capturedBinds = args; return this; },
+                all: async () => ({ results: [] }),
+            };
+        },
+    };
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: auth(`${BASE}/api/admin/streams?days=-5`),
+    });
+    assert.equal(r.status, 200);
+    assert.equal(capturedBinds[0], 30);
+});
+
+test("streams: days > 365 → clamped to 30", async () => {
+    let capturedBinds = [];
+    const db = {
+        prepare(sql) {
+            return {
+                bind(...args) { capturedBinds = args; return this; },
+                all: async () => ({ results: [] }),
+            };
+        },
+    };
+    const r = await onRequestGet({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: auth(`${BASE}/api/admin/streams?days=999`),
+    });
+    assert.equal(r.status, 200);
+    assert.equal(capturedBinds[0], 30);
+});
+
+test("streams: empty result → empty array", async () => {
+    const r = await onRequestGet({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: auth(`${BASE}/api/admin/streams`),
+    });
+    const j = await r.json();
+    assert.deepEqual(j.streams, []);
+});

--- a/pages/functions/api/admin/suspend.test.mjs
+++ b/pages/functions/api/admin/suspend.test.mjs
@@ -1,0 +1,125 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { onRequestPost } from "./suspend.js";
+
+const BASE = "https://sc-cpe-web.pages.dev";
+
+function postAuth(url, body) {
+    return new Request(url, {
+        method: "POST",
+        headers: { Authorization: "Bearer adm", "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+function stubDB(overrides = {}) {
+    const noop = { meta: {} };
+    return {
+        prepare(sql) {
+            const handler = Object.entries(overrides).find(([p]) =>
+                new RegExp(p, "i").test(sql)
+            );
+            let binds = [];
+            const stmt = {
+                bind(...args) { binds = args; return stmt; },
+                first: async () => handler ? handler[1](sql, binds) : null,
+                all: async () => handler ? { results: handler[1](sql, binds) } : { results: [] },
+                run: async () => noop,
+            };
+            return stmt;
+        },
+    };
+}
+
+function auditDB(overrides = {}) {
+    return stubDB({
+        ...overrides,
+        "INSERT INTO audit_log": () => null,
+        "SELECT id, ts, prev_hash FROM audit_log ORDER BY ts DESC": () => ({
+            id: "01X", ts: "2026-04-24T00:00:00Z", prev_hash: "abc",
+        }),
+    });
+}
+
+function mkKV() {
+    const store = new Map();
+    return {
+        get: async (k) => store.get(k) ?? null,
+        put: async (k, v) => store.set(k, v),
+        delete: async (k) => store.delete(k),
+    };
+}
+
+test("suspend: unauthorized → 401", async () => {
+    const r = await onRequestPost({
+        env: { DB: stubDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: new Request(`${BASE}/api/admin/suspend`, { method: "POST" }),
+    });
+    assert.equal(r.status, 401);
+});
+
+test("suspend: missing user_id → 400", async () => {
+    const r = await onRequestPost({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: postAuth(`${BASE}/api/admin/suspend`, { suspended: true, reason: "test" }),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "invalid_user_id");
+});
+
+test("suspend: missing reason → 400", async () => {
+    const r = await onRequestPost({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: postAuth(`${BASE}/api/admin/suspend`, { user_id: "01USERID1234", suspended: true }),
+    });
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error, "reason_required_under_500_chars");
+});
+
+test("suspend: user not found → 404", async () => {
+    const r = await onRequestPost({
+        env: { DB: auditDB(), ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: postAuth(`${BASE}/api/admin/suspend`, {
+            user_id: "01NOTFOUND12", suspended: true, reason: "Abuse",
+        }),
+    });
+    assert.equal(r.status, 404);
+});
+
+test("suspend: valid suspension → 200", async () => {
+    const db = auditDB({
+        "FROM users WHERE id": () => ({ id: "01USERID1234", state: "active", suspended_at: null }),
+        "UPDATE users SET suspended_at": () => null,
+    });
+    const r = await onRequestPost({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: postAuth(`${BASE}/api/admin/suspend`, {
+            user_id: "01USERID1234", suspended: true, reason: "Abuse detected",
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.user_id, "01USERID1234");
+    assert.ok(j.suspended_at);
+});
+
+test("suspend: unsuspend → 200 with null suspended_at", async () => {
+    const db = auditDB({
+        "FROM users WHERE id": () => ({ id: "01USERID1234", state: "active", suspended_at: "2026-04-20T00:00:00Z" }),
+        "UPDATE users SET suspended_at": () => null,
+    });
+    const r = await onRequestPost({
+        env: { DB: db, ADMIN_TOKEN: "adm", RATE_KV: mkKV() },
+        request: postAuth(`${BASE}/api/admin/suspend`, {
+            user_id: "01USERID1234", suspended: false, reason: "Appeal resolved",
+        }),
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.suspended_at, null);
+});

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -41,4 +41,9 @@ node --test \
     pages/functions/api/admin/export.test.mjs \
     pages/functions/api/admin/streams.test.mjs \
     pages/functions/api/admin/suspend.test.mjs \
-    pages/functions/api/admin/email-suppression.test.mjs
+    pages/functions/api/admin/email-suppression.test.mjs \
+    pages/functions/api/admin/auth/webauthn.test.mjs \
+    pages/functions/api/admin/auth/passkey-auth.test.mjs \
+    pages/functions/api/admin/auth/passkeys.test.mjs \
+    pages/functions/api/admin/auth/admins.test.mjs \
+    pages/functions/api/admin/auth/me.test.mjs

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -38,4 +38,7 @@ node --test \
     workers/email-sender/src/email-sender.test.mjs \
     workers/purge/src/scheduled-tasks.test.mjs \
     pages/functions/api/admin/audit-log.test.mjs \
-    pages/functions/api/admin/export.test.mjs
+    pages/functions/api/admin/export.test.mjs \
+    pages/functions/api/admin/streams.test.mjs \
+    pages/functions/api/admin/suspend.test.mjs \
+    pages/functions/api/admin/email-suppression.test.mjs


### PR DESCRIPTION
## Summary
- **Passkey/WebAuthn login**: instant biometric login for admin dashboard — no email wait. Manual WebAuthn implementation using Web Crypto API (zero npm dependencies). Supports ES256 (P-256) and RS256 passkeys.
- **7-day sessions**: session cookie extended from 24h to 7 days, reducing daily re-login friction.
- **Admin identity + roles**: `isAdmin()` now returns `{ id, email, role }` instead of boolean. Two roles: `owner` (full control, admin management) and `admin` (operator). Bearer token treated as `owner`.
- **Admin management UI**: owners can invite admins by email (sends magic link invite), view admin list with passkey counts, and remove admins. Owner-only section in dashboard.
- **Passkey management**: register, list, and remove passkeys from the dashboard. Login page shows "Sign in with passkey" button when WebAuthn is supported.
- **Migration 014**: `admin_passkeys` table for WebAuthn credentials, `invited_by`/`display_name` columns on `admin_users`, owner role upgrade.

## New endpoints
| Endpoint | Method | Purpose |
|----------|--------|---------|
| `/api/admin/auth/passkey/register-options` | POST | Generate WebAuthn registration challenge |
| `/api/admin/auth/passkey/register-verify` | POST | Verify and store passkey registration |
| `/api/admin/auth/passkey/auth-options` | POST | Generate WebAuthn authentication challenge |
| `/api/admin/auth/passkey/auth-verify` | POST | Verify passkey login, issue session cookie |
| `/api/admin/auth/passkeys` | GET/DELETE | List/remove own passkeys |
| `/api/admin/auth/admins` | GET/POST/DELETE | List/invite/remove admin accounts (owner-only) |
| `/api/admin/auth/me` | GET | Current admin identity + role |

## Test plan
- [x] Full test suite passes (460 tests, 0 failures)
- [ ] Deploy to preview, verify passkey enrollment flow
- [ ] Verify passkey login after enrollment
- [ ] Verify 7-day session persists across browser restarts
- [ ] Verify admin invite sends email with magic link
- [ ] Verify operator role cannot access admin management endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)