### PR TITLE
feat(dashboard): Phase B polish — card priority, getting started, settings accordion

### DIFF
--- a/pages/dashboard.css
+++ b/pages/dashboard.css
@@ -336,3 +336,78 @@
 .btn-x { background: #000; color: #fff; border: 0; text-decoration: none; }
 .btn-x:hover { background: #333; filter: none; }
 .badge-preview img { max-width: 100%; border-radius: 12px; }
+
+/* ── Today card live-pulse ────────────────────────── */
+.today-card.today-live {
+    border-left: 4px solid var(--ok);
+    animation: live-pulse 2s ease-in-out infinite;
+}
+@keyframes live-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
+    50% { box-shadow: 0 0 12px 2px rgba(34, 197, 94, 0.15); }
+}
+.today-card.today-credited { border-left: 4px solid var(--ok); }
+.today-card.today-ended { border-left: 4px solid var(--warn); }
+
+/* ── Getting Started checklist ────────────────────── */
+.getting-started { border-left: 4px solid var(--accent); }
+.gs-steps {
+    display: flex; align-items: center; gap: 0;
+    margin: 12px 0 8px; flex-wrap: nowrap; justify-content: center;
+}
+.gs-step { display: flex; flex-direction: column; align-items: center; gap: 4px; min-width: 80px; }
+.gs-dot {
+    width: 28px; height: 28px; border-radius: 50%;
+    border: 2px solid var(--border-strong); background: var(--card);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 14px; font-weight: 700; color: var(--muted);
+    transition: all 0.3s;
+}
+.gs-dot.gs-done { background: var(--ok); border-color: var(--ok); color: #fff; }
+.gs-dot.gs-done::after { content: "\2713"; }
+.gs-dot.gs-next { border-color: var(--accent); color: var(--accent); animation: gs-pulse 1.5s ease-in-out infinite; }
+@keyframes gs-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0); }
+    50% { box-shadow: 0 0 8px 2px rgba(59, 130, 246, 0.25); }
+}
+.gs-connector { width: 32px; height: 2px; background: var(--border); margin: 0 4px; flex-shrink: 1; min-width: 12px; margin-bottom: 20px; }
+.gs-connector.gs-done { background: var(--ok); }
+.gs-label { font-size: 11px; color: var(--muted); text-align: center; font-weight: 600; }
+.gs-step.gs-active .gs-label { color: var(--accent); }
+.gs-hint { font-size: 12px; text-align: center; margin-top: 4px; }
+
+/* ── Settings accordion ───────────────────────────── */
+.settings-accordion { margin-top: 2rem; }
+.settings-accordion > summary {
+    cursor: pointer; list-style: none;
+    font-size: 0.85rem; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 1.5px; color: var(--muted);
+    padding-bottom: 6px; border-bottom: 1px solid var(--border);
+    user-select: none;
+}
+.settings-accordion > summary::-webkit-details-marker { display: none; }
+.settings-accordion > summary::after { content: " \25B6"; font-size: 10px; margin-left: 6px; }
+.settings-accordion[open] > summary::after { content: " \25BC"; }
+.settings-inner { margin-top: 0.5rem; }
+.settings-inner > .card { margin-bottom: 0.75rem; }
+
+/* ── Toast notifications ──────────────────────────── */
+.toast-container {
+    position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
+    z-index: 600; display: flex; flex-direction: column; gap: 8px;
+    align-items: center; pointer-events: none;
+}
+.toast {
+    padding: 10px 20px; border-radius: 6px; font-size: 14px; font-weight: 600;
+    pointer-events: auto; animation: toast-in 0.3s ease-out, toast-out 0.3s ease-in 2.7s forwards;
+    max-width: 90vw; text-align: center;
+}
+.toast-ok { background: var(--ok-soft-bg); color: var(--ok-soft-text); border: 1px solid var(--ok); }
+.toast-err { background: var(--bad-soft-bg); color: var(--bad-soft-text); border: 1px solid var(--bad); }
+@keyframes toast-in { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes toast-out { from { opacity: 1; } to { opacity: 0; } }
+
+@media (prefers-reduced-motion: reduce) {
+    .today-card.today-live, .gs-dot.gs-next, .toast { animation: none; }
+    .skeleton { animation: none; }
+}

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -72,6 +72,16 @@
             <p>Your account has been suspended. You will not earn attendance credit until the suspension is lifted. If you believe this is an error, please contact the Simply Cyber team.</p>
         </div>
 
+        <div id="today-card" class="card today-card" hidden>
+            <h2 class="card-heading">Today's Daily Threat Briefing</h2>
+            <p id="today-title" class="muted"></p>
+            <p id="today-status"></p>
+            <p id="today-hint" class="muted" hidden>
+                Post a qualifying message (3+ characters, letters or numbers) in the
+                live chat to get credited. This page refreshes automatically.
+            </p>
+        </div>
+
         <div id="window-warn-card" class="card window-warn" hidden>
             <h2 class="card-heading">Code posted outside the live window</h2>
             <p id="window-warn-body"></p>
@@ -82,7 +92,28 @@
             </p>
         </div>
 
-        <div class="card">
+        <div id="getting-started" class="card getting-started" hidden>
+            <h2 class="card-heading">Getting started</h2>
+            <div class="gs-steps">
+                <div class="gs-step" id="gs-register">
+                    <div class="gs-dot gs-done"></div>
+                    <div class="gs-label">Register</div>
+                </div>
+                <div class="gs-connector"></div>
+                <div class="gs-step" id="gs-verify">
+                    <div class="gs-dot"></div>
+                    <div class="gs-label">Verify in chat</div>
+                </div>
+                <div class="gs-connector"></div>
+                <div class="gs-step" id="gs-first-cpe">
+                    <div class="gs-dot"></div>
+                    <div class="gs-label">First CPE earned</div>
+                </div>
+            </div>
+            <p id="gs-hint" class="muted gs-hint"></p>
+        </div>
+
+        <div class="card" id="identity-card">
             <h2 id="name"></h2>
             <p>Status: <strong id="state"></strong></p>
             <div id="pending" hidden>
@@ -150,16 +181,6 @@
             <a id="profile-link" class="share-btn" style="display:none;margin-left:8px;font-size:.8rem;" target="_blank" rel="noopener">View public profile</a>
         </div>
 
-        <div class="card" id="today-card" hidden>
-            <h2 class="card-heading">Today's Daily Threat Briefing</h2>
-            <p id="today-title" class="muted"></p>
-            <p id="today-status"></p>
-            <p id="today-hint" class="muted" hidden>
-                Post a qualifying message (3+ characters, letters or numbers) in the
-                live chat to get credited. This page refreshes automatically.
-            </p>
-        </div>
-
         <div class="card link-card" id="link-card" hidden>
             <h2 class="card-heading">Link your YouTube channel</h2>
             <p class="muted remember-desc">
@@ -205,7 +226,7 @@
             </div>
         </div>
 
-        <div class="card">
+        <div class="card" id="calendar-card">
             <h2>Attendance calendar</h2>
             <div class="cal-nav">
                 <button type="button" id="cal-prev" aria-label="previous month">&lsaquo;</button>
@@ -221,94 +242,97 @@
             </p>
         </div>
 
-        <div class="card">
+        <div class="card" id="attendance-card">
             <h2>Attendance history</h2>
             <div id="att" class="att-list" hidden></div>
-            <p id="att-empty" hidden class="muted">No attendance records yet. See you at the next Daily Threat Briefing.</p>
+            <p id="att-empty" hidden class="muted">No attendance records yet. The Daily Threat Briefing streams weekdays at 8:00 AM ET. Post any 3+ character message in the live chat to earn 0.5 CPE per session.</p>
         </div>
 
-        <div class="card">
+        <div class="card" id="certs-card">
             <h2>Certificates</h2>
             <div id="cert-dl-bar" class="cert-dl-bar" hidden>
                 <button type="button" id="cert-dl-btn">Download All (ZIP)</button>
                 <span class="dl-status" id="cert-dl-status"></span>
             </div>
             <div id="certs" class="cert-list" hidden></div>
-            <p id="cert-empty" hidden class="muted">No certificates yet. Certs are issued monthly.</p>
+            <p id="cert-empty" hidden class="muted">No certificates yet. Certificates are issued at the start of each month for the prior month's attendance. Attend your first briefing and your first cert will arrive next month.</p>
             <p class="muted cert-footer">
                 If a name or session count looks wrong, tap <strong>Report an issue</strong>
                 on the cert — feedback goes straight to the admin digest so we can reissue.
             </p>
         </div>
 
-        <h2 class="section-heading">Settings</h2>
-
-        <div class="card" id="renewal-card" hidden>
-            <h2 class="card-heading">Certification renewal tracker</h2>
-            <div id="renewal-display" hidden>
-                <div class="renewal-summary" id="renewal-summary"></div>
-                <div class="renewal-bar-track"><div class="renewal-bar-fill" id="renewal-bar"></div></div>
-                <div class="renewal-deadline" id="renewal-deadline"></div>
-                <button type="button" class="renewal-edit-btn" id="renewal-edit-btn">Edit</button>
-                <button type="button" class="renewal-edit-btn renewal-remove-btn" id="renewal-remove-btn">Remove</button>
-            </div>
-            <div id="renewal-setup">
-                <p class="muted rotate-desc">Track progress toward your certification renewal CPE requirement.</p>
-                <form class="renewal-form" id="renewal-form">
-                    <label>Certification name <input type="text" id="renewal-cert-name" placeholder="CISSP, CISM, etc." maxlength="100" required></label>
-                    <label>Renewal deadline <input type="date" id="renewal-deadline-input" required></label>
-                    <label>CPE required <input type="number" id="renewal-cpe-req" min="1" max="9999" placeholder="60" required></label>
-                    <div class="renewal-actions">
-                        <button type="submit">Save</button>
-                        <button type="button" class="appeal-cancel" id="renewal-cancel-btn" hidden>Cancel</button>
+        <details class="settings-accordion" id="settings-section">
+            <summary class="section-heading">Settings</summary>
+            <div class="settings-inner">
+                <div class="card" id="renewal-card" hidden>
+                    <h2 class="card-heading">Certification renewal tracker</h2>
+                    <div id="renewal-display" hidden>
+                        <div class="renewal-summary" id="renewal-summary"></div>
+                        <div class="renewal-bar-track"><div class="renewal-bar-fill" id="renewal-bar"></div></div>
+                        <div class="renewal-deadline" id="renewal-deadline"></div>
+                        <button type="button" class="renewal-edit-btn" id="renewal-edit-btn">Edit</button>
+                        <button type="button" class="renewal-edit-btn renewal-remove-btn" id="renewal-remove-btn">Remove</button>
                     </div>
-                    <span id="renewal-msg" class="muted prefs-hint" hidden></span>
-                </form>
-            </div>
-        </div>
+                    <div id="renewal-setup">
+                        <p class="muted rotate-desc">Track progress toward your certification renewal CPE requirement.</p>
+                        <form class="renewal-form" id="renewal-form">
+                            <label>Certification name <input type="text" id="renewal-cert-name" placeholder="CISSP, CISM, etc." maxlength="100" required></label>
+                            <label>Renewal deadline <input type="date" id="renewal-deadline-input" required></label>
+                            <label>CPE required <input type="number" id="renewal-cpe-req" min="1" max="9999" placeholder="60" required></label>
+                            <div class="renewal-actions">
+                                <button type="submit">Save</button>
+                                <button type="button" class="appeal-cancel" id="renewal-cancel-btn" hidden>Cancel</button>
+                            </div>
+                            <span id="renewal-msg" class="muted prefs-hint" hidden></span>
+                        </form>
+                    </div>
+                </div>
 
-        <div class="card" id="prefs-card" hidden>
-            <h2 class="card-heading">Certificate delivery</h2>
-            <p class="muted rotate-desc">
-                Most certification bodies (including (ISC)²) accept the
-                bundled monthly certificate. Pick individual per-session
-                certs only if your certification body specifically asks
-                for per-activity documentation at audit — uncommon.
-                You can also request a one-off per-session cert on any
-                attendance row above.
-            </p>
-            <div id="prefs-radios" class="prefs-radios">
-                <label><input type="radio" name="cert_style" value="bundled"> One monthly bundle <span class="muted prefs-hint">(recommended)</span></label>
-                <label><input type="radio" name="cert_style" value="per_session"> Individual cert for every attended session</label>
-                <label><input type="radio" name="cert_style" value="both"> Both (bundle + per-session)</label>
-            </div>
-            <p id="prefs-msg" class="muted prefs-hint" hidden></p>
-        </div>
+                <div class="card" id="prefs-card" hidden>
+                    <h2 class="card-heading">Certificate delivery</h2>
+                    <p class="muted rotate-desc">
+                        Most certification bodies (including (ISC)&sup2;) accept the
+                        bundled monthly certificate. Pick individual per-session
+                        certs only if your certification body specifically asks
+                        for per-activity documentation at audit — uncommon.
+                        You can also request a one-off per-session cert on any
+                        attendance row above.
+                    </p>
+                    <div id="prefs-radios" class="prefs-radios">
+                        <label><input type="radio" name="cert_style" value="bundled"> One monthly bundle <span class="muted prefs-hint">(recommended)</span></label>
+                        <label><input type="radio" name="cert_style" value="per_session"> Individual cert for every attended session</label>
+                        <label><input type="radio" name="cert_style" value="both"> Both (bundle + per-session)</label>
+                    </div>
+                    <p id="prefs-msg" class="muted prefs-hint" hidden></p>
+                </div>
 
-        <div class="card" id="email-prefs-card" hidden>
-            <h2 class="card-heading">Email preferences</h2>
-            <p class="muted rotate-desc">
-                Choose which engagement emails you receive. Transactional emails
-                (registration, cert delivery, security) are always sent.
-            </p>
-            <div class="prefs-radios" id="email-prefs-checks">
-                <label><input type="checkbox" data-cat="monthly_digest" checked> Monthly digest</label>
-                <label><input type="checkbox" data-cat="cert_nudge" checked> Certificate reminders</label>
-                <label><input type="checkbox" data-cat="renewal_nudge" checked> Renewal reminders</label>
-                <label><input type="checkbox" data-cat="streak_milestone" checked> Streak milestones</label>
-            </div>
-            <p id="email-prefs-msg" class="muted prefs-hint" hidden></p>
-        </div>
+                <div class="card" id="email-prefs-card" hidden>
+                    <h2 class="card-heading">Email preferences</h2>
+                    <p class="muted rotate-desc">
+                        Choose which engagement emails you receive. Transactional emails
+                        (registration, cert delivery, security) are always sent.
+                    </p>
+                    <div class="prefs-radios" id="email-prefs-checks">
+                        <label><input type="checkbox" data-cat="monthly_digest" checked> Monthly digest</label>
+                        <label><input type="checkbox" data-cat="cert_nudge" checked> Certificate reminders</label>
+                        <label><input type="checkbox" data-cat="renewal_nudge" checked> Renewal reminders</label>
+                        <label><input type="checkbox" data-cat="streak_milestone" checked> Streak milestones</label>
+                    </div>
+                    <p id="email-prefs-msg" class="muted prefs-hint" hidden></p>
+                </div>
 
-        <div class="card" id="leaderboard-card" hidden>
-            <h2 class="card-heading">Community leaderboard</h2>
-            <label class="check">
-                <input type="checkbox" id="leaderboard-toggle">
-                <span>Show me on the <a href="/leaderboard.html">community leaderboard</a>
-                <span class="muted leaderboard-hint">Your first name and last initial will be visible. Email and full name are never shown.</span></span>
-            </label>
-            <span id="leaderboard-msg" class="muted prefs-hint" hidden></span>
-        </div>
+                <div class="card" id="leaderboard-card" hidden>
+                    <h2 class="card-heading">Community leaderboard</h2>
+                    <label class="check">
+                        <input type="checkbox" id="leaderboard-toggle">
+                        <span>Show me on the <a href="/leaderboard.html">community leaderboard</a>
+                        <span class="muted leaderboard-hint">Your first name and last initial will be visible. Email and full name are never shown.</span></span>
+                    </label>
+                    <span id="leaderboard-msg" class="muted prefs-hint" hidden></span>
+                </div>
+            </div>
+        </details>
 
         <h2 class="section-heading">Account</h2>
 
@@ -381,6 +405,7 @@
         <a href="/terms.html">Terms</a>
         <a href="/privacy.html">Privacy</a>
     </footer>
+    <div id="toast-container" class="toast-container" aria-live="polite"></div>
 </main>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js" integrity="sha384-+mbV2IY1Zk/X1p/nWllGySJSUN8uMs+gUAN10Or95UBH0fpj6GfKgPmgC5EXieXG" crossorigin="anonymous" defer></script>
 <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -144,6 +144,9 @@ async function load() {
     document.getElementById("total").textContent = cpe.toFixed(1);
     document.getElementById("share-btn").hidden = cpe <= 0;
 
+    renderGettingStarted(d.user, cpe);
+    applyCardVisibility(d.user);
+
     renderWindowWarnings(d.code_window_warnings || []);
 
     calData = { attendance: d.attendance || [], appeals: d.appeals || [] };
@@ -611,9 +614,11 @@ document.getElementById("prefs-radios").addEventListener("change", async functio
             body: JSON.stringify({ cert_style: radio.value }),
         });
         if (!r.ok) throw new Error("HTTP " + r.status);
-        msg.textContent = "saved \u2014 next monthly run will respect this.";
+        msg.textContent = "saved";
+        showToast("Cert delivery preference saved", "ok");
     } catch (err) {
         msg.textContent = "failed: " + err.message;
+        showToast("Failed to save: " + err.message, "err");
     }
 });
 
