### PR TITLE
chore: replace Claude references with Codex in all .md files

### DIFF
--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -130,5 +130,5 @@ chmod +x .githooks/pre-push
 
 ## Architecture context
 
-See `CLAUDE.md` for invariants, deployment details, and known gaps.
+See `AGENTS.md` for invariants, deployment details, and known gaps.
 See `docs/DESIGN.md` for architecture decisions.

--- a/docs/superpowers/plans/2026-04-22-ops-admin-preview.md
+++ b/docs/superpowers/plans/2026-04-22-ops-admin-preview.md
@@ -1453,14 +1453,14 @@ git commit -m "feat(preview): add PR preview deploy workflow with seed data"
 
 ---
 
-### Task 14: Update CLAUDE.md known gaps
+### Task 14: Update AGENTS.md known gaps
 
 **Files:**
-- Modify: `CLAUDE.md`
+- Modify: `AGENTS.md`
 
 - [ ] **Step 1: Update known gaps section**
 
-In `CLAUDE.md`, find the line:
+In `AGENTS.md`, find the line:
 
 ```
 - CF Pages PR previews remain disabled — current bindings are prod;
@@ -1480,7 +1480,7 @@ Replace those two lines with:
 - [ ] **Step 2: Commit**
 
 ```bash
-git add CLAUDE.md
+git add AGENTS.md
 git commit -m "docs: update known gaps — PR previews configured, backups durable"
 ```
 

--- a/docs/superpowers/plans/2026-04-24-email-improvements.md
+++ b/docs/superpowers/plans/2026-04-24-email-improvements.md
@@ -121,7 +121,7 @@ git commit -m "feat(email): add helper functions (button, code, progress, divide
 **Files:**
 - Modify: `workers/purge/src/index.js:286-305`
 
-The purge worker has its own copy of `emailShell` (CLAUDE.md invariant: must stay in sync). It also needs local copies of the helpers since it can't import from `_lib.js`.
+The purge worker has its own copy of `emailShell` (AGENTS.md invariant: must stay in sync). It also needs local copies of the helpers since it can't import from `_lib.js`.
 
 - [ ] **Step 1: Add helper functions before `emailShell` in purge worker**
 

--- a/docs/superpowers/plans/2026-04-24-readme-engineer-plugin.md
+++ b/docs/superpowers/plans/2026-04-24-readme-engineer-plugin.md
@@ -2,11 +2,11 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Build a Claude Code plugin with four skills (generate, audit, improve, diagrams) that creates, scores, and iteratively improves README files across any project.
+**Goal:** Build a Codex plugin with four skills (generate, audit, improve, diagrams) that creates, scores, and iteratively improves README files across any project.
 
-**Architecture:** Multi-skill Claude Code plugin at `C:/dev/readme-engineer/` with bundled Node.js scripts for automated scoring, Puppeteer screenshot analysis, and Mermaid CLI rendering. Skills are markdown files with YAML frontmatter that guide Claude's behavior. Scripts do the mechanical work and return JSON for Claude to interpret.
+**Architecture:** Multi-skill Codex plugin at `C:/dev/readme-engineer/` with bundled Node.js scripts for automated scoring, Puppeteer screenshot analysis, and Mermaid CLI rendering. Skills are markdown files with YAML frontmatter that guide Codex's behavior. Scripts do the mechanical work and return JSON for Codex to interpret.
 
-**Tech Stack:** Node.js (ESM via .mjs), Puppeteer, @mermaid-js/mermaid-cli, Claude Code plugin format
+**Tech Stack:** Node.js (ESM via .mjs), Puppeteer, @mermaid-js/mermaid-cli, Codex plugin format
 
 ---
 
@@ -14,7 +14,7 @@
 
 ```
 C:/dev/readme-engineer/
-├── .claude-plugin/
+├── .codex-plugin/
 │   └── plugin.json                  # Plugin metadata (Task 1)
 ├── skills/
 │   ├── readme-generate/
