### PR TITLE
feat(dashboard): dashboard modes, attendance expand, card animations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,6 +422,21 @@ tag instead of `width="100%"`.
   unit tests across 3 test files. Docs: `docs/DEV_SETUP.md` (developer
   setup) and `docs/ADMIN_ONBOARDING.md` (admin guide).
 
+- **Dashboard Phase B** — shipped 2026-04-25 (PR #78). Card ordering
+  (today at top, window warnings follow), getting-started 3-step progress
+  bar, state-based card visibility, settings accordion (`<details>`),
+  toast notifications, improved empty states, `prefers-reduced-motion`.
+- **Dashboard Phase C** — shipped 2026-04-25 (PR #79). Two-column CSS
+  grid on desktop (>960px): stats + calendar left, attendance + certs
+  right. `wide-dash` class on `<main>` widens max-width to 1080px.
+  Interactive calendar (click credited day → inline detail panel with
+  `aria-expanded`). Cert card 2-column grid. Dashboard modes: daily
+  (08-11 ET weekdays — attendance/certs collapsed with expand button)
+  vs review (stats emphasized). Attendance row expand/collapse for
+  evidence details. Last-updated indicator + manual refresh button.
+  Skip link, ARIA landmarks, keyboard support. Type scale audit
+  (min 11px). Card entrance animation with reduced-motion fallback.
+
 ## Where to look for more context
 
 - `docs/RUNBOOK.md` — operator-facing ops procedures

--- a/pages/dashboard.css
+++ b/pages/dashboard.css
@@ -131,8 +131,23 @@
 .att-list { display: flex; flex-direction: column; gap: 10px; }
 .att-row {
     border: 1px solid var(--border); border-radius: 6px; padding: 12px 14px;
-    background: var(--card);
+    background: var(--card); cursor: pointer;
 }
+.att-row:hover { border-color: var(--border-strong); }
+.att-row:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.att-detail {
+    font-size: 12px; color: var(--muted); margin-top: 8px;
+    padding-top: 8px; border-top: 1px solid var(--border);
+    display: none;
+}
+.att-row.att-expanded .att-detail { display: block; }
+.att-detail-row { display: flex; gap: 8px; margin-bottom: 4px; }
+.att-detail-label { font-weight: 600; color: var(--fg-strong); min-width: 100px; }
+.att-expand-indicator {
+    font-size: 11px; color: var(--muted); margin-left: 8px;
+    transition: transform 0.2s;
+}
+.att-expanded .att-expand-indicator { transform: rotate(90deg); }
 .att-row-top {
     display: flex; justify-content: space-between; align-items: baseline;
     gap: 8px; flex-wrap: wrap;
@@ -424,6 +439,20 @@
 @keyframes toast-in { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
 @keyframes toast-out { from { opacity: 1; } to { opacity: 0; } }
 
+/* ── Dashboard modes ─────────────────────────────── */
+.daily-collapsed .att-list,
+.daily-collapsed .cert-list,
+.daily-collapsed .cert-dl-bar { display: none; }
+.daily-collapsed .daily-expand-btn { display: inline-block; }
+.daily-expand-btn {
+    display: none; font-size: 12px; margin-top: 6px;
+    padding: 6px 12px; min-height: 32px;
+    background: transparent; color: var(--accent); border: 1px solid var(--border);
+    border-radius: 4px; cursor: pointer;
+}
+.daily-expand-btn:hover { background: var(--accent-soft-bg); border-color: var(--accent); filter: none; }
+[data-mode="review"] #stats-card { border-left: 4px solid var(--accent); }
+
 /* ── Last-updated bar ────────────────────────────── */
 .last-updated-bar {
     display: flex; align-items: center; justify-content: flex-end;
@@ -454,7 +483,18 @@
     .dashboard-grid > #certs-card { grid-column: 2; }
 }
 
+/* ── Card entrance animation ─────────────────────── */
+#body > .card, .dashboard-grid > .card, .settings-inner > .card {
+    animation: card-enter 0.3s ease-out;
+}
+@keyframes card-enter {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .today-card.today-live, .gs-dot.gs-next, .toast { animation: none; }
     .skeleton { animation: none; }
+    #body > .card, .dashboard-grid > .card, .settings-inner > .card { animation: none; }
+    .att-expand-indicator { transition: none; }
 }

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -252,12 +252,14 @@
 
         <div class="card" id="attendance-card">
             <h2>Attendance history</h2>
+            <button type="button" class="daily-expand-btn" id="att-expand-btn">Show attendance history</button>
             <div id="att" class="att-list" hidden></div>
             <p id="att-empty" hidden class="muted">No attendance records yet. The Daily Threat Briefing streams weekdays at 8:00 AM ET. Post any 3+ character message in the live chat to earn 0.5 CPE per session.</p>
         </div>
 
         <div class="card" id="certs-card">
             <h2>Certificates</h2>
+            <button type="button" class="daily-expand-btn" id="certs-expand-btn">Show certificates</button>
             <div id="cert-dl-bar" class="cert-dl-bar" hidden>
                 <button type="button" id="cert-dl-btn">Download All (ZIP)</button>
                 <span class="dl-status" id="cert-dl-status"></span>

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -261,6 +261,9 @@ function renderAttendance(items) {
         var a = items[i];
         var row = document.createElement("div");
         row.className = "att-row";
+        row.setAttribute("tabindex", "0");
+        row.setAttribute("role", "button");
+        row.setAttribute("aria-expanded", "false");
         var title = escapeHtml(a.title || a.yt_video_id);
         var yt = "https://youtu.be/" + encodeURIComponent(a.yt_video_id);
         var badge = attendanceBadge(a);
@@ -276,16 +279,40 @@ function renderAttendance(items) {
         var actions = a.per_session_cert_exists
             ? '<span class="att-ps-done">per-session cert issued</span>'
             : '<button type="button" class="att-ps-btn" data-stream="' + a.stream_id + '">Request per-session cert</button>';
+        var detailRows = [];
+        if (a.first_msg_at) detailRows.push('<div class="att-detail-row"><span class="att-detail-label">Message time</span><span>' + escapeHtml(formatDateTime(a.first_msg_at)) + '</span></div>');
+        if (a.credited_at) detailRows.push('<div class="att-detail-row"><span class="att-detail-label">Credited</span><span>' + escapeHtml(formatDateTime(a.credited_at)) + '</span></div>');
+        if (hasEvidence) detailRows.push('<div class="att-detail-row"><span class="att-detail-label">Evidence hash</span><span class="dash">' + escapeHtml(a.first_msg_sha256) + '</span></div>');
+        detailRows.push('<div class="att-detail-row"><span class="att-detail-label">Source</span><span>' + escapeHtml(a.source) + '</span></div>');
+        detailRows.push('<div class="att-detail-row"><span class="att-detail-label">Stream</span><span class="dash">' + escapeHtml(a.yt_video_id) + '</span></div>');
+
         row.innerHTML =
             '<div class="att-row-top"><div>' +
-            '<div class="att-title"><a href="' + yt + '" target="_blank" rel="noopener">' + title + "</a></div>" +
+            '<div class="att-title"><a href="' + yt + '" target="_blank" rel="noopener">' + title + '</a><span class="att-expand-indicator">&#9654;</span></div>' +
             '<div class="att-meta">' + meta + "</div>" +
             "</div>" + headerRight + "</div>" +
+            '<div class="att-detail">' + detailRows.join("") + '</div>' +
             '<div class="att-actions">' + actions + "</div>";
         host.appendChild(row);
     }
 }
 
+function toggleAttRow(row) {
+    var expanded = row.classList.toggle("att-expanded");
+    row.setAttribute("aria-expanded", expanded ? "true" : "false");
+}
+document.getElementById("att").addEventListener("click", function (e) {
+    if (e.target.closest(".att-ps-btn")) return;
+    if (e.target.closest("a")) return;
+    var row = e.target.closest(".att-row");
+    if (row) toggleAttRow(row);
+});
+document.getElementById("att").addEventListener("keydown", function (e) {
+    if (e.key !== "Enter" && e.key !== " ") return;
+    if (e.target.closest(".att-ps-btn")) return;
+    var row = e.target.closest(".att-row");
+    if (row) { e.preventDefault(); toggleAttRow(row); }
+});
 document.getElementById("att").addEventListener("click", async function (e) {
     var btn = e.target.closest(".att-ps-btn");
     if (!btn || btn.disabled) return;
@@ -766,7 +793,45 @@ function renderGettingStarted(user, totalCpe) {
     }
 }
 
+function getETHour() {
+    try {
+        var parts = new Intl.DateTimeFormat("en-US", {
+            timeZone: "America/New_York", hour: "numeric", hour12: false,
+        }).formatToParts(new Date());
+        for (var i = 0; i < parts.length; i++) {
+            if (parts[i].type === "hour") return parseInt(parts[i].value, 10);
+        }
+    } catch (e) {}
+    return new Date().getHours();
+}
+
+function getETDow() {
+    try {
+        var parts = new Intl.DateTimeFormat("en-US", {
+            timeZone: "America/New_York", weekday: "short",
+        }).formatToParts(new Date());
+        var map = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+        for (var i = 0; i < parts.length; i++) {
+            if (parts[i].type === "weekday") return map[parts[i].value] || 0;
+        }
+    } catch (e) {}
+    return new Date().getDay();
+}
+
+function getDashboardMode(user) {
+    if (user.state === "pending_verification") return "onboarding";
+    if (user.state === "active" && !user.yt_channel_id) return "onboarding";
+    var dow = getETDow();
+    var h = getETHour();
+    if (dow >= 1 && dow <= 5 && h >= 8 && h < 11) return "daily";
+    return "review";
+}
+
 function applyCardVisibility(user) {
+    var mode = getDashboardMode(user);
+    var body = document.getElementById("body");
+    body.dataset.mode = mode;
+
     var isPending = user.state === "pending_verification";
     var isActive = user.state === "active";
     var hasChannel = !!user.yt_channel_id;
@@ -777,6 +842,16 @@ function applyCardVisibility(user) {
     }
     if (isActive && !hasChannel) {
         document.getElementById("link-card").hidden = false;
+    }
+
+    var att = document.getElementById("attendance-card");
+    var certs = document.getElementById("certs-card");
+    if (mode === "daily") {
+        if (att && !att.dataset.userExpanded) att.classList.add("daily-collapsed");
+        if (certs && !certs.dataset.userExpanded) certs.classList.add("daily-collapsed");
+    } else {
+        if (att) att.classList.remove("daily-collapsed");
+        if (certs) certs.classList.remove("daily-collapsed");
     }
 }
 
@@ -1360,6 +1435,17 @@ if (loginForm) {
         }
     });
 }
+
+document.getElementById("att-expand-btn").addEventListener("click", function () {
+    var card = document.getElementById("attendance-card");
+    card.classList.remove("daily-collapsed");
+    card.dataset.userExpanded = "1";
+});
+document.getElementById("certs-expand-btn").addEventListener("click", function () {
+    var card = document.getElementById("certs-card");
+    card.classList.remove("daily-collapsed");
+    card.dataset.userExpanded = "1";
+});
 
 document.getElementById("refresh-btn").addEventListener("click", function () {
     var btn = document.getElementById("refresh-btn");


### PR DESCRIPTION
## Summary
- **Dashboard modes**: auto-switches between daily mode (08-11 ET weekdays — attendance/certs collapsed with expand buttons, today card dominant) and review mode (stats emphasized with accent border, everything expanded). Uses `Intl.DateTimeFormat` for both ET hour and weekday to avoid cross-timezone bugs. User-expanded state persists across 30s auto-refresh.
- **Attendance row expand/collapse**: click or keyboard (Enter/Space) reveals full details — message time, evidence hash, source, stream ID. ARIA `role="button"` + `aria-expanded` + `focus-visible` outline.
- **Card entrance animations**: fade + slide-up on card appearance. `prefers-reduced-motion` disables all animations.
- **CLAUDE.md**: documented Phase B + Phase C features in Known gaps.

## Codex review fixes (4 issues found, all fixed)
1. Mixed-timezone weekday: `getDay()` used browser local tz while hour used ET — now both use ET via `Intl.DateTimeFormat`
2. Collapse persistence: daily-collapsed re-applied on every `load()` — now respects `dataset.userExpanded`
3. Mode transition: `daily-collapsed` class never removed when leaving daily mode — now removed in review mode
4. Attendance rows had no keyboard/ARIA support — added `tabindex`, `role="button"`, `aria-expanded`, `focus-visible`

## Test plan
- [x] 421 backend tests pass
- [ ] During 08-11 ET weekdays: attendance + certs collapsed with "Show" buttons
- [ ] Outside briefing hours: everything expanded, stats card has accent border
- [ ] Expand attendance/certs during daily mode → stays expanded after auto-refresh
- [ ] Click attendance row → details expand with evidence hash, stream ID
- [ ] Keyboard: Tab to attendance row, Enter/Space toggles expand
- [ ] `prefers-reduced-motion` → no card entrance animation
- [ ] Dark/light theme renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)