@@ -693,10 +698,74 @@ function escapeHtml(s) {
     });
 }
 
+function showToast(message, type) {
+    var container = document.getElementById("toast-container");
+    if (!container) return;
+    var el = document.createElement("div");
+    el.className = "toast " + (type === "err" ? "toast-err" : "toast-ok");
+    el.textContent = message;
+    container.appendChild(el);
+    setTimeout(function () { el.remove(); }, 3100);
+}
+
+function renderGettingStarted(user, totalCpe) {
+    var card = document.getElementById("getting-started");
+    var isVerified = user.state === "active";
+    var hasChannel = !!user.yt_channel_id;
+    var isLinked = isVerified && hasChannel;
+    var hasCpe = totalCpe > 0;
+    if (isLinked && hasCpe) { card.hidden = true; return; }
+    card.hidden = false;
+    var step1 = document.getElementById("gs-register");
+    var step2 = document.getElementById("gs-verify");
+    var step3 = document.getElementById("gs-first-cpe");
+    var conn1 = step1.nextElementSibling;
+    var conn2 = step2.nextElementSibling;
+    var hint = document.getElementById("gs-hint");
+    step1.querySelector(".gs-dot").className = "gs-dot gs-done";
+    conn1.className = isLinked ? "gs-connector gs-done" : "gs-connector";
+    if (isLinked) {
+        step2.querySelector(".gs-dot").className = "gs-dot gs-done";
+        step2.className = "gs-step";
+        conn2.className = hasCpe ? "gs-connector gs-done" : "gs-connector";
+        if (hasCpe) {
+            step3.querySelector(".gs-dot").className = "gs-dot gs-done";
+            step3.className = "gs-step";
+        } else {
+            step3.querySelector(".gs-dot").className = "gs-dot gs-next";
+            step3.className = "gs-step gs-active";
+            hint.textContent = "Attend a Daily Threat Briefing and post a message in the live chat to earn your first 0.5 CPE.";
+        }
+    } else {
+        step2.querySelector(".gs-dot").className = "gs-dot gs-next";
+        step2.className = "gs-step gs-active";
+        step3.querySelector(".gs-dot").className = "gs-dot";
+        step3.className = "gs-step";
+        hint.textContent = isVerified
+            ? "Post your SC-CPE code in the YouTube live chat during the briefing to link your channel."
+            : "Post your SC-CPE verification code in the YouTube live chat during the briefing to verify your account.";
+    }
+}
+
+function applyCardVisibility(user) {
+    var isPending = user.state === "pending_verification";
+    var isActive = user.state === "active";
+    var hasChannel = !!user.yt_channel_id;
+    var ids = ["stats-card", "calendar-card", "attendance-card", "certs-card", "settings-section"];
+    for (var i = 0; i < ids.length; i++) {
+        var el = document.getElementById(ids[i]);
+        if (el) el.hidden = isPending;
+    }
+    if (isActive && !hasChannel) {
+        document.getElementById("link-card").hidden = false;
+    }
+}
+
 var refreshTimer = null;
 var userState = "active";
 function renderToday(today) {
     var card = document.getElementById("today-card");
+    card.classList.remove("today-live", "today-credited", "today-ended");
     if (!today) {
         card.hidden = true;
         if (refreshTimer) { clearTimeout(refreshTimer); refreshTimer = null; }
@@ -710,9 +779,12 @@ function renderToday(today) {
     var status = document.getElementById("today-status");
     var hint = document.getElementById("today-hint");
     if (today.credited) {
+        card.classList.add("today-credited");
+        // Static safe HTML with no user-controlled content
         status.innerHTML = "<strong class='today-credited'>&#10003; Credited</strong> &nbsp;0.5 CPE recorded for this session.";
         hint.hidden = true;
     } else if (today.state === "live") {
+        card.classList.add("today-live");
         if (userState === "pending_verification") {
             status.innerHTML = "<strong class='today-waiting'>&#128308; The briefing is live now!</strong> Post your <code>SC-CPE{...}</code> code in the YouTube live chat to verify your account and get credit for this session.";
         } else {
@@ -723,6 +795,7 @@ function renderToday(today) {
         refreshTimer = setTimeout(function () { refreshTimer = null; load(); }, 30000);
         return;
     } else {
+        card.classList.add("today-ended");
         var credits = (calData.attendance || []).length;
         var lastCredit = credits
             ? calData.attendance.slice().sort(function (a, b) {
@@ -920,7 +993,8 @@ document.getElementById("renewal-remove-btn").addEventListener("click", async fu
         document.getElementById("renewal-display").hidden = true;
         document.getElementById("renewal-setup").hidden = false;
         document.getElementById("renewal-form").reset();
-    } catch (e) { msg.textContent = "failed: " + e.message; }
+        showToast("Renewal tracker removed", "ok");
+    } catch (e) { msg.textContent = "failed: " + e.message; showToast("Failed: " + e.message, "err"); }
 });
 document.getElementById("renewal-form").addEventListener("submit", async function (e) {
     e.preventDefault();
@@ -940,7 +1014,8 @@ document.getElementById("renewal-form").addEventListener("submit", async functio
         msg.hidden = true;
         document.getElementById("renewal-cancel-btn").hidden = true;
         showRenewalDisplay(tracker);
-    } catch (e) { msg.textContent = "failed: " + e.message; }
+        showToast("Renewal tracker saved", "ok");
+    } catch (e) { msg.textContent = "failed: " + e.message; showToast("Failed: " + e.message, "err"); }
 });
 
 // --- Bulk cert download ---
@@ -1111,9 +1186,11 @@ document.getElementById("leaderboard-toggle").addEventListener("change", async f
             body: JSON.stringify({ show_on_leaderboard: e.target.checked }),
         });
         if (!r.ok) throw new Error("HTTP " + r.status);
-        msg.textContent = e.target.checked ? "You're on the leaderboard!" : "Removed from leaderboard.";
+        msg.textContent = e.target.checked ? "On the leaderboard" : "Removed";
+        showToast(e.target.checked ? "You're on the leaderboard!" : "Removed from leaderboard", "ok");
     } catch (err) {
         msg.textContent = "Failed: " + err.message;
+        showToast("Failed: " + err.message, "err");
         e.target.checked = !e.target.checked;
     }
 });