@@ -46,14 +46,14 @@ C:/dev/readme-engineer/
 ### Task 1: Plugin Scaffold
 
 **Files:**
-- Create: `C:/dev/readme-engineer/.claude-plugin/plugin.json`
+- Create: `C:/dev/readme-engineer/.codex-plugin/plugin.json`
 - Create: `C:/dev/readme-engineer/package.json`
 - Create: `C:/dev/readme-engineer/.gitignore`
 
 - [ ] **Step 1: Create plugin directory structure**
 
 ```bash
-mkdir -p /c/dev/readme-engineer/.claude-plugin
+mkdir -p /c/dev/readme-engineer/.codex-plugin
 mkdir -p /c/dev/readme-engineer/skills/{readme-generate,readme-audit,readme-improve,readme-diagrams}
 mkdir -p /c/dev/readme-engineer/scripts
 mkdir -p /c/dev/readme-engineer/templates/mermaid-config
@@ -61,7 +61,7 @@ mkdir -p /c/dev/readme-engineer/templates/mermaid-config
 
 - [ ] **Step 2: Create plugin.json**
 
-Create `C:/dev/readme-engineer/.claude-plugin/plugin.json`:
+Create `C:/dev/readme-engineer/.codex-plugin/plugin.json`:
 
 ```json
 {
@@ -497,7 +497,7 @@ description: "Use when scoring, auditing, rating, or evaluating a README file qu
 Content covers the 5-step workflow:
 1. Run `node PLUGIN_DIR/scripts/score.mjs --readme README.md --json` for automated scoring
 2. Run `node PLUGIN_DIR/scripts/screenshot.mjs` for responsive analysis (if diagrams exist)
-3. Claude evaluates subjective quality (impact depth, visual impression, clarity) and adjusts automated scores +/- 1 per dimension
+3. Codex evaluates subjective quality (impact depth, visual impression, clarity) and adjusts automated scores +/- 1 per dimension
 4. Present scorecard in the rubric's output format with bar charts and gap list
 5. Produce prioritized fix list ordered by points/effort, suggest readme-improve for iteration
 
@@ -591,7 +591,7 @@ Create `C:/dev/readme-engineer/README.md` with:
 - What + Why: portfolio thesis, most READMEs written once and never improved
 - Skills table: 4 skills with trigger phrases and descriptions
 - Scoring rubric summary: 3 dimensions, 10 pts each
-- Install: `claude plugin install /path/to/readme-engineer`
+- Install: `codex plugin install /path/to/readme-engineer`
 - Dependencies: `npm install -g puppeteer @mermaid-js/mermaid-cli`
 - Quick Start: 4 example commands
 - License: MIT
@@ -623,12 +623,12 @@ cd /c/dev/readme-engineer && git add -A && git commit -m "feat: add plugin READM
 - [ ] **Step 6: Register plugin**
 
 ```bash
-claude plugin install /c/dev/readme-engineer
+codex plugin install /c/dev/readme-engineer
 ```
 
 - [ ] **Step 7: Smoke test — audit sc-cpe**
 
-Open Claude Code in `C:/dev/sc-cpe` and say "audit my README". Verify the readme-audit skill loads, score.mjs runs, and a scorecard is produced.
+Open Codex in `C:/dev/sc-cpe` and say "audit my README". Verify the readme-audit skill loads, score.mjs runs, and a scorecard is produced.
 
 - [ ] **Step 8: Fix any issues and final commit**
 

--- a/docs/superpowers/specs/2026-04-24-readme-engineer-plugin-design.md
+++ b/docs/superpowers/specs/2026-04-24-readme-engineer-plugin-design.md
@@ -2,15 +2,15 @@
 
 ## Overview
 
-A Claude Code plugin that generates, audits, scores, and iteratively improves README files across any project. Packages the responsive diagram rendering pipeline, multi-viewport screenshot analysis, and multi-dimensional scoring rubric developed in the sc-cpe project into a reusable tool.
+A Codex plugin that generates, audits, scores, and iteratively improves README files across any project. Packages the responsive diagram rendering pipeline, multi-viewport screenshot analysis, and multi-dimensional scoring rubric developed in the sc-cpe project into a reusable tool.
 
 **Core thesis:** Your README is your portfolio. This plugin treats it as a first-class engineering artifact — scored, tested, and iterated on like production code.
 
 ## Plugin Structure
 
 ```
-~/.claude/plugins/readme-engineer/
-├── .claude-plugin/
+~/.codex/plugins/readme-engineer/
+├── .codex-plugin/
 │   └── plugin.json                # name, description, version, author
 ├── skills/
 │   ├── readme-generate/
@@ -62,7 +62,7 @@ A Claude Code plugin that generates, audits, scores, and iteratively improves RE
 **Workflow:**
 1. Run `score.mjs` for automated structural checks
 2. Screenshot README at 5 viewports (375, 768, 1280, 1920, 2560px)
-3. Claude evaluates subjective dimensions (impact quality, decision depth, clarity)
+3. Codex evaluates subjective dimensions (impact quality, decision depth, clarity)
 4. Produce scorecard with per-dimension breakdown
 5. Produce prioritized fix list ordered by impact-per-effort
 6. Analyze screenshots for responsive issues (diagram readability, layout problems)

--- a/docs/superpowers/specs/2026-04-24-ship-confidence-design.md
+++ b/docs/superpowers/specs/2026-04-24-ship-confidence-design.md
@@ -175,7 +175,7 @@ In the batch case (me/[token] returns multiple certs), use a single query with `
 
 ### Problem
 
-The project has 7+ secrets (ADMIN_TOKEN, OB_SIGNING_KEY, RESEND_API_KEY, RESEND_WEBHOOK_SECRET, PDF_SIGNING_KEY_PASSWORD, CLOUDFLARE_API_TOKEN, WATCHDOG_SECRET). CLAUDE.md documents rotation dates, but there's no automated reminder. A forgotten rotation is a silent security gap.
+The project has 7+ secrets (ADMIN_TOKEN, OB_SIGNING_KEY, RESEND_API_KEY, RESEND_WEBHOOK_SECRET, PDF_SIGNING_KEY_PASSWORD, CLOUDFLARE_API_TOKEN, WATCHDOG_SECRET). AGENTS.md documents rotation dates, but there's no automated reminder. A forgotten rotation is a silent security gap.
 
 ### Design
 

--- a/outputs/dmarc-resend-verification-prompt.md
+++ b/outputs/dmarc-resend-verification-prompt.md
@@ -10,7 +10,7 @@ Goal: finish the launch-blocking email authentication check for `signalplane.co`
 
 Known facts from the repo and live DNS as of 2026-04-27:
 
-- `CLAUDE.md` records the gap: Resend DKIM/SPF are present, but `signalplane.co` has no DMARC record.
+- `AGENTS.md` records the gap: Resend DKIM/SPF are present, but `signalplane.co` has no DMARC record.
 - `docs/LAUNCH_READINESS.md` marks DMARC as P0 before public announcement.
 - `dig TXT _dmarc.signalplane.co +short` currently returns no record.
 - `dig TXT signalplane.co +short` returns only Namecheap forwarding SPF: `v=spf1 include:spf.efwd.registrar-servers.com ~all`.
@@ -62,7 +62,7 @@ Tasks:
 
 6. Update docs only after DNS is actually live:
    - `README.md`: remove “DMARC DNS pending”.
-   - `CLAUDE.md`: remove the known gap entry or replace it with the verified date.
+   - `AGENTS.md`: remove the known gap entry or replace it with the verified date.
    - `docs/LAUNCH_READINESS.md`: check off the DMARC P0 item with the verification date.
    - `docs/RUNBOOK.md`: keep the verification command and current record.
 

--- a/outputs/next-session-prompt.md
+++ b/outputs/next-session-prompt.md
@@ -1,10 +1,10 @@
 # Next Session Prompt — QA & Hardening
 
-Paste this into a new Claude Code session:
+Paste this into a new Codex session:
 
 ---
 
-QA/hardening session for the `feat/ops-polish` bundle (PR #67). Goal: find bugs, edge cases, and integration gaps across all 8 shipped features before merge. Read CLAUDE.md first.
+QA/hardening session for the `feat/ops-polish` bundle (PR #67). Goal: find bugs, edge cases, and integration gaps across all 8 shipped features before merge. Read AGENTS.md first.
 
 Work on `main` (or the merge result). Commit fixes as you go. Run `bash scripts/test.sh` after each fix to confirm green. Push when done.
 
@@ -98,7 +98,7 @@ Test each analytics endpoint with boundary inputs:
 
 1. **`docs/DEV_SETUP.md`**: Follow the setup instructions on a clean checkout. Verify every command works. Check that the preview environment table matches `wrangler.toml` `[env.preview]` bindings.
 2. **`docs/ADMIN_ONBOARDING.md`**: Walk through each "Common admin tasks" section against the actual admin.html UI. Verify the dashboard section table matches what's actually rendered. Confirm emergency procedures match the actual kill switch and cron trigger UX.
-3. **`CLAUDE.md`**: Verify the ops-polish entry accurately describes what was shipped. Verify the "Where to look" section includes DEV_SETUP.md and ADMIN_ONBOARDING.md.
+3. **`AGENTS.md`**: Verify the ops-polish entry accurately describes what was shipped. Verify the "Where to look" section includes DEV_SETUP.md and ADMIN_ONBOARDING.md.
 4. **`README.md`**: Verify the API surface table includes `/api/admin/streams`, `/api/admin/suspend`, and `/api/admin/email-suppression`. Verify the endpoint count in the `<summary>` tag is correct (49).
 
 ## Phase 10: Security spot-check

--- a/outputs/phase-d-dashboard-polish-prompt.md
+++ b/outputs/phase-d-dashboard-polish-prompt.md
@@ -569,4 +569,4 @@ for a second opinion.
   upgrade, dark mode premium, transitions, mobile polish
 - `pages/style.css` — type scale tokens, spacing tokens, body gradient,
   card shadow defaults
-- `CLAUDE.md` — update Known gaps with Phase D changes
+- `AGENTS.md` — update Known gaps with Phase D changes

--- a/scripts/claude-heal-prompt.md
+++ b/scripts/claude-heal-prompt.md
@@ -1,6 +1,6 @@
-# Claude Code Healing Session
+# Codex Healing Session
 
-Paste this into a Claude Code session in the `sc-cpe` directory when you
+Paste this into a Codex session in the `sc-cpe` directory when you
 receive a self-heal escalation alert (Discord or GitHub issue).
 
 ---
@@ -10,7 +10,7 @@ receive a self-heal escalation alert (Discord or GitHub issue).
 ```
 SC-CPE self-healing escalated. Diagnose and fix.
 
-1. Read CLAUDE.md for project context
+1. Read AGENTS.md for project context
 2. Read docs/RUNBOOK.md for ops procedures  
 3. Check current state:
    - curl -s https://sc-cpe-web.pages.dev/api/health | jq .


### PR DESCRIPTION
## Summary

- Replace all Claude-branded references with Codex equivalents across docs, outputs, and scripts
- `Claude Code` → `Codex`
- `CLAUDE.md` → `AGENTS.md`
- `claude-code` / `claude plugin install` → `codex` equivalents
- `~/.claude/`, `.claude/`, `.claude-plugin/` → `.codex/` equivalents
- Catch-all `Claude` → `Codex`
- 10 `.md` files updated; no `.js`, `.py`, `.json`, or workflow files touched

## Test plan
- [x] `grep -ri "claude" --include="*.md" . | grep -v ".git"` returns empty
- [x] Only `docs/`, `outputs/`, `scripts/` directories modified
- [x] `.github/workflows/` untouched

🤖 Generated with [Claude Code](https://claude.ai/claude-code)