@@ -1138,8 +1215,10 @@ document.getElementById("email-prefs-checks").addEventListener("change", async f
         });
         if (!r.ok) throw new Error("HTTP " + r.status);
         msg.textContent = "saved";
+        showToast("Email preferences saved", "ok");
     } catch (err) {
         msg.textContent = "failed: " + err.message;
+        showToast("Failed: " + err.message, "err");
         cb.checked = !cb.checked;
     }
 });


### PR DESCRIPTION
## Summary
- **Today card promoted to top** with live-pulse animation when a stream is active, credited/ended visual states
- **Getting Started checklist** — 3-step progress bar (Register → Verify in chat → First CPE) shown until all complete; correctly distinguishes verified-but-unlinked users
- **State-based visibility** — pending_verification users only see relevant cards (today, identity, getting started); everything else hidden
- **Settings accordion** — cert delivery, email prefs, renewal tracker, and leaderboard collapsed into a single `<details>` section; account cards (rotate, remember) stay separate
- **Toast notifications** — `showToast(msg, type)` replaces tiny inline feedback for settings saves; inline messages retained for screen readers
- **Improved empty states** — attendance and certificates empty states now include actionable guidance instead of one-liners
- **Accessibility** — `prefers-reduced-motion` disables all pulse/shimmer animations
- **Mobile** — getting-started steps use `flex-wrap: nowrap` with shrinkable connectors

## Review notes
Codex CLI (GPT-5.4) review identified and fixed 4 issues before commit:
1. Getting-started step 2 incorrectly treated active-but-unlinked users as verified
2. Missing `prefers-reduced-motion` fallback for pulse animations
3. Mobile connector wrapping could orphan elements
4. Unused `totalCpe` parameter in `applyCardVisibility()`

## Test plan
- [x] 421 unit tests passing
- [ ] Visual test: load dashboard as pending_verification user — only today + getting-started + identity cards visible
- [ ] Visual test: load as active user with no channel — link card prominent, step 2 highlighted
- [ ] Visual test: load as active linked user with CPE — getting-started hidden, full dashboard
- [ ] Visual test: settings accordion opens/closes, saves persist
- [ ] Visual test: toast appears on settings save, disappears after 3s
- [ ] Visual test: today card pulses when stream is live
- [ ] Accessibility: enable reduced motion in OS settings, verify no animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)